### PR TITLE
[FEAT] 역할 체인지, 닉네임 중복 검사, 닉네임 등록 기능 구현

### DIFF
--- a/src/docs/asciidoc/api.adoc
+++ b/src/docs/asciidoc/api.adoc
@@ -13,3 +13,6 @@ operation::member-role-change[snippets='http-request,http-response']
 operation::check-nickname[snippets='http-request,query-parameters,http-response,response-fields']
 === 회원 닉네임 등록
 operation::member-nickname-register[snippets='http-request,request-fields,http-response']
+=== 에러 코드
+include::{snippets}/member-error-Code/response-body.adoc[]
+

--- a/src/docs/asciidoc/api.adoc
+++ b/src/docs/asciidoc/api.adoc
@@ -8,3 +8,6 @@
 
 == 헬스 체크 API
 operation::health-check[snippets='http-request,http-response']
+
+== 회원 역할 변경 API
+operation::member-role-change[snippets='http-request,http-response']

--- a/src/docs/asciidoc/api.adoc
+++ b/src/docs/asciidoc/api.adoc
@@ -3,14 +3,11 @@
 :icons: font
 :source-highlighter: highlightjs
 :toc: left
-:toclevels: 1
+:toclevels: 2
 :sectlinks:
 
-== 헬스 체크 API
-operation::health-check[snippets='http-request,http-response']
-
-== 회원 역할 변경 API
+== 회원 API
+=== 회원 역할 변경 API
 operation::member-role-change[snippets='http-request,http-response']
-
-== 닉네임 중복 검사 API
+=== 닉네임 중복 검사 API
 operation::check-nickname[snippets='http-request,query-parameters,http-response,response-fields']

--- a/src/docs/asciidoc/api.adoc
+++ b/src/docs/asciidoc/api.adoc
@@ -6,6 +6,10 @@
 :toclevels: 2
 :sectlinks:
 
+== 인증 API
+=== 에러 코드
+include::{snippets}/auth-error-Code/response-body.adoc[]
+
 == 회원 API
 === 회원 역할 변경
 operation::member-role-change[snippets='http-request,http-response']

--- a/src/docs/asciidoc/api.adoc
+++ b/src/docs/asciidoc/api.adoc
@@ -11,3 +11,6 @@ operation::health-check[snippets='http-request,http-response']
 
 == 회원 역할 변경 API
 operation::member-role-change[snippets='http-request,http-response']
+
+== 닉네임 중복 검사 API
+operation::check-nickname[snippets='http-request,query-parameters,http-response,response-fields']

--- a/src/docs/asciidoc/api.adoc
+++ b/src/docs/asciidoc/api.adoc
@@ -7,7 +7,9 @@
 :sectlinks:
 
 == 회원 API
-=== 회원 역할 변경 API
+=== 회원 역할 변경
 operation::member-role-change[snippets='http-request,http-response']
-=== 닉네임 중복 검사 API
+=== 닉네임 중복 검사
 operation::check-nickname[snippets='http-request,query-parameters,http-response,response-fields']
+=== 회원 닉네임 등록
+operation::member-nickname-register[snippets='http-request,request-fields,http-response']

--- a/src/main/java/com/birca/bircabackend/command/member/application/MemberService.java
+++ b/src/main/java/com/birca/bircabackend/command/member/application/MemberService.java
@@ -21,7 +21,7 @@ public class MemberService {
     public void changeMemberRole(RoleChangeRequest request, LoginMember loginMember) {
         Member member = memberRepository.findById(loginMember.id())
                 .orElseThrow(() -> BusinessException.from(MemberErrorCode.MEMBER_NOT_FOUND));
-        MemberRole role = MemberRole.valueOf(request.role());
+        MemberRole role = MemberRole.from(request.role());
         member.changeRole(role);
     }
 }

--- a/src/main/java/com/birca/bircabackend/command/member/application/MemberService.java
+++ b/src/main/java/com/birca/bircabackend/command/member/application/MemberService.java
@@ -1,17 +1,27 @@
 package com.birca.bircabackend.command.member.application;
 
 import com.birca.bircabackend.command.auth.login.LoginMember;
+import com.birca.bircabackend.command.member.domain.Member;
+import com.birca.bircabackend.command.member.domain.MemberRepository;
+import com.birca.bircabackend.command.member.domain.MemberRole;
 import com.birca.bircabackend.command.member.dto.RoleChangeRequest;
+import com.birca.bircabackend.command.member.exception.MemberErrorCode;
+import com.birca.bircabackend.common.exception.BusinessException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
 
 @Component
-@RequiredArgsConstructor
 @Transactional
+@RequiredArgsConstructor
 public class MemberService {
 
-    public void changeMemberRole(RoleChangeRequest request, LoginMember loginMember) {
+    private final MemberRepository memberRepository;
 
+    public void changeMemberRole(RoleChangeRequest request, LoginMember loginMember) {
+        Member member = memberRepository.findById(loginMember.id())
+                .orElseThrow(() -> BusinessException.from(MemberErrorCode.MEMBER_NOT_FOUND));
+        MemberRole role = MemberRole.valueOf(request.role());
+        member.changeRole(role);
     }
 }

--- a/src/main/java/com/birca/bircabackend/command/member/application/MemberService.java
+++ b/src/main/java/com/birca/bircabackend/command/member/application/MemberService.java
@@ -1,0 +1,17 @@
+package com.birca.bircabackend.command.member.application;
+
+import com.birca.bircabackend.command.auth.login.LoginMember;
+import com.birca.bircabackend.command.member.dto.RoleChangeRequest;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+@Component
+@RequiredArgsConstructor
+@Transactional
+public class MemberService {
+
+    public void changeMemberRole(RoleChangeRequest request, LoginMember loginMember) {
+
+    }
+}

--- a/src/main/java/com/birca/bircabackend/command/member/application/MemberService.java
+++ b/src/main/java/com/birca/bircabackend/command/member/application/MemberService.java
@@ -7,11 +7,14 @@ import com.birca.bircabackend.command.member.domain.MemberRole;
 import com.birca.bircabackend.command.member.domain.Nickname;
 import com.birca.bircabackend.command.member.dto.NicknameRegisterRequest;
 import com.birca.bircabackend.command.member.dto.RoleChangeRequest;
-import com.birca.bircabackend.command.member.exception.MemberErrorCode;
+import com.birca.bircabackend.common.EntityUtil;
 import com.birca.bircabackend.common.exception.BusinessException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
+
+import static com.birca.bircabackend.command.member.exception.MemberErrorCode.DUPLICATED_NICKNAME;
+import static com.birca.bircabackend.command.member.exception.MemberErrorCode.MEMBER_NOT_FOUND;
 
 @Component
 @Transactional
@@ -19,9 +22,10 @@ import org.springframework.transaction.annotation.Transactional;
 public class MemberService {
 
     private final MemberRepository memberRepository;
+    private final EntityUtil entityUtil;
 
     public void changeMemberRole(RoleChangeRequest request, LoginMember loginMember) {
-        Member member = getMember(loginMember.id());
+        Member member = entityUtil.getEntity(Member.class, loginMember.id(), MEMBER_NOT_FOUND);
         MemberRole role = MemberRole.from(request.role());
         member.changeRole(role);
     }
@@ -29,18 +33,13 @@ public class MemberService {
     public void registerNickname(NicknameRegisterRequest request, LoginMember loginMember) {
         Nickname nickname = new Nickname(request.nickname());
         validateDuplicatedNickname(nickname);
-        Member member = getMember(loginMember.id());
+        Member member = entityUtil.getEntity(Member.class, loginMember.id(), MEMBER_NOT_FOUND);
         member.registerNickname(nickname);
     }
 
     private void validateDuplicatedNickname(Nickname nickname) {
         if (memberRepository.existsByNickname(nickname)) {
-            throw BusinessException.from(MemberErrorCode.DUPLICATED_NICKNAME);
+            throw BusinessException.from(DUPLICATED_NICKNAME);
         }
-    }
-
-    private Member getMember(Long memberId) {
-        return memberRepository.findById(memberId)
-                .orElseThrow(() -> BusinessException.from(MemberErrorCode.MEMBER_NOT_FOUND));
     }
 }

--- a/src/main/java/com/birca/bircabackend/command/member/application/MemberService.java
+++ b/src/main/java/com/birca/bircabackend/command/member/application/MemberService.java
@@ -4,6 +4,7 @@ import com.birca.bircabackend.command.auth.login.LoginMember;
 import com.birca.bircabackend.command.member.domain.Member;
 import com.birca.bircabackend.command.member.domain.MemberRepository;
 import com.birca.bircabackend.command.member.domain.MemberRole;
+import com.birca.bircabackend.command.member.domain.Nickname;
 import com.birca.bircabackend.command.member.dto.NicknameRegisterRequest;
 import com.birca.bircabackend.command.member.dto.RoleChangeRequest;
 import com.birca.bircabackend.command.member.exception.MemberErrorCode;
@@ -20,25 +21,26 @@ public class MemberService {
     private final MemberRepository memberRepository;
 
     public void changeMemberRole(RoleChangeRequest request, LoginMember loginMember) {
-        Member member = getMember(loginMember);
+        Member member = getMember(loginMember.id());
         MemberRole role = MemberRole.from(request.role());
         member.changeRole(role);
     }
 
     public void registerNickname(NicknameRegisterRequest request, LoginMember loginMember) {
-        validateDuplicatedNickname(request);
-        Member member = getMember(loginMember);
-        member.registerNickname(request.nickname());
+        Nickname nickname = new Nickname(request.nickname());
+        validateDuplicatedNickname(nickname);
+        Member member = getMember(loginMember.id());
+        member.registerNickname(nickname);
     }
 
-    private void validateDuplicatedNickname(NicknameRegisterRequest request) {
-        if (memberRepository.existsByNickname(request.nickname())) {
+    private void validateDuplicatedNickname(Nickname nickname) {
+        if (memberRepository.existsByNickname(nickname)) {
             throw BusinessException.from(MemberErrorCode.DUPLICATED_NICKNAME);
         }
     }
 
-    private Member getMember(LoginMember loginMember) {
-        return memberRepository.findById(loginMember.id())
+    private Member getMember(Long memberId) {
+        return memberRepository.findById(memberId)
                 .orElseThrow(() -> BusinessException.from(MemberErrorCode.MEMBER_NOT_FOUND));
     }
 }

--- a/src/main/java/com/birca/bircabackend/command/member/application/MemberService.java
+++ b/src/main/java/com/birca/bircabackend/command/member/application/MemberService.java
@@ -4,6 +4,7 @@ import com.birca.bircabackend.command.auth.login.LoginMember;
 import com.birca.bircabackend.command.member.domain.Member;
 import com.birca.bircabackend.command.member.domain.MemberRepository;
 import com.birca.bircabackend.command.member.domain.MemberRole;
+import com.birca.bircabackend.command.member.dto.NicknameRegisterRequest;
 import com.birca.bircabackend.command.member.dto.RoleChangeRequest;
 import com.birca.bircabackend.command.member.exception.MemberErrorCode;
 import com.birca.bircabackend.common.exception.BusinessException;
@@ -23,5 +24,9 @@ public class MemberService {
                 .orElseThrow(() -> BusinessException.from(MemberErrorCode.MEMBER_NOT_FOUND));
         MemberRole role = MemberRole.from(request.role());
         member.changeRole(role);
+    }
+
+    public void registerNickname(NicknameRegisterRequest request, LoginMember loginMember) {
+
     }
 }

--- a/src/main/java/com/birca/bircabackend/command/member/application/MemberService.java
+++ b/src/main/java/com/birca/bircabackend/command/member/application/MemberService.java
@@ -20,13 +20,25 @@ public class MemberService {
     private final MemberRepository memberRepository;
 
     public void changeMemberRole(RoleChangeRequest request, LoginMember loginMember) {
-        Member member = memberRepository.findById(loginMember.id())
-                .orElseThrow(() -> BusinessException.from(MemberErrorCode.MEMBER_NOT_FOUND));
+        Member member = getMember(loginMember);
         MemberRole role = MemberRole.from(request.role());
         member.changeRole(role);
     }
 
     public void registerNickname(NicknameRegisterRequest request, LoginMember loginMember) {
+        validateDuplicatedNickname(request);
+        Member member = getMember(loginMember);
+        member.registerNickname(request.nickname());
+    }
 
+    private void validateDuplicatedNickname(NicknameRegisterRequest request) {
+        if (memberRepository.existsByNickname(request.nickname())) {
+            throw BusinessException.from(MemberErrorCode.DUPLICATED_NICKNAME);
+        }
+    }
+
+    private Member getMember(LoginMember loginMember) {
+        return memberRepository.findById(loginMember.id())
+                .orElseThrow(() -> BusinessException.from(MemberErrorCode.MEMBER_NOT_FOUND));
     }
 }

--- a/src/main/java/com/birca/bircabackend/command/member/domain/Member.java
+++ b/src/main/java/com/birca/bircabackend/command/member/domain/Member.java
@@ -21,5 +21,10 @@ public class Member extends BaseEntity {
     private String email;
 
     @Enumerated(EnumType.STRING)
-    private MemberRole memberRole;
+    @Column(name = "member_role")
+    private MemberRole role;
+
+    public void changeRole(MemberRole role) {
+        this.role = role;
+    }
 }

--- a/src/main/java/com/birca/bircabackend/command/member/domain/Member.java
+++ b/src/main/java/com/birca/bircabackend/command/member/domain/Member.java
@@ -1,10 +1,7 @@
 package com.birca.bircabackend.command.member.domain;
 
 import com.birca.bircabackend.common.domain.BaseEntity;
-import jakarta.persistence.Column;
-import jakarta.persistence.Entity;
-import jakarta.persistence.EnumType;
-import jakarta.persistence.Enumerated;
+import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -14,8 +11,8 @@ import lombok.NoArgsConstructor;
 @Getter
 public class Member extends BaseEntity {
 
-    @Column(unique = true)
-    private String nickname;
+    @Embedded
+    private Nickname nickname;
 
     @Column(unique = true)
     private String email;
@@ -28,7 +25,7 @@ public class Member extends BaseEntity {
         this.role = role;
     }
 
-    public void registerNickname(String nickname) {
+    public void registerNickname(Nickname nickname) {
         this.nickname = nickname;
     }
 }

--- a/src/main/java/com/birca/bircabackend/command/member/domain/Member.java
+++ b/src/main/java/com/birca/bircabackend/command/member/domain/Member.java
@@ -27,4 +27,8 @@ public class Member extends BaseEntity {
     public void changeRole(MemberRole role) {
         this.role = role;
     }
+
+    public void registerNickname(String nickname) {
+        this.nickname = nickname;
+    }
 }

--- a/src/main/java/com/birca/bircabackend/command/member/domain/MemberRepository.java
+++ b/src/main/java/com/birca/bircabackend/command/member/domain/MemberRepository.java
@@ -7,4 +7,6 @@ import java.util.Optional;
 public interface MemberRepository extends Repository<Member, Long> {
 
     Optional<Member> findById(Long id);
+
+    boolean existsByNickname(String nickname);
 }

--- a/src/main/java/com/birca/bircabackend/command/member/domain/MemberRepository.java
+++ b/src/main/java/com/birca/bircabackend/command/member/domain/MemberRepository.java
@@ -1,0 +1,10 @@
+package com.birca.bircabackend.command.member.domain;
+
+import org.springframework.data.repository.Repository;
+
+import java.util.Optional;
+
+public interface MemberRepository extends Repository<Member, Long> {
+
+    Optional<Member> findById(Long id);
+}

--- a/src/main/java/com/birca/bircabackend/command/member/domain/MemberRepository.java
+++ b/src/main/java/com/birca/bircabackend/command/member/domain/MemberRepository.java
@@ -8,5 +8,5 @@ public interface MemberRepository extends Repository<Member, Long> {
 
     Optional<Member> findById(Long id);
 
-    boolean existsByNickname(String nickname);
+    boolean existsByNickname(Nickname nickname);
 }

--- a/src/main/java/com/birca/bircabackend/command/member/domain/MemberRepository.java
+++ b/src/main/java/com/birca/bircabackend/command/member/domain/MemberRepository.java
@@ -2,11 +2,7 @@ package com.birca.bircabackend.command.member.domain;
 
 import org.springframework.data.repository.Repository;
 
-import java.util.Optional;
-
 public interface MemberRepository extends Repository<Member, Long> {
-
-    Optional<Member> findById(Long id);
 
     boolean existsByNickname(Nickname nickname);
 }

--- a/src/main/java/com/birca/bircabackend/command/member/domain/MemberRole.java
+++ b/src/main/java/com/birca/bircabackend/command/member/domain/MemberRole.java
@@ -1,8 +1,22 @@
 package com.birca.bircabackend.command.member.domain;
 
+import com.birca.bircabackend.command.member.exception.MemberErrorCode;
+import com.birca.bircabackend.common.exception.BusinessException;
+
+import java.util.Arrays;
+
 public enum MemberRole {
 
     HOST,
     VISITANT,
     OWNER
+
+    ;
+
+    public static MemberRole from(String name) {
+        return Arrays.stream(values())
+                .filter(role -> role.name().equals(name.toUpperCase()))
+                .findFirst()
+                .orElseThrow(() -> BusinessException.from(MemberErrorCode.INVALID_ROLE));
+    }
 }

--- a/src/main/java/com/birca/bircabackend/command/member/domain/Nickname.java
+++ b/src/main/java/com/birca/bircabackend/command/member/domain/Nickname.java
@@ -1,0 +1,31 @@
+package com.birca.bircabackend.command.member.domain;
+
+import com.birca.bircabackend.command.member.exception.MemberErrorCode;
+import com.birca.bircabackend.common.exception.BusinessException;
+import jakarta.persistence.Column;
+import jakarta.persistence.Embeddable;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Embeddable
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
+public class Nickname {
+
+    private static final int MAX_LENGTH = 10;
+
+    @Column(name = "nickname", unique = true)
+    private String value;
+
+    public Nickname(String value) {
+        validateInvalidNickname(value);
+        this.value = value;
+    }
+
+    private void validateInvalidNickname(String value) {
+        if (value.length() > MAX_LENGTH || value.isBlank()) {
+            throw BusinessException.from(MemberErrorCode.INVALID_NICKNAME);
+        }
+    }
+}

--- a/src/main/java/com/birca/bircabackend/command/member/dto/NicknameRegisterRequest.java
+++ b/src/main/java/com/birca/bircabackend/command/member/dto/NicknameRegisterRequest.java
@@ -1,0 +1,4 @@
+package com.birca.bircabackend.command.member.dto;
+
+public record NicknameRegisterRequest(String nickname) {
+}

--- a/src/main/java/com/birca/bircabackend/command/member/dto/RoleChangeRequest.java
+++ b/src/main/java/com/birca/bircabackend/command/member/dto/RoleChangeRequest.java
@@ -1,0 +1,4 @@
+package com.birca.bircabackend.command.member.dto;
+
+public record RoleChangeRequest(String role) {
+}

--- a/src/main/java/com/birca/bircabackend/command/member/exception/MemberErrorCode.java
+++ b/src/main/java/com/birca/bircabackend/command/member/exception/MemberErrorCode.java
@@ -9,13 +9,13 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor(access = AccessLevel.PACKAGE)
 public enum MemberErrorCode implements ErrorCode {
 
+    DUPLICATED_NICKNAME(3001 , 400, "중복된 닉네임입니다."),
+    INVALID_NICKNAME(3002, 400, "닉네임은 비어있거나 10자를 넘을 수 없습니다."),
     INVALID_ROLE(3003, 400, "존재하지 않는 역할입니다."),
+    MEMBER_NOT_FOUND(3004, 404, "존재하지 않는 회원입니다.")
 
-    MEMBER_NOT_FOUND(3004, 404, "존재하지 않는 회원입니다."),
 
-    DUPLICATED_NICKNAME(3001 , 400, "중복된 닉네임입닌다."),
-
-    INVALID_NICKNAME(3002, 400, "닉네임은 비어있거나 10자를 넘을 수 없습니다.");
+    ;
 
 
     private final int value;

--- a/src/main/java/com/birca/bircabackend/command/member/exception/MemberErrorCode.java
+++ b/src/main/java/com/birca/bircabackend/command/member/exception/MemberErrorCode.java
@@ -9,9 +9,12 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor(access = AccessLevel.PACKAGE)
 public enum MemberErrorCode implements ErrorCode {
 
-    MEMBER_NOT_FOUND(3004, 404, "존재하지 않는 회원입니다.")
+    INVALID_ROLE(3003, 400, "존재하지 않는 역할입니다."),
+
+    MEMBER_NOT_FOUND(3004, 404, "존재하지 않는 회원입니다."),
 
     ;
+
 
     private final int value;
     private final int httpStatusCode;

--- a/src/main/java/com/birca/bircabackend/command/member/exception/MemberErrorCode.java
+++ b/src/main/java/com/birca/bircabackend/command/member/exception/MemberErrorCode.java
@@ -13,9 +13,9 @@ public enum MemberErrorCode implements ErrorCode {
 
     MEMBER_NOT_FOUND(3004, 404, "존재하지 않는 회원입니다."),
 
-    DUPLICATED_NICKNAME(3001 , 400, "중복된 닉네임입닌다.")
+    DUPLICATED_NICKNAME(3001 , 400, "중복된 닉네임입닌다."),
 
-    ;
+    INVALID_NICKNAME(3002, 400, "닉네임은 비어있거나 10자를 넘을 수 없습니다.");
 
 
     private final int value;

--- a/src/main/java/com/birca/bircabackend/command/member/exception/MemberErrorCode.java
+++ b/src/main/java/com/birca/bircabackend/command/member/exception/MemberErrorCode.java
@@ -1,0 +1,19 @@
+package com.birca.bircabackend.command.member.exception;
+
+import com.birca.bircabackend.common.exception.ErrorCode;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor(access = AccessLevel.PACKAGE)
+public enum MemberErrorCode implements ErrorCode {
+
+    MEMBER_NOT_FOUND(3004, 404, "존재하지 않는 회원입니다.")
+
+    ;
+
+    private final int value;
+    private final int httpStatusCode;
+    private final String message;
+}

--- a/src/main/java/com/birca/bircabackend/command/member/exception/MemberErrorCode.java
+++ b/src/main/java/com/birca/bircabackend/command/member/exception/MemberErrorCode.java
@@ -13,6 +13,8 @@ public enum MemberErrorCode implements ErrorCode {
 
     MEMBER_NOT_FOUND(3004, 404, "존재하지 않는 회원입니다."),
 
+    DUPLICATED_NICKNAME(3001 , 400, "중복된 닉네임입닌다.")
+
     ;
 
 

--- a/src/main/java/com/birca/bircabackend/command/member/presentation/MemberController.java
+++ b/src/main/java/com/birca/bircabackend/command/member/presentation/MemberController.java
@@ -3,6 +3,7 @@ package com.birca.bircabackend.command.member.presentation;
 import com.birca.bircabackend.command.auth.login.LoginMember;
 import com.birca.bircabackend.command.auth.login.RequiredLogin;
 import com.birca.bircabackend.command.member.application.MemberService;
+import com.birca.bircabackend.command.member.dto.NicknameRegisterRequest;
 import com.birca.bircabackend.command.member.dto.RoleChangeRequest;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
@@ -23,6 +24,14 @@ public class MemberController {
     public ResponseEntity<Void> changeMemberRole(@RequestBody RoleChangeRequest request,
                                                  LoginMember loginMember) {
         memberService.changeMemberRole(request, loginMember);
+        return ResponseEntity.ok().build();
+    }
+
+    @PostMapping("/v1/join/register-nickname")
+    @RequiredLogin
+    public ResponseEntity<Void> registerNickname(@RequestBody NicknameRegisterRequest request,
+                                                 LoginMember loginMember) {
+        memberService.registerNickname(request, loginMember);
         return ResponseEntity.ok().build();
     }
 }

--- a/src/main/java/com/birca/bircabackend/command/member/presentation/MemberController.java
+++ b/src/main/java/com/birca/bircabackend/command/member/presentation/MemberController.java
@@ -1,0 +1,28 @@
+package com.birca.bircabackend.command.member.presentation;
+
+import com.birca.bircabackend.command.auth.login.LoginMember;
+import com.birca.bircabackend.command.auth.login.RequiredLogin;
+import com.birca.bircabackend.command.member.application.MemberService;
+import com.birca.bircabackend.command.member.dto.RoleChangeRequest;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api")
+@RequiredArgsConstructor
+public class MemberController {
+
+    private final MemberService memberService;
+
+    @PostMapping("/v1/members/role-change")
+    @RequiredLogin
+    public ResponseEntity<Void> changeMemberRole(@RequestBody RoleChangeRequest request,
+                                                 LoginMember loginMember) {
+        memberService.changeMemberRole(request, loginMember);
+        return ResponseEntity.ok().build();
+    }
+}

--- a/src/main/java/com/birca/bircabackend/common/EntityUtil.java
+++ b/src/main/java/com/birca/bircabackend/common/EntityUtil.java
@@ -1,0 +1,21 @@
+package com.birca.bircabackend.common;
+
+import com.birca.bircabackend.common.exception.BusinessException;
+import com.birca.bircabackend.common.exception.ErrorCode;
+import jakarta.persistence.EntityManager;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+import java.util.Optional;
+
+@Component
+@RequiredArgsConstructor
+public class EntityUtil {
+
+    private final EntityManager entityManager;
+
+    public <T> T getEntity(Class<T> type, Long id, ErrorCode errorCode) {
+        return Optional.ofNullable(entityManager.find(type, id))
+                .orElseThrow(() -> BusinessException.from(errorCode));
+    }
+}

--- a/src/main/java/com/birca/bircabackend/query/controller/MemberQueryController.java
+++ b/src/main/java/com/birca/bircabackend/query/controller/MemberQueryController.java
@@ -1,0 +1,25 @@
+package com.birca.bircabackend.query.controller;
+
+import com.birca.bircabackend.command.auth.login.RequiredLogin;
+import com.birca.bircabackend.query.dto.NicknameCheckResponse;
+import com.birca.bircabackend.query.service.MemberQueryService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api")
+@RequiredArgsConstructor
+public class MemberQueryController {
+
+    private final MemberQueryService memberQueryService;
+
+    @GetMapping("/v1/join/check-nickname")
+    @RequiredLogin
+    public ResponseEntity<NicknameCheckResponse> checkNicknameDuplicated(@RequestParam String nickname) {
+        return ResponseEntity.ok(memberQueryService.checkNickname(nickname));
+    }
+}

--- a/src/main/java/com/birca/bircabackend/query/controller/MemberQueryController.java
+++ b/src/main/java/com/birca/bircabackend/query/controller/MemberQueryController.java
@@ -19,7 +19,7 @@ public class MemberQueryController {
 
     @GetMapping("/v1/join/check-nickname")
     @RequiredLogin
-    public ResponseEntity<NicknameCheckResponse> checkNicknameDuplicated(@RequestParam String nickname) {
+    public ResponseEntity<NicknameCheckResponse> checkNicknameDuplicated(@RequestParam(name = "nickname") String nickname) {
         return ResponseEntity.ok(memberQueryService.checkNickname(nickname));
     }
 }

--- a/src/main/java/com/birca/bircabackend/query/dto/NicknameCheckResponse.java
+++ b/src/main/java/com/birca/bircabackend/query/dto/NicknameCheckResponse.java
@@ -1,0 +1,4 @@
+package com.birca.bircabackend.query.dto;
+
+public record NicknameCheckResponse(Boolean success) {
+}

--- a/src/main/java/com/birca/bircabackend/query/repository/MemberQueryRepository.java
+++ b/src/main/java/com/birca/bircabackend/query/repository/MemberQueryRepository.java
@@ -1,9 +1,10 @@
 package com.birca.bircabackend.query.repository;
 
 import com.birca.bircabackend.command.member.domain.Member;
+import com.birca.bircabackend.command.member.domain.Nickname;
 import org.springframework.data.repository.Repository;
 
 public interface MemberQueryRepository extends Repository<Member, Long> {
 
-    Boolean existsByNickname(String nickname);
+    Boolean existsByNickname(Nickname nickname);
 }

--- a/src/main/java/com/birca/bircabackend/query/repository/MemberQueryRepository.java
+++ b/src/main/java/com/birca/bircabackend/query/repository/MemberQueryRepository.java
@@ -1,0 +1,9 @@
+package com.birca.bircabackend.query.repository;
+
+import com.birca.bircabackend.command.member.domain.Member;
+import org.springframework.data.repository.Repository;
+
+public interface MemberQueryRepository extends Repository<Member, Long> {
+
+    Boolean existsByNickname(String nickname);
+}

--- a/src/main/java/com/birca/bircabackend/query/service/MemberQueryService.java
+++ b/src/main/java/com/birca/bircabackend/query/service/MemberQueryService.java
@@ -1,5 +1,6 @@
 package com.birca.bircabackend.query.service;
 
+import com.birca.bircabackend.command.member.domain.Nickname;
 import com.birca.bircabackend.query.dto.NicknameCheckResponse;
 import com.birca.bircabackend.query.repository.MemberQueryRepository;
 import lombok.RequiredArgsConstructor;
@@ -14,7 +15,7 @@ public class MemberQueryService {
     private final MemberQueryRepository memberQueryRepository;
 
     public NicknameCheckResponse checkNickname(String nickname) {
-        Boolean isDuplicated = memberQueryRepository.existsByNickname(nickname);
+        Boolean isDuplicated = memberQueryRepository.existsByNickname(new Nickname(nickname));
         return new NicknameCheckResponse(isDuplicated);
     }
 }

--- a/src/main/java/com/birca/bircabackend/query/service/MemberQueryService.java
+++ b/src/main/java/com/birca/bircabackend/query/service/MemberQueryService.java
@@ -1,0 +1,20 @@
+package com.birca.bircabackend.query.service;
+
+import com.birca.bircabackend.query.dto.NicknameCheckResponse;
+import com.birca.bircabackend.query.repository.MemberQueryRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+public class MemberQueryService {
+
+    private final MemberQueryRepository memberQueryRepository;
+
+    public NicknameCheckResponse checkNickname(String nickname) {
+        Boolean isDuplicated = memberQueryRepository.existsByNickname(nickname);
+        return new NicknameCheckResponse(isDuplicated);
+    }
+}

--- a/src/test/java/com/birca/bircabackend/command/auth/RequiredLoginTest.java
+++ b/src/test/java/com/birca/bircabackend/command/auth/RequiredLoginTest.java
@@ -3,13 +3,12 @@ package com.birca.bircabackend.command.auth;
 import com.birca.bircabackend.command.auth.exception.AuthErrorCode;
 import com.birca.bircabackend.command.auth.token.JwtTokenProvider;
 import com.birca.bircabackend.command.auth.token.TokenPayload;
+import com.birca.bircabackend.support.enviroment.DocumentationTest;
 import org.apache.http.HttpHeaders;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
-import org.springframework.context.annotation.Import;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.ResultActions;
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers;
@@ -18,9 +17,7 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
-@WebMvcTest
-@Import(JwtTokenProvider.class)
-class RequiredLoginTest {
+class RequiredLoginTest extends DocumentationTest {
 
     @Autowired
     private MockMvc mockMvc;

--- a/src/test/java/com/birca/bircabackend/command/auth/presentation/AuthControllerTest.java
+++ b/src/test/java/com/birca/bircabackend/command/auth/presentation/AuthControllerTest.java
@@ -1,0 +1,32 @@
+package com.birca.bircabackend.command.auth.presentation;
+
+import com.birca.bircabackend.command.auth.exception.AuthErrorCode;
+import com.birca.bircabackend.support.enviroment.DocumentationTest;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.ResultActions;
+
+import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
+import static org.springframework.restdocs.payload.PayloadDocumentation.responseFields;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+public class AuthControllerTest extends DocumentationTest {
+
+    @Test
+    void 인증_에러_코드() throws Exception {
+        // when
+        ResultActions result = mockMvc.perform(get("/error-codes")
+                .queryParam("className", "com.birca.bircabackend.command.auth.exception.AuthErrorCode")
+                .contentType(MediaType.APPLICATION_JSON)
+        );
+
+        // then
+        result.andExpect((status().isOk()))
+                .andDo(document("auth-error-Code",
+                        HOST_INFO,
+                        DOCUMENT_RESPONSE,
+                        responseFields(getErrorDescriptor(AuthErrorCode.values()))
+                ));
+    }
+}

--- a/src/test/java/com/birca/bircabackend/command/member/MemberFixtureRepository.java
+++ b/src/test/java/com/birca/bircabackend/command/member/MemberFixtureRepository.java
@@ -1,0 +1,7 @@
+package com.birca.bircabackend.command.member;
+
+import com.birca.bircabackend.command.member.domain.Member;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface MemberFixtureRepository extends JpaRepository<Member, Long> {
+}

--- a/src/test/java/com/birca/bircabackend/command/member/acceptance/MemberAcceptanceTest.java
+++ b/src/test/java/com/birca/bircabackend/command/member/acceptance/MemberAcceptanceTest.java
@@ -9,9 +9,11 @@ import org.junit.jupiter.api.Test;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
+import org.springframework.test.context.jdbc.Sql;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+@Sql("/fixture/member-fixture.sql")
 class MemberAcceptanceTest extends AcceptanceTest {
 
     @Test

--- a/src/test/java/com/birca/bircabackend/command/member/acceptance/MemberAcceptanceTest.java
+++ b/src/test/java/com/birca/bircabackend/command/member/acceptance/MemberAcceptanceTest.java
@@ -1,5 +1,6 @@
 package com.birca.bircabackend.command.member.acceptance;
 
+import com.birca.bircabackend.command.member.dto.NicknameRegisterRequest;
 import com.birca.bircabackend.command.member.dto.RoleChangeRequest;
 import com.birca.bircabackend.support.enviroment.AcceptanceTest;
 import io.restassured.RestAssured;
@@ -16,23 +17,43 @@ import static org.assertj.core.api.Assertions.assertThat;
 @Sql("/fixture/member-fixture.sql")
 class MemberAcceptanceTest extends AcceptanceTest {
 
+    private static final Long MEMBER_ID = 1L;
+
     @Test
     void 회원의_역할을_변경한다() {
         // given
-        Long memberId = 1L;
         RoleChangeRequest request = new RoleChangeRequest("HOST");
 
         // when
         ExtractableResponse<Response> response = RestAssured.given().log().all()
                 .when()
                 .contentType(MediaType.APPLICATION_JSON_VALUE)
-                .header(HttpHeaders.AUTHORIZATION, bearerTokenProvider.getToken(memberId))
+                .header(HttpHeaders.AUTHORIZATION, bearerTokenProvider.getToken(MEMBER_ID))
                 .body(request)
                 .post("/api/v1/members/role-change")
                 .then().log().all()
                 .extract();
 
         //then
+        assertThat(response.statusCode()).isEqualTo(HttpStatus.OK.value());
+    }
+
+    @Test
+    void 회원의_닉네임을_등록한다() {
+        // given
+        NicknameRegisterRequest request = new NicknameRegisterRequest("등록 닉네임");
+
+        // when
+        ExtractableResponse<Response> response = RestAssured.given().log().all()
+                .when()
+                .contentType(MediaType.APPLICATION_JSON_VALUE)
+                .header(HttpHeaders.AUTHORIZATION, bearerTokenProvider.getToken(MEMBER_ID))
+                .body(request)
+                .post("/api/v1/join/register-nickname")
+                .then().log().all()
+                .extract();
+
+        // then
         assertThat(response.statusCode()).isEqualTo(HttpStatus.OK.value());
     }
 }

--- a/src/test/java/com/birca/bircabackend/command/member/acceptance/MemberAcceptanceTest.java
+++ b/src/test/java/com/birca/bircabackend/command/member/acceptance/MemberAcceptanceTest.java
@@ -1,0 +1,36 @@
+package com.birca.bircabackend.command.member.acceptance;
+
+import com.birca.bircabackend.command.member.dto.RoleChangeRequest;
+import com.birca.bircabackend.support.enviroment.AcceptanceTest;
+import io.restassured.RestAssured;
+import io.restassured.response.ExtractableResponse;
+import io.restassured.response.Response;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class MemberAcceptanceTest extends AcceptanceTest {
+
+    @Test
+    void 회원의_역할을_변경한다() {
+        // given
+        Long memberId = 1L;
+        RoleChangeRequest request = new RoleChangeRequest("HOST");
+
+        // when
+        ExtractableResponse<Response> response = RestAssured.given().log().all()
+                .when()
+                .contentType(MediaType.APPLICATION_JSON_VALUE)
+                .header(HttpHeaders.AUTHORIZATION, bearerTokenProvider.getToken(memberId))
+                .body(request)
+                .post("/api/v1/members/role-change")
+                .then().log().all()
+                .extract();
+
+        //then
+        assertThat(response.statusCode()).isEqualTo(HttpStatus.OK.value());
+    }
+}

--- a/src/test/java/com/birca/bircabackend/command/member/application/MemberServiceTest.java
+++ b/src/test/java/com/birca/bircabackend/command/member/application/MemberServiceTest.java
@@ -2,7 +2,6 @@ package com.birca.bircabackend.command.member.application;
 
 import com.birca.bircabackend.command.auth.login.LoginMember;
 import com.birca.bircabackend.command.member.MemberFixtureRepository;
-import com.birca.bircabackend.command.member.domain.Member;
 import com.birca.bircabackend.command.member.dto.NicknameRegisterRequest;
 import com.birca.bircabackend.command.member.dto.RoleChangeRequest;
 import com.birca.bircabackend.command.member.exception.MemberErrorCode;
@@ -93,7 +92,7 @@ class MemberServiceTest extends ServiceTest {
 
             // then
             assertThat(memberFixtureRepository.findById(LOGIN_ID))
-                    .map(Member::getNickname)
+                    .map(member -> member.getNickname().getValue())
                     .get()
                     .isEqualTo(nickname);
         }

--- a/src/test/java/com/birca/bircabackend/command/member/application/MemberServiceTest.java
+++ b/src/test/java/com/birca/bircabackend/command/member/application/MemberServiceTest.java
@@ -50,6 +50,19 @@ class MemberServiceTest extends ServiceTest {
                     .isEqualTo(role);
         }
 
+        @ParameterizedTest
+        @ValueSource(strings = {"HOSTS", "VISITANTS", "INVALID"})
+        void 없는_역할로_변경하는_경우를_검증한다(String role) {
+            // given
+            RoleChangeRequest request = new RoleChangeRequest(role);
+
+            // when then
+            assertThatThrownBy(() -> memberService.changeMemberRole(request, loginMember))
+                    .isInstanceOf(BusinessException.class)
+                    .extracting("errorCode")
+                    .isEqualTo(MemberErrorCode.INVALID_ROLE);
+        }
+
         @Test
         void 변경할_때_없는_회원인_경우를_검증한다() {
             // given

--- a/src/test/java/com/birca/bircabackend/command/member/application/MemberServiceTest.java
+++ b/src/test/java/com/birca/bircabackend/command/member/application/MemberServiceTest.java
@@ -2,6 +2,8 @@ package com.birca.bircabackend.command.member.application;
 
 import com.birca.bircabackend.command.auth.login.LoginMember;
 import com.birca.bircabackend.command.member.MemberFixtureRepository;
+import com.birca.bircabackend.command.member.domain.Member;
+import com.birca.bircabackend.command.member.dto.NicknameRegisterRequest;
 import com.birca.bircabackend.command.member.dto.RoleChangeRequest;
 import com.birca.bircabackend.command.member.exception.MemberErrorCode;
 import com.birca.bircabackend.common.exception.BusinessException;
@@ -44,7 +46,7 @@ class MemberServiceTest extends ServiceTest {
             memberService.changeMemberRole(request, loginMember);
 
             // then
-            assertThat(memberFixtureRepository.findById(1L))
+            assertThat(memberFixtureRepository.findById(LOGIN_ID))
                     .map(member -> member.getRole().name())
                     .get()
                     .isEqualTo(role);
@@ -73,6 +75,40 @@ class MemberServiceTest extends ServiceTest {
                     .isInstanceOf(BusinessException.class)
                     .extracting("errorCode")
                     .isEqualTo(MemberErrorCode.MEMBER_NOT_FOUND);
+        }
+    }
+
+    @Nested
+    @DisplayName("닉네임을")
+    class RegisterNicknameTest {
+
+        @Test
+        void 정상_등록한다() {
+            // given
+            String nickname = "정상 닉네임";
+            NicknameRegisterRequest request = new NicknameRegisterRequest(nickname);
+
+            // when
+            memberService.registerNickname(request, loginMember);
+
+            // then
+            assertThat(memberFixtureRepository.findById(LOGIN_ID))
+                    .map(Member::getNickname)
+                    .get()
+                    .isEqualTo(nickname);
+        }
+
+        @Test
+        void 중복_등록하는_경우를_검증한다() {
+            // given
+            String nickname = "더즈";
+            NicknameRegisterRequest request = new NicknameRegisterRequest(nickname);
+
+            // when // then
+            assertThatThrownBy(() -> memberService.registerNickname(request, loginMember))
+                    .isInstanceOf(BusinessException.class)
+                    .extracting("errorCode")
+                    .isEqualTo(MemberErrorCode.DUPLICATED_NICKNAME);
         }
     }
 }

--- a/src/test/java/com/birca/bircabackend/command/member/application/MemberServiceTest.java
+++ b/src/test/java/com/birca/bircabackend/command/member/application/MemberServiceTest.java
@@ -3,15 +3,19 @@ package com.birca.bircabackend.command.member.application;
 import com.birca.bircabackend.command.auth.login.LoginMember;
 import com.birca.bircabackend.command.member.MemberFixtureRepository;
 import com.birca.bircabackend.command.member.dto.RoleChangeRequest;
+import com.birca.bircabackend.command.member.exception.MemberErrorCode;
+import com.birca.bircabackend.common.exception.BusinessException;
 import com.birca.bircabackend.support.enviroment.ServiceTest;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.test.context.jdbc.Sql;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 @Sql("/fixture/member-fixture.sql")
 class MemberServiceTest extends ServiceTest {
@@ -44,6 +48,18 @@ class MemberServiceTest extends ServiceTest {
                     .map(member -> member.getRole().name())
                     .get()
                     .isEqualTo(role);
+        }
+
+        @Test
+        void 변경할_때_없는_회원인_경우를_검증한다() {
+            // given
+            RoleChangeRequest request = new RoleChangeRequest("HOST");
+
+            // when // then
+            assertThatThrownBy(() -> memberService.changeMemberRole(request, new LoginMember(100L)))
+                    .isInstanceOf(BusinessException.class)
+                    .extracting("errorCode")
+                    .isEqualTo(MemberErrorCode.MEMBER_NOT_FOUND);
         }
     }
 }

--- a/src/test/java/com/birca/bircabackend/command/member/application/MemberServiceTest.java
+++ b/src/test/java/com/birca/bircabackend/command/member/application/MemberServiceTest.java
@@ -1,0 +1,49 @@
+package com.birca.bircabackend.command.member.application;
+
+import com.birca.bircabackend.command.auth.login.LoginMember;
+import com.birca.bircabackend.command.member.MemberFixtureRepository;
+import com.birca.bircabackend.command.member.dto.RoleChangeRequest;
+import com.birca.bircabackend.support.enviroment.ServiceTest;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.context.jdbc.Sql;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@Sql("/fixture/member-fixture.sql")
+class MemberServiceTest extends ServiceTest {
+
+    private static final long LOGIN_ID = 1L;
+
+    @Autowired
+    private MemberService memberService;
+
+    @Autowired
+    private MemberFixtureRepository memberFixtureRepository;
+
+    private final LoginMember loginMember = new LoginMember(LOGIN_ID);
+
+    @Nested
+    @DisplayName("회원 역할을")
+    class RoleChangeTest {
+
+        @ParameterizedTest
+        @ValueSource(strings = {"HOST", "VISITANT", "OWNER"})
+        void 존재_하는_역할로_변경_한다(String role) {
+            // given
+            RoleChangeRequest request = new RoleChangeRequest(role);
+
+            // when
+            memberService.changeMemberRole(request, loginMember);
+
+            // then
+            assertThat(memberFixtureRepository.findById(1L))
+                    .map(member -> member.getRole().name())
+                    .get()
+                    .isEqualTo(role);
+        }
+    }
+}

--- a/src/test/java/com/birca/bircabackend/command/member/domain/MemberRoleTest.java
+++ b/src/test/java/com/birca/bircabackend/command/member/domain/MemberRoleTest.java
@@ -1,0 +1,37 @@
+package com.birca.bircabackend.command.member.domain;
+
+import com.birca.bircabackend.command.member.exception.MemberErrorCode;
+import com.birca.bircabackend.common.exception.BusinessException;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class MemberRoleTest {
+
+    @Nested
+    class CreateTest {
+
+        @ParameterizedTest
+        @ValueSource(strings = {"HOST", "VISITANT", "OWNER"})
+        void 올바른_이름으로_역할을_생성한다(String name) {
+            // when
+            MemberRole role = MemberRole.from(name);
+
+            // then
+            assertThat(role).isEqualTo(MemberRole.valueOf(name));
+        }
+
+        @ParameterizedTest
+        @ValueSource(strings = {"HOSTS", "VISITANTS", "INVALID"})
+        void 없는_이름으로_역할을_생성하는_경우를_검증한다(String name) {
+            // when then
+            assertThatThrownBy(() -> MemberRole.from(name))
+                    .isInstanceOf(BusinessException.class)
+                    .extracting("errorCode")
+                    .isEqualTo(MemberErrorCode.INVALID_ROLE);
+        }
+    }
+}

--- a/src/test/java/com/birca/bircabackend/command/member/domain/MemberTest.java
+++ b/src/test/java/com/birca/bircabackend/command/member/domain/MemberTest.java
@@ -1,0 +1,31 @@
+package com.birca.bircabackend.command.member.domain;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class MemberTest {
+
+    private final Member member = new Member();
+
+    @Nested
+    @DisplayName("회원 역할을")
+    class RoleChangeTest {
+
+        @ParameterizedTest
+        @ValueSource(strings = {"HOST", "VISITANT", "OWNER"})
+        void 존재_하는_역할로_변경_한다(String requestRole) {
+            // given
+            MemberRole role = MemberRole.valueOf(requestRole);
+
+            // when
+            member.changeRole(role);
+
+            // then
+            assertThat(member.getRole()).isEqualTo(role);
+        }
+    }
+}

--- a/src/test/java/com/birca/bircabackend/command/member/domain/NicknameTest.java
+++ b/src/test/java/com/birca/bircabackend/command/member/domain/NicknameTest.java
@@ -1,0 +1,39 @@
+package com.birca.bircabackend.command.member.domain;
+
+import com.birca.bircabackend.command.member.exception.MemberErrorCode;
+import com.birca.bircabackend.common.exception.BusinessException;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class NicknameTest {
+
+    @Nested
+    @DisplayName("닉네임 생성 시")
+    class CreateTest {
+
+        @ParameterizedTest
+        @ValueSource(strings = {"nickname", "닉네임", "일", "0123456789"})
+        void 정상적으로_생성한다(String value) {
+            // when
+            Nickname nickname = new Nickname(value);
+
+            // then
+            assertThat(nickname.getValue()).isEqualTo(value);
+        }
+
+        @ParameterizedTest
+        @ValueSource(strings = {"", " ", "12345678910", "abcdefghijklmn"})
+        void 빈_값이거나_10자를_넘는_경우를_검증한다(String value) {
+            // when // then
+            assertThatThrownBy(() -> new Nickname(value))
+                    .isInstanceOf(BusinessException.class)
+                    .extracting("errorCode")
+                    .isEqualTo(MemberErrorCode.INVALID_NICKNAME);
+        }
+    }
+}

--- a/src/test/java/com/birca/bircabackend/command/member/presentation/MemberControllerTest.java
+++ b/src/test/java/com/birca/bircabackend/command/member/presentation/MemberControllerTest.java
@@ -2,6 +2,7 @@ package com.birca.bircabackend.command.member.presentation;
 
 import com.birca.bircabackend.command.member.dto.NicknameRegisterRequest;
 import com.birca.bircabackend.command.member.dto.RoleChangeRequest;
+import com.birca.bircabackend.command.member.exception.MemberErrorCode;
 import com.birca.bircabackend.support.enviroment.DocumentationTest;
 import org.junit.jupiter.api.Test;
 import org.springframework.http.HttpHeaders;
@@ -11,6 +12,7 @@ import org.springframework.test.web.servlet.ResultActions;
 
 import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
 import static org.springframework.restdocs.payload.PayloadDocumentation.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
@@ -53,6 +55,23 @@ class MemberControllerTest extends DocumentationTest {
                         requestFields(
                                 fieldWithPath("nickname").type(JsonFieldType.STRING).description("등록할 닉네임")
                         )
+                ));
+    }
+
+    @Test
+    void 회원_에러_코드() throws Exception {
+        // when
+        ResultActions result = mockMvc.perform(get("/error-codes")
+                .queryParam("className", "com.birca.bircabackend.command.member.exception.MemberErrorCode")
+                .contentType(MediaType.APPLICATION_JSON)
+        );
+
+        // then
+        result.andExpect((status().isOk()))
+                .andDo(document("member-error-Code",
+                        HOST_INFO,
+                        DOCUMENT_RESPONSE,
+                        responseFields(getErrorDescriptor(MemberErrorCode.values()))
                 ));
     }
 }

--- a/src/test/java/com/birca/bircabackend/command/member/presentation/MemberControllerTest.java
+++ b/src/test/java/com/birca/bircabackend/command/member/presentation/MemberControllerTest.java
@@ -20,7 +20,7 @@ class MemberControllerTest extends DocumentationTest {
         RoleChangeRequest request = new RoleChangeRequest("HOST");
 
         // when
-        ResultActions result = mockMvc.perform(post("/api/v1/member/role-change")
+        ResultActions result = mockMvc.perform(post("/api/v1/members/role-change")
                 .contentType(MediaType.APPLICATION_JSON)
                 .header(HttpHeaders.AUTHORIZATION, bearerTokenProvider.getToken(memberId))
                 .content(objectMapper.writeValueAsString(request))
@@ -28,6 +28,6 @@ class MemberControllerTest extends DocumentationTest {
 
         // then
         result.andExpect((status().isOk()))
-                .andDo(document("회원_역할_변경", HOST_INFO));
+                .andDo(document("member-role-change", HOST_INFO));
     }
 }

--- a/src/test/java/com/birca/bircabackend/command/member/presentation/MemberControllerTest.java
+++ b/src/test/java/com/birca/bircabackend/command/member/presentation/MemberControllerTest.java
@@ -51,7 +51,7 @@ class MemberControllerTest extends DocumentationTest {
         result.andExpect((status().isOk()))
                 .andDo(document("member-nickname-register", HOST_INFO,
                         requestFields(
-                                fieldWithPath("nickname").type(JsonFieldType.BOOLEAN).description("등록할 닉네임")
+                                fieldWithPath("nickname").type(JsonFieldType.STRING).description("등록할 닉네임")
                         )
                 ));
     }

--- a/src/test/java/com/birca/bircabackend/command/member/presentation/MemberControllerTest.java
+++ b/src/test/java/com/birca/bircabackend/command/member/presentation/MemberControllerTest.java
@@ -1,33 +1,58 @@
 package com.birca.bircabackend.command.member.presentation;
 
+import com.birca.bircabackend.command.member.dto.NicknameRegisterRequest;
 import com.birca.bircabackend.command.member.dto.RoleChangeRequest;
 import com.birca.bircabackend.support.enviroment.DocumentationTest;
 import org.junit.jupiter.api.Test;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
+import org.springframework.restdocs.payload.JsonFieldType;
 import org.springframework.test.web.servlet.ResultActions;
 
 import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
+import static org.springframework.restdocs.payload.PayloadDocumentation.*;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 class MemberControllerTest extends DocumentationTest {
 
+    private static final Long MEMBER_ID = 1L;
+
     @Test
     void 회원의_역할을_변경한다() throws Exception {
         // given
-        Long memberId = 1L;
         RoleChangeRequest request = new RoleChangeRequest("HOST");
 
         // when
         ResultActions result = mockMvc.perform(post("/api/v1/members/role-change")
                 .contentType(MediaType.APPLICATION_JSON)
-                .header(HttpHeaders.AUTHORIZATION, bearerTokenProvider.getToken(memberId))
+                .header(HttpHeaders.AUTHORIZATION, bearerTokenProvider.getToken(MEMBER_ID))
                 .content(objectMapper.writeValueAsString(request))
         );
 
         // then
         result.andExpect((status().isOk()))
                 .andDo(document("member-role-change", HOST_INFO));
+    }
+
+    @Test
+    void 회원의_닉네임을_등록한다() throws Exception {
+        // given
+        NicknameRegisterRequest request = new NicknameRegisterRequest("닉네임");
+
+        // when
+        ResultActions result = mockMvc.perform(post("/api/v1/join/register-nickname")
+                .contentType(MediaType.APPLICATION_JSON)
+                .header(HttpHeaders.AUTHORIZATION, bearerTokenProvider.getToken(MEMBER_ID))
+                .content(objectMapper.writeValueAsString(request))
+        );
+
+        // then
+        result.andExpect((status().isOk()))
+                .andDo(document("member-nickname-register", HOST_INFO,
+                        requestFields(
+                                fieldWithPath("nickname").type(JsonFieldType.BOOLEAN).description("등록할 닉네임")
+                        )
+                ));
     }
 }

--- a/src/test/java/com/birca/bircabackend/command/member/presentation/MemberControllerTest.java
+++ b/src/test/java/com/birca/bircabackend/command/member/presentation/MemberControllerTest.java
@@ -1,0 +1,33 @@
+package com.birca.bircabackend.command.member.presentation;
+
+import com.birca.bircabackend.command.member.dto.RoleChangeRequest;
+import com.birca.bircabackend.support.enviroment.DocumentationTest;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.ResultActions;
+
+import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+class MemberControllerTest extends DocumentationTest {
+
+    @Test
+    void 회원의_역할을_변경한다() throws Exception {
+        // given
+        Long memberId = 1L;
+        RoleChangeRequest request = new RoleChangeRequest("HOST");
+
+        // when
+        ResultActions result = mockMvc.perform(post("/api/v1/member/role-change")
+                .contentType(MediaType.APPLICATION_JSON)
+                .header(HttpHeaders.AUTHORIZATION, bearerTokenProvider.getToken(memberId))
+                .content(objectMapper.writeValueAsString(request))
+        );
+
+        // then
+        result.andExpect((status().isOk()))
+                .andDo(document("회원_역할_변경", HOST_INFO));
+    }
+}

--- a/src/test/java/com/birca/bircabackend/query/acceptance/MemberQueryAcceptanceTest.java
+++ b/src/test/java/com/birca/bircabackend/query/acceptance/MemberQueryAcceptanceTest.java
@@ -1,0 +1,43 @@
+package com.birca.bircabackend.query.acceptance;
+
+import com.birca.bircabackend.support.enviroment.AcceptanceTest;
+import io.restassured.RestAssured;
+import io.restassured.response.ExtractableResponse;
+import io.restassured.response.Response;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.jdbc.Sql;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertAll;
+
+
+@Sql("/fixture/member-fixture.sql")
+class MemberQueryAcceptanceTest extends AcceptanceTest {
+
+    @ParameterizedTest
+    @CsvSource({"새 닉네임, false", "더즈, true"})
+    void 중복된_닉네임인지_검사한다(String requestNickname, boolean isDuplicated) {
+        // given
+        Long memberId = 1L;
+
+        // when
+        ExtractableResponse<Response> response = RestAssured.given().log().all()
+                .when()
+                .contentType(MediaType.APPLICATION_JSON_VALUE)
+                .header(HttpHeaders.AUTHORIZATION, bearerTokenProvider.getToken(memberId))
+                .param("nickname", requestNickname)
+                .get("/api/v1/join/check-nickname")
+                .then().log().all()
+                .extract();
+
+        //then
+        assertAll(
+                () -> assertThat(response.statusCode()).isEqualTo(HttpStatus.OK.value()),
+                () -> assertThat(response.jsonPath().getBoolean("success")).isEqualTo(isDuplicated)
+        );
+    }
+}

--- a/src/test/java/com/birca/bircabackend/query/controller/MemberQueryControllerTest.java
+++ b/src/test/java/com/birca/bircabackend/query/controller/MemberQueryControllerTest.java
@@ -1,0 +1,50 @@
+package com.birca.bircabackend.query.controller;
+
+import com.birca.bircabackend.query.dto.NicknameCheckResponse;
+import com.birca.bircabackend.support.enviroment.DocumentationTest;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.restdocs.payload.JsonFieldType;
+import org.springframework.test.web.servlet.ResultActions;
+
+import static org.mockito.BDDMockito.given;
+import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
+import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
+import static org.springframework.restdocs.payload.PayloadDocumentation.responseFields;
+import static org.springframework.restdocs.request.RequestDocumentation.parameterWithName;
+import static org.springframework.restdocs.request.RequestDocumentation.queryParameters;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+class MemberQueryControllerTest extends DocumentationTest {
+
+
+    @Test
+    void 닉네임_중복을_검사한다() throws Exception {
+        // given
+        Long memberId = 1L;
+        String requestNickname = "does";
+        given(memberQueryService.checkNickname(requestNickname))
+                .willReturn(new NicknameCheckResponse(true));
+
+        // when
+        ResultActions result = mockMvc.perform(get("/api/v1/join/check-nickname")
+                .contentType(MediaType.APPLICATION_JSON)
+                .header(HttpHeaders.AUTHORIZATION, bearerTokenProvider.getToken(memberId))
+                        .characterEncoding("UTF-8")
+                .queryParam("nickname", requestNickname)
+        );
+
+        // then
+        result.andExpect((status().isOk()))
+                .andDo(document("check-nickname", HOST_INFO,
+                        queryParameters(
+                                parameterWithName("nickname").description("검사할 닉네임")
+                        ),
+                        responseFields(
+                                fieldWithPath("success").type(JsonFieldType.BOOLEAN).description("중복 여부")
+                        )
+                ));
+    }
+}

--- a/src/test/java/com/birca/bircabackend/query/service/MemberQueryServiceTest.java
+++ b/src/test/java/com/birca/bircabackend/query/service/MemberQueryServiceTest.java
@@ -1,0 +1,27 @@
+package com.birca.bircabackend.query.service;
+
+import com.birca.bircabackend.query.dto.NicknameCheckResponse;
+import com.birca.bircabackend.support.enviroment.ServiceTest;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.context.jdbc.Sql;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@Sql("/fixture/member-fixture.sql")
+class MemberQueryServiceTest extends ServiceTest {
+
+    @Autowired
+    private MemberQueryService memberQueryService;
+
+    @ParameterizedTest
+    @CsvSource({"새 닉네임, false", "더즈, true", "더즈1, false"})
+    void 중복된_닉네임인지_검사한다(String requestNickname, boolean isDuplicated) {
+        // when
+        NicknameCheckResponse response = memberQueryService.checkNickname(requestNickname);
+
+        // then
+        assertThat(response.success()).isEqualTo(isDuplicated);
+    }
+}

--- a/src/test/java/com/birca/bircabackend/support/ErrorCodeController.java
+++ b/src/test/java/com/birca/bircabackend/support/ErrorCodeController.java
@@ -1,0 +1,35 @@
+package com.birca.bircabackend.support;
+
+import com.birca.bircabackend.common.exception.ErrorCode;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.Arrays;
+import java.util.Map;
+
+import static java.util.stream.Collectors.toMap;
+
+@RestController
+@RequestMapping("/error-codes")
+public class ErrorCodeController {
+
+    @GetMapping
+    public Map<Integer, Object> getErrorCode(@RequestParam(name = "className") String className) throws ClassNotFoundException {
+        Class<?> errorCodeType = Class.forName(className);
+        ErrorCode[] errorCodes = (ErrorCode[]) errorCodeType.getEnumConstants();
+        return Arrays.stream(errorCodes)
+                .collect(toMap(ErrorCode::getValue, ErrorCodeResponse::new));
+    }
+
+    record ErrorCodeResponse(
+            Integer httpStatus,
+            String message
+    ) {
+        public ErrorCodeResponse(ErrorCode code) {
+            this(code.getHttpStatusCode(), code.getMessage());
+        }
+    }
+
+}

--- a/src/test/java/com/birca/bircabackend/support/TestBearerTokenProvider.java
+++ b/src/test/java/com/birca/bircabackend/support/TestBearerTokenProvider.java
@@ -1,0 +1,17 @@
+package com.birca.bircabackend.support;
+
+import com.birca.bircabackend.command.auth.token.JwtTokenProvider;
+import com.birca.bircabackend.command.auth.token.TokenPayload;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+@Component
+public class TestBearerTokenProvider {
+
+    @Autowired
+    private JwtTokenProvider jwtTokenProvider;
+
+    public String getToken(Long id) {
+        return "Bearer " + jwtTokenProvider.createToken(new TokenPayload(id));
+    }
+}

--- a/src/test/java/com/birca/bircabackend/support/enviroment/AcceptanceTest.java
+++ b/src/test/java/com/birca/bircabackend/support/enviroment/AcceptanceTest.java
@@ -1,8 +1,10 @@
 package com.birca.bircabackend.support.enviroment;
 
+import com.birca.bircabackend.support.TestBearerTokenProvider;
 import com.birca.bircabackend.support.isolation.DatabaseIsolation;
 import io.restassured.RestAssured;
 import org.junit.jupiter.api.BeforeEach;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.web.server.LocalServerPort;
 
@@ -17,4 +19,7 @@ public class AcceptanceTest {
     void setUp() {
         RestAssured.port = port;
     }
+
+    @Autowired
+    protected TestBearerTokenProvider bearerTokenProvider;
 }

--- a/src/test/java/com/birca/bircabackend/support/enviroment/DocumentationTest.java
+++ b/src/test/java/com/birca/bircabackend/support/enviroment/DocumentationTest.java
@@ -1,11 +1,13 @@
 package com.birca.bircabackend.support.enviroment;
 
 import com.birca.bircabackend.command.auth.token.JwtTokenProvider;
+import com.birca.bircabackend.command.member.application.MemberService;
 import com.birca.bircabackend.support.TestBearerTokenProvider;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.restdocs.AutoConfigureRestDocs;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.context.annotation.Import;
 import org.springframework.restdocs.operation.preprocess.OperationRequestPreprocessor;
 import org.springframework.test.web.servlet.MockMvc;
@@ -34,4 +36,7 @@ public class DocumentationTest {
 
     @Autowired
     protected TestBearerTokenProvider bearerTokenProvider;
+
+    @MockBean
+    protected MemberService memberService;
 }

--- a/src/test/java/com/birca/bircabackend/support/enviroment/DocumentationTest.java
+++ b/src/test/java/com/birca/bircabackend/support/enviroment/DocumentationTest.java
@@ -2,6 +2,7 @@ package com.birca.bircabackend.support.enviroment;
 
 import com.birca.bircabackend.command.auth.token.JwtTokenProvider;
 import com.birca.bircabackend.command.member.application.MemberService;
+import com.birca.bircabackend.common.exception.ErrorCode;
 import com.birca.bircabackend.query.service.MemberQueryService;
 import com.birca.bircabackend.support.TestBearerTokenProvider;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -11,9 +12,16 @@ import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.context.annotation.Import;
 import org.springframework.restdocs.operation.preprocess.OperationRequestPreprocessor;
+import org.springframework.restdocs.operation.preprocess.OperationResponsePreprocessor;
+import org.springframework.restdocs.payload.FieldDescriptor;
 import org.springframework.test.web.servlet.MockMvc;
 
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Stream;
+
 import static org.springframework.restdocs.operation.preprocess.Preprocessors.*;
+import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
 
 @WebMvcTest
 @Import({
@@ -29,6 +37,8 @@ public class DocumentationTest {
             .removePort(), prettyPrint()
     );
 
+    protected static final OperationResponsePreprocessor DOCUMENT_RESPONSE = preprocessResponse(prettyPrint());
+
     @Autowired
     protected MockMvc mockMvc;
 
@@ -43,4 +53,12 @@ public class DocumentationTest {
 
     @MockBean
     protected MemberQueryService memberQueryService;
+
+    protected List<FieldDescriptor> getErrorDescriptor(ErrorCode[] errorCodes) {
+        return Arrays.stream(errorCodes)
+                .flatMap(errorCode -> Stream.of(
+                        fieldWithPath(errorCode.getValue() + ".httpStatus").description(errorCode.getHttpStatusCode()),
+                        fieldWithPath(errorCode.getValue() + ".message").description(errorCode.getMessage())
+                )).toList();
+    }
 }

--- a/src/test/java/com/birca/bircabackend/support/enviroment/DocumentationTest.java
+++ b/src/test/java/com/birca/bircabackend/support/enviroment/DocumentationTest.java
@@ -2,6 +2,7 @@ package com.birca.bircabackend.support.enviroment;
 
 import com.birca.bircabackend.command.auth.token.JwtTokenProvider;
 import com.birca.bircabackend.command.member.application.MemberService;
+import com.birca.bircabackend.query.service.MemberQueryService;
 import com.birca.bircabackend.support.TestBearerTokenProvider;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -39,4 +40,7 @@ public class DocumentationTest {
 
     @MockBean
     protected MemberService memberService;
+
+    @MockBean
+    protected MemberQueryService memberQueryService;
 }

--- a/src/test/java/com/birca/bircabackend/support/enviroment/DocumentationTest.java
+++ b/src/test/java/com/birca/bircabackend/support/enviroment/DocumentationTest.java
@@ -1,6 +1,7 @@
 package com.birca.bircabackend.support.enviroment;
 
 import com.birca.bircabackend.command.auth.token.JwtTokenProvider;
+import com.birca.bircabackend.support.TestBearerTokenProvider;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.restdocs.AutoConfigureRestDocs;
@@ -12,7 +13,10 @@ import org.springframework.test.web.servlet.MockMvc;
 import static org.springframework.restdocs.operation.preprocess.Preprocessors.*;
 
 @WebMvcTest
-@Import(JwtTokenProvider.class)
+@Import({
+        JwtTokenProvider.class,
+        TestBearerTokenProvider.class
+})
 @AutoConfigureRestDocs
 public class DocumentationTest {
 
@@ -27,4 +31,7 @@ public class DocumentationTest {
 
     @Autowired
     protected ObjectMapper objectMapper;
+
+    @Autowired
+    protected TestBearerTokenProvider bearerTokenProvider;
 }

--- a/src/test/resources/fixture/member-fixture.sql
+++ b/src/test/resources/fixture/member-fixture.sql
@@ -1,0 +1,2 @@
+INSERT INTO member (id, nickname, email, member_role)
+VALUES (1, '더즈', 'ldk@gmail.com', 'VISITANT');


### PR DESCRIPTION
## 🌍 이슈 번호
- closed #10 
- closed #11  

## 📝 구현 내용
- 역할 체인지 기능 구현
- 닉네임 중복 검사 기능 구현
- 닉네임 등록 기능 구현

## 🍀 확인해야 할 부분
3개의 기능을 해도 작은줄 알았는데 막상 구현해보니 테스트도 많고 좀 큰 PR이 된 것 같습니다. 다음부턴 많아도 2개 API를 구현하도록 해야할 것 같아요.

- 이번 PR에서 command/query를 어떻게 나눴는지 한 번 봐주시면 좋을 것 같아요!
- 각 테스트를 어떻게 작성했는지 참고하시면 될 것 같아요!
- 서로 작업한 부분이 충돌 날 수 있는데 해결하면 되니까 부담없이 해주시면 됩니다. 테스트만 통과한다면 마음껏 코드를 수정할 수 있으니 테스트 작성이 중요할 것 같습니다.
