### PR TITLE
[TEST] TestContainer 의존성 추가 및 ci 스크립트 작성

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,20 @@
+name: CI Build
+on:
+  pull_request:
+    branches:
+      - '**'
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: 저장소 Checkout
+        uses: actions/checkout@v3
+
+      - name: 자바 17 설정
+        uses: actions/setup-java@v3
+        with:
+          java-version: '17'
+          distribution: 'adopt'
+      - name: 빌드
+        run: SPRING_PROFILES_ACTIVE=ci ./gradlew build

--- a/build.gradle
+++ b/build.gradle
@@ -40,6 +40,10 @@ dependencies {
 	testImplementation 'org.springframework.restdocs:spring-restdocs-mockmvc'
 	asciidoctorExtensions 'org.springframework.restdocs:spring-restdocs-asciidoctor'
 	testImplementation 'io.rest-assured:rest-assured'
+
+	testImplementation "org.testcontainers:testcontainers:1.19.3"
+	testImplementation "org.testcontainers:junit-jupiter:1.19.3"
+	testImplementation "org.testcontainers:mysql:1.19.3"
 }
 
 ext {

--- a/build.gradle
+++ b/build.gradle
@@ -50,6 +50,11 @@ ext {
 	snippetsDir = file('build/generated-snippets')
 }
 
+test {
+	outputs.dir snippetsDir
+	useJUnitPlatform()
+}
+
 asciidoctor {
 	configurations 'asciidoctorExtensions'
 	inputs.dir snippetsDir
@@ -62,6 +67,7 @@ task copyDocument(type: Copy) {
 	from file("build/docs/asciidoc")
 	into file("src/main/resources/static/docs")
 }
+
 
 bootJar {
 	dependsOn copyDocument

--- a/src/main/resources/application-ci.yml
+++ b/src/main/resources/application-ci.yml
@@ -8,6 +8,3 @@ spring:
       hibernate:
         format_sql: true
         show_sql: true
-
-report-check-origin: fake-origin.com
-cors-allow-origins: http://localhost:3000

--- a/src/main/resources/application-ci.yml
+++ b/src/main/resources/application-ci.yml
@@ -1,0 +1,13 @@
+spring:
+  datasource:
+    driver-class-name: org.testcontainers.jdbc.ContainerDatabaseDriver
+    url: jdbc:tc:mysql:8.0:///test_container_test
+    username: root
+    password: password
+  jpa:
+      hibernate:
+        format_sql: true
+        show_sql: true
+
+report-check-origin: fake-origin.com
+cors-allow-origins: http://localhost:3000

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -21,6 +21,13 @@ spring:
 spring:
   config:
     activate:
+      on-profile: ci
+    import: application-ci.yml
+
+---
+spring:
+  config:
+    activate:
       on-profile: prod
     import:
       - classpath:be-config/application-prod.yml

--- a/src/main/resources/static/docs/api.html
+++ b/src/main/resources/static/docs/api.html
@@ -479,7 +479,7 @@ Host: www.api.birca.com</code></pre>
 <div id="footer">
 <div id="footer-text">
 Version 0.0.1-SNAPSHOT<br>
-Last updated 2024-01-15 16:29:18 +0900
+Last updated 2024-01-18 22:13:45 +0900
 </div>
 </div>
 <script src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/9.18.3/highlight.min.js"></script>

--- a/src/test/java/com/birca/bircabackend/support/isolation/DatabaseManager.java
+++ b/src/test/java/com/birca/bircabackend/support/isolation/DatabaseManager.java
@@ -36,14 +36,14 @@ class DatabaseManager {
         String replacement = "$1_$2";
         return entityType.getName()
                 .replaceAll(regex, replacement)
-                .toUpperCase();
+                .toLowerCase();
     }
 
     public void truncateTables() {
-        entityManager.createNativeQuery("SET REFERENTIAL_INTEGRITY FALSE").executeUpdate();
+        entityManager.createNativeQuery("SET foreign_key_checks = 0").executeUpdate();
         for (String tableName : tableNames) {
             entityManager.createNativeQuery("TRUNCATE TABLE " + tableName).executeUpdate();
         }
-        entityManager.createNativeQuery("SET REFERENTIAL_INTEGRITY TRUE").executeUpdate();
+        entityManager.createNativeQuery("SET foreign_key_checks = 1").executeUpdate();
     }
 }


### PR DESCRIPTION
## 🌍 이슈 번호
closed #3 

## 📝 구현 내용
### TestContainer를 사용해서 MySQL 테스트 환경 구성
- application.yml에 spring.active.profile을 local로 하면 H2 DB로 테스트 실행
- application.yml에 spring.active.profile을 ci로 하면 도커 컨테이너를 사용해 MySQL DB로 테스트 실행

간혹 H2 데이터베이스로만 테스트하는 경우 MySQL을 사용하는 운영 환경에서 사소한 문법 오류로 인해 장애가 나는 경우가 있어 MySQL 테스트 환경도 세팅한 것입니다.

- H2와 MySQL을 둘 다 사용하는 이유
  - TestContainer를 사용하면 도커 컨테이너로 MySQL을 사용해야 하기에 도커를 설치 및 켜두어야 테스트가 가능해 번거롭다.
  - 도커를 띄어 테스트하기에 테스트 속도가 많이 느리다.
  - 평소 개발할 때는 H2 DB를 사용해 빠른 테스트를 수행하고 배포 전 최소 1번 이상의 MySQL 테스트만 하면 된다 판단하여 둘 다 사용하기로 함

MySQL 테스트를 하지 않고 배포하는 휴먼 에러를 방지하기 위해 PR을 날리면 Github Action에서 ci 환경에서 테스트를 수행하도록 구성

## 🍀 확인해야 할 부분
원래라면 develop 브랜치에다가 PR을 날려야하지만 아직 본격적인 개발이 시작되지 않았고 이 PR도 환경 세팅적인 PR이기에 일단 main에 바로 날렸습니다.