### PR TITLE
[FEAT] 아티스트 그룹 조회 및 아티스트 그룹의 아티스트 조회 기능 구현

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,6 @@ out/
 
 ### VS Code ###
 .vscode/
+
+## QType
+/src/main/generated/

--- a/build.gradle
+++ b/build.gradle
@@ -48,6 +48,12 @@ dependencies {
 	implementation 'io.jsonwebtoken:jjwt-api:0.11.5'
 	runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.11.5'
 	runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.11.5'
+
+	// querydsl
+	implementation 'com.querydsl:querydsl-jpa:5.0.0:jakarta'
+	annotationProcessor 'com.querydsl:querydsl-apt:5.0.0:jakarta'
+	annotationProcessor "jakarta.annotation:jakarta.annotation-api"
+	annotationProcessor "jakarta.persistence:jakarta.persistence-api"
 }
 
 ext {

--- a/src/docs/asciidoc/api.adoc
+++ b/src/docs/asciidoc/api.adoc
@@ -20,7 +20,8 @@ operation::member-nickname-register[snippets='http-request,request-fields,http-r
 === 에러 코드
 include::{snippets}/member-error-Code/response-body.adoc[]
 
-
 == 아티스트 API
 === 아티스트 그룹 목록 조회
 operation::get-artist-groups[snippets='http-request,query-parameters,http-response,response-fields']
+=== 아티스트 그룹 멤버 조회
+operation::get-artist-group-members[snippets='http-request,path-parameters,http-response,response-fields']

--- a/src/docs/asciidoc/api.adoc
+++ b/src/docs/asciidoc/api.adoc
@@ -20,3 +20,7 @@ operation::member-nickname-register[snippets='http-request,request-fields,http-r
 === 에러 코드
 include::{snippets}/member-error-Code/response-body.adoc[]
 
+
+== 아티스트 API
+=== 아티스트 그룹 목록 조회
+operation::get-artist-groups[snippets='http-request,query-parameters,http-response,response-fields']

--- a/src/main/java/com/birca/bircabackend/command/artist/domain/ArtistGroup.java
+++ b/src/main/java/com/birca/bircabackend/command/artist/domain/ArtistGroup.java
@@ -1,15 +1,14 @@
 package com.birca.bircabackend.command.artist.domain;
 
 import com.birca.bircabackend.common.domain.BaseEntity;
-import jakarta.persistence.Column;
-import jakarta.persistence.Entity;
-import jakarta.persistence.Lob;
+import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Entity
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(indexes = @Index(name = "IDX_NAME", columnList = "name"))
 @Getter
 public class ArtistGroup extends BaseEntity {
 

--- a/src/main/java/com/birca/bircabackend/query/controller/ArtistQueryController.java
+++ b/src/main/java/com/birca/bircabackend/query/controller/ArtistQueryController.java
@@ -2,14 +2,13 @@ package com.birca.bircabackend.query.controller;
 
 import com.birca.bircabackend.command.auth.login.RequiredLogin;
 import com.birca.bircabackend.query.dto.ArtistGroupResponse;
+import com.birca.bircabackend.query.dto.ArtistResponse;
 import com.birca.bircabackend.query.dto.PagingParams;
 import com.birca.bircabackend.query.service.ArtistGroupQueryService;
+import com.birca.bircabackend.query.service.ArtistQueryService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.ModelAttribute;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
 
@@ -19,10 +18,17 @@ import java.util.List;
 public class ArtistQueryController {
 
     private final ArtistGroupQueryService artistGroupQueryService;
+    private final ArtistQueryService artistQueryService;
 
     @GetMapping("/v1/artist-groups")
     @RequiredLogin
     public ResponseEntity<List<ArtistGroupResponse>> getArtistGroups(@ModelAttribute PagingParams pagingParams) {
         return ResponseEntity.ok(artistGroupQueryService.findGroups(pagingParams));
+    }
+
+    @GetMapping("/v1/artist-groups/{groupId}/artists")
+    @RequiredLogin
+    public ResponseEntity<List<ArtistResponse>> getArtistsOfGroup(@PathVariable(name = "groupId") Long groupId) {
+        return ResponseEntity.ok(artistQueryService.findArtistByGroup(groupId));
     }
 }

--- a/src/main/java/com/birca/bircabackend/query/controller/ArtistQueryController.java
+++ b/src/main/java/com/birca/bircabackend/query/controller/ArtistQueryController.java
@@ -1,0 +1,28 @@
+package com.birca.bircabackend.query.controller;
+
+import com.birca.bircabackend.command.auth.login.RequiredLogin;
+import com.birca.bircabackend.query.dto.ArtistGroupResponse;
+import com.birca.bircabackend.query.dto.PagingParams;
+import com.birca.bircabackend.query.service.ArtistGroupQueryService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.ModelAttribute;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/api")
+@RequiredArgsConstructor
+public class ArtistQueryController {
+
+    private final ArtistGroupQueryService artistGroupQueryService;
+
+    @GetMapping("/v1/artist-groups")
+    @RequiredLogin
+    public ResponseEntity<List<ArtistGroupResponse>> getArtistGroups(@ModelAttribute PagingParams pagingParams) {
+        return ResponseEntity.ok(artistGroupQueryService.findGroups(pagingParams));
+    }
+}

--- a/src/main/java/com/birca/bircabackend/query/dto/ArtistGroupResponse.java
+++ b/src/main/java/com/birca/bircabackend/query/dto/ArtistGroupResponse.java
@@ -1,0 +1,13 @@
+package com.birca.bircabackend.query.dto;
+
+import com.birca.bircabackend.command.artist.domain.ArtistGroup;
+
+public record ArtistGroupResponse(
+        Long groupId,
+        String groupName,
+        String groupImage) {
+
+    public ArtistGroupResponse(ArtistGroup group) {
+        this(group.getId(), group.getName(), group.getImageUrl());
+    }
+}

--- a/src/main/java/com/birca/bircabackend/query/dto/ArtistResponse.java
+++ b/src/main/java/com/birca/bircabackend/query/dto/ArtistResponse.java
@@ -1,0 +1,8 @@
+package com.birca.bircabackend.query.dto;
+
+public record ArtistResponse(
+        Long artistId,
+        String artistName,
+        String artistImage
+) {
+}

--- a/src/main/java/com/birca/bircabackend/query/dto/ArtistResponse.java
+++ b/src/main/java/com/birca/bircabackend/query/dto/ArtistResponse.java
@@ -1,8 +1,14 @@
 package com.birca.bircabackend.query.dto;
 
+import com.birca.bircabackend.command.artist.domain.Artist;
+
 public record ArtistResponse(
         Long artistId,
         String artistName,
         String artistImage
 ) {
+
+    public ArtistResponse(Artist artist) {
+        this(artist.getId(), artist.getName(), artist.getImageUrl());
+    }
 }

--- a/src/main/java/com/birca/bircabackend/query/dto/PagingParams.java
+++ b/src/main/java/com/birca/bircabackend/query/dto/PagingParams.java
@@ -9,6 +9,9 @@ import lombok.Setter;
 @Setter
 public class PagingParams {
 
-    private Long cursor;
-    private Integer size;
+    private static Long DEFAULT_CURSOR = 0L;
+    private static Integer DEFAULT_SIZE = 6;
+
+    private Long cursor = DEFAULT_CURSOR;
+    private Integer size = DEFAULT_SIZE;
 }

--- a/src/main/java/com/birca/bircabackend/query/dto/PagingParams.java
+++ b/src/main/java/com/birca/bircabackend/query/dto/PagingParams.java
@@ -1,0 +1,14 @@
+package com.birca.bircabackend.query.dto;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@NoArgsConstructor
+@Setter
+public class PagingParams {
+
+    private Long cursor;
+    private Integer size;
+}

--- a/src/main/java/com/birca/bircabackend/query/repository/ArtistGroupDynamicRepository.java
+++ b/src/main/java/com/birca/bircabackend/query/repository/ArtistGroupDynamicRepository.java
@@ -1,0 +1,11 @@
+package com.birca.bircabackend.query.repository;
+
+import com.birca.bircabackend.command.artist.domain.ArtistGroup;
+import com.birca.bircabackend.query.dto.PagingParams;
+
+import java.util.List;
+
+public interface ArtistGroupDynamicRepository {
+
+    List<ArtistGroup> queryPagedGroupsSortByName(PagingParams pagingParams);
+}

--- a/src/main/java/com/birca/bircabackend/query/repository/ArtistGroupDynamicRepositoryImpl.java
+++ b/src/main/java/com/birca/bircabackend/query/repository/ArtistGroupDynamicRepositoryImpl.java
@@ -1,0 +1,26 @@
+package com.birca.bircabackend.query.repository;
+
+import com.birca.bircabackend.command.artist.domain.ArtistGroup;
+import com.birca.bircabackend.query.dto.PagingParams;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+import static com.birca.bircabackend.command.artist.domain.QArtistGroup.artistGroup;
+
+@Repository
+@RequiredArgsConstructor
+public class ArtistGroupDynamicRepositoryImpl implements ArtistGroupDynamicRepository {
+
+    private final JPAQueryFactory queryFactory;
+
+    @Override
+    public List<ArtistGroup> queryPagedGroupsSortByName(PagingParams pagingParams) {
+        return queryFactory.selectFrom(artistGroup)
+                .orderBy(artistGroup.name.asc())
+                .limit(pagingParams.getSize())
+                .fetch();
+    }
+}

--- a/src/main/java/com/birca/bircabackend/query/repository/ArtistGroupQueryRepository.java
+++ b/src/main/java/com/birca/bircabackend/query/repository/ArtistGroupQueryRepository.java
@@ -1,12 +1,7 @@
 package com.birca.bircabackend.query.repository;
 
 import com.birca.bircabackend.command.artist.domain.ArtistGroup;
-import com.birca.bircabackend.query.dto.PagingParams;
 import org.springframework.data.repository.Repository;
 
-import java.util.List;
-
-public interface ArtistGroupQueryRepository extends Repository<ArtistGroup, Long> {
-
-    List<ArtistGroup> queryPagedGroups(PagingParams pagingParams);
+public interface ArtistGroupQueryRepository extends Repository<ArtistGroup, Long>, ArtistGroupDynamicRepository {
 }

--- a/src/main/java/com/birca/bircabackend/query/repository/ArtistGroupQueryRepository.java
+++ b/src/main/java/com/birca/bircabackend/query/repository/ArtistGroupQueryRepository.java
@@ -1,0 +1,12 @@
+package com.birca.bircabackend.query.repository;
+
+import com.birca.bircabackend.command.artist.domain.ArtistGroup;
+import com.birca.bircabackend.query.dto.PagingParams;
+import org.springframework.data.repository.Repository;
+
+import java.util.List;
+
+public interface ArtistGroupQueryRepository extends Repository<ArtistGroup, Long> {
+
+    List<ArtistGroup> queryPagedGroups(PagingParams pagingParams);
+}

--- a/src/main/java/com/birca/bircabackend/query/repository/ArtistQueryRepository.java
+++ b/src/main/java/com/birca/bircabackend/query/repository/ArtistQueryRepository.java
@@ -1,0 +1,11 @@
+package com.birca.bircabackend.query.repository;
+
+import com.birca.bircabackend.command.artist.domain.Artist;
+import org.springframework.data.repository.Repository;
+
+import java.util.List;
+
+public interface ArtistQueryRepository extends Repository<Artist, Long> {
+
+    List<Artist> findByGroupId(Long groupId);
+}

--- a/src/main/java/com/birca/bircabackend/query/repository/DynamicBooleanBuilder.java
+++ b/src/main/java/com/birca/bircabackend/query/repository/DynamicBooleanBuilder.java
@@ -1,0 +1,38 @@
+package com.birca.bircabackend.query.repository;
+
+import com.querydsl.core.BooleanBuilder;
+import com.querydsl.core.types.dsl.BooleanExpression;
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+
+import java.util.function.Supplier;
+
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public class DynamicBooleanBuilder {
+
+    private final BooleanBuilder booleanBuilder = new BooleanBuilder();
+
+    public static DynamicBooleanBuilder builder() {
+        return new DynamicBooleanBuilder();
+    }
+
+    public DynamicBooleanBuilder and(Supplier<BooleanExpression> expressionSupplier) {
+        try {
+            booleanBuilder.and(expressionSupplier.get());
+        } catch (IllegalArgumentException | NullPointerException ignored) {
+        }
+        return this;
+    }
+
+    public DynamicBooleanBuilder or(Supplier<BooleanExpression> expressionSupplier) {
+        try {
+            booleanBuilder.or(expressionSupplier.get());
+        } catch (IllegalArgumentException | NullPointerException ignored) {
+        }
+        return this;
+    }
+
+    public BooleanBuilder build() {
+        return booleanBuilder;
+    }
+}

--- a/src/main/java/com/birca/bircabackend/query/repository/config/QuerydslConfig.java
+++ b/src/main/java/com/birca/bircabackend/query/repository/config/QuerydslConfig.java
@@ -1,0 +1,16 @@
+package com.birca.bircabackend.query.repository.config;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import jakarta.persistence.EntityManager;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class QuerydslConfig {
+
+    @Bean
+    public JPAQueryFactory jpaQueryFactory(EntityManager entityManager) {
+        return new JPAQueryFactory(entityManager);
+    }
+
+}

--- a/src/main/java/com/birca/bircabackend/query/service/ArtistGroupQueryService.java
+++ b/src/main/java/com/birca/bircabackend/query/service/ArtistGroupQueryService.java
@@ -17,7 +17,7 @@ public class ArtistGroupQueryService {
     private final ArtistGroupQueryRepository artistGroupQueryRepository;
 
     public List<ArtistGroupResponse> findGroups(PagingParams pagingParams) {
-        return artistGroupQueryRepository.queryPagedGroups(pagingParams)
+        return artistGroupQueryRepository.queryPagedGroupsSortByName(pagingParams)
                 .stream()
                 .map(ArtistGroupResponse::new)
                 .toList();

--- a/src/main/java/com/birca/bircabackend/query/service/ArtistGroupQueryService.java
+++ b/src/main/java/com/birca/bircabackend/query/service/ArtistGroupQueryService.java
@@ -1,0 +1,25 @@
+package com.birca.bircabackend.query.service;
+
+import com.birca.bircabackend.query.dto.ArtistGroupResponse;
+import com.birca.bircabackend.query.dto.PagingParams;
+import com.birca.bircabackend.query.repository.ArtistGroupQueryRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Service
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+public class ArtistGroupQueryService {
+
+    private final ArtistGroupQueryRepository artistGroupQueryRepository;
+
+    public List<ArtistGroupResponse> findGroups(PagingParams pagingParams) {
+        return artistGroupQueryRepository.queryPagedGroups(pagingParams)
+                .stream()
+                .map(ArtistGroupResponse::new)
+                .toList();
+    }
+}

--- a/src/main/java/com/birca/bircabackend/query/service/ArtistQueryService.java
+++ b/src/main/java/com/birca/bircabackend/query/service/ArtistQueryService.java
@@ -1,0 +1,18 @@
+package com.birca.bircabackend.query.service;
+
+import com.birca.bircabackend.query.dto.ArtistResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Service
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+public class ArtistQueryService {
+
+    public List<ArtistResponse> findArtistByGroup(Long groupId) {
+        return null;
+    }
+}

--- a/src/main/java/com/birca/bircabackend/query/service/ArtistQueryService.java
+++ b/src/main/java/com/birca/bircabackend/query/service/ArtistQueryService.java
@@ -1,6 +1,7 @@
 package com.birca.bircabackend.query.service;
 
 import com.birca.bircabackend.query.dto.ArtistResponse;
+import com.birca.bircabackend.query.repository.ArtistQueryRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -12,7 +13,12 @@ import java.util.List;
 @RequiredArgsConstructor
 public class ArtistQueryService {
 
+    private final ArtistQueryRepository artistQueryRepository;
+
     public List<ArtistResponse> findArtistByGroup(Long groupId) {
-        return null;
+        return artistQueryRepository.findByGroupId(groupId)
+                .stream()
+                .map(ArtistResponse::new)
+                .toList();
     }
 }

--- a/src/main/resources/db/migration/V1__init.sql
+++ b/src/main/resources/db/migration/V1__init.sql
@@ -56,6 +56,8 @@ CREATE TABLE artist_group
     CONSTRAINT pk_artistgroup PRIMARY KEY (id)
 );
 
+CREATE INDEX IDX_NAME ON artist_group (name);
+
 CREATE TABLE artist
 (
     id        BIGINT AUTO_INCREMENT NOT NULL,

--- a/src/test/java/com/birca/bircabackend/query/acceptance/ArtistQueryAcceptanceTest.java
+++ b/src/test/java/com/birca/bircabackend/query/acceptance/ArtistQueryAcceptanceTest.java
@@ -39,4 +39,25 @@ class ArtistQueryAcceptanceTest extends AcceptanceTest {
                 () -> assertThat(response.jsonPath().getList(".")).hasSize(size)
         );
     }
+
+    @Test
+    void 아티스트_그룹의_멤버를_조회한다() {
+        // given
+        Long btsId = 6L;
+
+        // when
+        ExtractableResponse<Response> response = RestAssured.given().log().all()
+                .when()
+                .contentType(MediaType.APPLICATION_JSON_VALUE)
+                .header(HttpHeaders.AUTHORIZATION, bearerTokenProvider.getToken(MEMBER_ID))
+                .get("/api/v1/artist-groups/{groupId}/artists", btsId)
+                .then().log().all()
+                .extract();
+
+        // then
+        assertAll(
+                () -> assertThat(response.statusCode()).isEqualTo(HttpStatus.OK.value()),
+                () -> assertThat(response.jsonPath().getList(".")).hasSize(7)
+        );
+    }
 }

--- a/src/test/java/com/birca/bircabackend/query/acceptance/ArtistQueryAcceptanceTest.java
+++ b/src/test/java/com/birca/bircabackend/query/acceptance/ArtistQueryAcceptanceTest.java
@@ -8,10 +8,12 @@ import org.junit.jupiter.api.Test;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
+import org.springframework.test.context.jdbc.Sql;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertAll;
 
+@Sql("/fixture/artist-fixture.sql")
 class ArtistQueryAcceptanceTest extends AcceptanceTest {
 
     private static final Long MEMBER_ID = 1L;
@@ -19,19 +21,22 @@ class ArtistQueryAcceptanceTest extends AcceptanceTest {
     @Test
     void 아티스트_그룹_목록을_조회한다() {
         // given
+        int size = 6;
 
         // when
         ExtractableResponse<Response> response = RestAssured.given().log().all()
                 .when()
                 .contentType(MediaType.APPLICATION_JSON_VALUE)
                 .header(HttpHeaders.AUTHORIZATION, bearerTokenProvider.getToken(MEMBER_ID))
+                .queryParam("size", size)
                 .get("/api/v1/artist-groups")
                 .then().log().all()
                 .extract();
 
         // then
         assertAll(
-                () -> assertThat(response.statusCode()).isEqualTo(HttpStatus.OK.value())
+                () -> assertThat(response.statusCode()).isEqualTo(HttpStatus.OK.value()),
+                () -> assertThat(response.jsonPath().getList(".")).hasSize(size)
         );
     }
 }

--- a/src/test/java/com/birca/bircabackend/query/acceptance/ArtistQueryAcceptanceTest.java
+++ b/src/test/java/com/birca/bircabackend/query/acceptance/ArtistQueryAcceptanceTest.java
@@ -1,0 +1,37 @@
+package com.birca.bircabackend.query.acceptance;
+
+import com.birca.bircabackend.support.enviroment.AcceptanceTest;
+import io.restassured.RestAssured;
+import io.restassured.response.ExtractableResponse;
+import io.restassured.response.Response;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertAll;
+
+class ArtistQueryAcceptanceTest extends AcceptanceTest {
+
+    private static final Long MEMBER_ID = 1L;
+
+    @Test
+    void 아티스트_그룹_목록을_조회한다() {
+        // given
+
+        // when
+        ExtractableResponse<Response> response = RestAssured.given().log().all()
+                .when()
+                .contentType(MediaType.APPLICATION_JSON_VALUE)
+                .header(HttpHeaders.AUTHORIZATION, bearerTokenProvider.getToken(MEMBER_ID))
+                .get("/api/v1/artist-groups")
+                .then().log().all()
+                .extract();
+
+        // then
+        assertAll(
+                () -> assertThat(response.statusCode()).isEqualTo(HttpStatus.OK.value())
+        );
+    }
+}

--- a/src/test/java/com/birca/bircabackend/query/controller/ArtistQueryControllerTest.java
+++ b/src/test/java/com/birca/bircabackend/query/controller/ArtistQueryControllerTest.java
@@ -1,0 +1,49 @@
+package com.birca.bircabackend.query.controller;
+
+import com.birca.bircabackend.support.enviroment.DocumentationTest;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.restdocs.payload.JsonFieldType;
+import org.springframework.test.web.servlet.ResultActions;
+
+import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
+import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
+import static org.springframework.restdocs.payload.PayloadDocumentation.responseFields;
+import static org.springframework.restdocs.request.RequestDocumentation.parameterWithName;
+import static org.springframework.restdocs.request.RequestDocumentation.queryParameters;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+public class ArtistQueryControllerTest extends DocumentationTest {
+
+    private static final Long MEMBER_ID = 1L;
+
+    @Test
+    void 아티스트_그룹_목록을_조회한다() throws Exception {
+        // given
+
+
+        // when
+        ResultActions result = mockMvc.perform(get("/api/v1/artist-groups")
+                .contentType(MediaType.APPLICATION_JSON)
+                .queryParam("cursor", "10")
+                .queryParam("size", "10")
+                .header(HttpHeaders.AUTHORIZATION, bearerTokenProvider.getToken(MEMBER_ID))
+        );
+
+        // then
+        result.andExpect((status().isOk()))
+                .andDo(document("get-artist-groups", HOST_INFO,
+                        queryParameters(
+                                parameterWithName("cursor").description("이전에 쿼리된 마지막 groupId"),
+                                parameterWithName("size").description("검색할 개수")
+                        ),
+                        responseFields(
+                                fieldWithPath("[].groupId").type(JsonFieldType.NUMBER).description("아티스트 그룹 ID"),
+                                fieldWithPath("[].groupName").type(JsonFieldType.STRING).description("아티스트 그룹 이름"),
+                                fieldWithPath("[].groupImage").type(JsonFieldType.STRING).description("아티스트 그룹 이미지 url")
+                        )
+                ));
+    }
+}

--- a/src/test/java/com/birca/bircabackend/query/controller/ArtistQueryControllerTest.java
+++ b/src/test/java/com/birca/bircabackend/query/controller/ArtistQueryControllerTest.java
@@ -3,7 +3,6 @@ package com.birca.bircabackend.query.controller;
 import com.birca.bircabackend.query.dto.ArtistGroupResponse;
 import com.birca.bircabackend.support.enviroment.DocumentationTest;
 import org.junit.jupiter.api.Test;
-import org.mockito.BDDMockito;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
 import org.springframework.restdocs.payload.JsonFieldType;
@@ -12,11 +11,11 @@ import org.springframework.test.web.servlet.ResultActions;
 import java.util.List;
 
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
 import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
 import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
 import static org.springframework.restdocs.payload.PayloadDocumentation.responseFields;
-import static org.springframework.restdocs.request.RequestDocumentation.parameterWithName;
-import static org.springframework.restdocs.request.RequestDocumentation.queryParameters;
+import static org.springframework.restdocs.request.RequestDocumentation.*;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
@@ -27,7 +26,7 @@ public class ArtistQueryControllerTest extends DocumentationTest {
     @Test
     void 아티스트_그룹_목록을_조회한다() throws Exception {
         // given
-        BDDMockito.given(artistGroupQueryService.findGroups(any()))
+        given(artistGroupQueryService.findGroups(any()))
                 .willReturn(List.of(
                         new ArtistGroupResponse(11L, "뉴진스", "newjeans.com"),
                         new ArtistGroupResponse(12L, "아이브", "ive.com"),
@@ -53,6 +52,30 @@ public class ArtistQueryControllerTest extends DocumentationTest {
                                 fieldWithPath("[].groupId").type(JsonFieldType.NUMBER).description("아티스트 그룹 ID"),
                                 fieldWithPath("[].groupName").type(JsonFieldType.STRING).description("아티스트 그룹 이름"),
                                 fieldWithPath("[].groupImage").type(JsonFieldType.STRING).description("아티스트 그룹 이미지 url")
+                        )
+                ));
+    }
+
+    @Test
+    void 아티스트_그룹의_멤버를_조회한다() throws Exception {
+        // given
+
+        // when
+        ResultActions result = mockMvc.perform(get("/api/v1/artist-groups/{groupId}/artists", 1L)
+                .contentType(MediaType.APPLICATION_JSON)
+                .header(HttpHeaders.AUTHORIZATION, bearerTokenProvider.getToken(MEMBER_ID))
+        );
+
+        // then
+        result.andExpect((status().isOk()))
+                .andDo(document("get-artist-group-members", HOST_INFO, DOCUMENT_RESPONSE,
+                        pathParameters(
+                                parameterWithName("groupId").description("조회할 그룹의 ID")
+                        ),
+                        responseFields(
+                                fieldWithPath("[].artistId").type(JsonFieldType.NUMBER).description("아티스트 ID"),
+                                fieldWithPath("[].artistName").type(JsonFieldType.STRING).description("아티스트 이름"),
+                                fieldWithPath("[].artistImage").type(JsonFieldType.STRING).description("아티스트 이미지 url")
                         )
                 ));
     }

--- a/src/test/java/com/birca/bircabackend/query/controller/ArtistQueryControllerTest.java
+++ b/src/test/java/com/birca/bircabackend/query/controller/ArtistQueryControllerTest.java
@@ -1,6 +1,7 @@
 package com.birca.bircabackend.query.controller;
 
 import com.birca.bircabackend.query.dto.ArtistGroupResponse;
+import com.birca.bircabackend.query.dto.ArtistResponse;
 import com.birca.bircabackend.support.enviroment.DocumentationTest;
 import org.junit.jupiter.api.Test;
 import org.springframework.http.HttpHeaders;
@@ -13,10 +14,10 @@ import java.util.List;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
 import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.get;
 import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
 import static org.springframework.restdocs.payload.PayloadDocumentation.responseFields;
 import static org.springframework.restdocs.request.RequestDocumentation.*;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 public class ArtistQueryControllerTest extends DocumentationTest {
@@ -59,9 +60,20 @@ public class ArtistQueryControllerTest extends DocumentationTest {
     @Test
     void 아티스트_그룹의_멤버를_조회한다() throws Exception {
         // given
+        Long groupId = 1L;
+        given(artistQueryService.findArtistByGroup(groupId))
+                .willReturn(List.of(
+                        new ArtistResponse(5L, "뷔", "image5.com"),
+                        new ArtistResponse(1L, "석진", "image1.com"),
+                        new ArtistResponse(7L, "슈가", "image7.com"),
+                        new ArtistResponse(2L, "정국", "image2.com"),
+                        new ArtistResponse(3L, "제이홉", "image3.com"),
+                        new ArtistResponse(6L, "지민", "image6.com"),
+                        new ArtistResponse(4L, "RM", "image4.com")
+                ));
 
         // when
-        ResultActions result = mockMvc.perform(get("/api/v1/artist-groups/{groupId}/artists", 1L)
+        ResultActions result = mockMvc.perform(get("/api/v1/artist-groups/{groupId}/artists", groupId)
                 .contentType(MediaType.APPLICATION_JSON)
                 .header(HttpHeaders.AUTHORIZATION, bearerTokenProvider.getToken(MEMBER_ID))
         );

--- a/src/test/java/com/birca/bircabackend/query/controller/ArtistQueryControllerTest.java
+++ b/src/test/java/com/birca/bircabackend/query/controller/ArtistQueryControllerTest.java
@@ -1,12 +1,17 @@
 package com.birca.bircabackend.query.controller;
 
+import com.birca.bircabackend.query.dto.ArtistGroupResponse;
 import com.birca.bircabackend.support.enviroment.DocumentationTest;
 import org.junit.jupiter.api.Test;
+import org.mockito.BDDMockito;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
 import org.springframework.restdocs.payload.JsonFieldType;
 import org.springframework.test.web.servlet.ResultActions;
 
+import java.util.List;
+
+import static org.mockito.ArgumentMatchers.any;
 import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
 import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
 import static org.springframework.restdocs.payload.PayloadDocumentation.responseFields;
@@ -22,19 +27,24 @@ public class ArtistQueryControllerTest extends DocumentationTest {
     @Test
     void 아티스트_그룹_목록을_조회한다() throws Exception {
         // given
-
+        BDDMockito.given(artistGroupQueryService.findGroups(any()))
+                .willReturn(List.of(
+                        new ArtistGroupResponse(11L, "뉴진스", "newjeans.com"),
+                        new ArtistGroupResponse(12L, "아이브", "ive.com"),
+                        new ArtistGroupResponse(13L, "방탄소년단", "bts.com")
+                ));
 
         // when
         ResultActions result = mockMvc.perform(get("/api/v1/artist-groups")
                 .contentType(MediaType.APPLICATION_JSON)
                 .queryParam("cursor", "10")
-                .queryParam("size", "10")
+                .queryParam("size", "3")
                 .header(HttpHeaders.AUTHORIZATION, bearerTokenProvider.getToken(MEMBER_ID))
         );
 
         // then
         result.andExpect((status().isOk()))
-                .andDo(document("get-artist-groups", HOST_INFO,
+                .andDo(document("get-artist-groups", HOST_INFO, DOCUMENT_RESPONSE,
                         queryParameters(
                                 parameterWithName("cursor").description("이전에 쿼리된 마지막 groupId"),
                                 parameterWithName("size").description("검색할 개수")

--- a/src/test/java/com/birca/bircabackend/query/service/ArtistGroupQueryServiceTest.java
+++ b/src/test/java/com/birca/bircabackend/query/service/ArtistGroupQueryServiceTest.java
@@ -1,0 +1,77 @@
+package com.birca.bircabackend.query.service;
+
+import com.birca.bircabackend.query.dto.ArtistGroupResponse;
+import com.birca.bircabackend.query.dto.PagingParams;
+import com.birca.bircabackend.support.enviroment.ServiceTest;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.context.jdbc.Sql;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@Sql("/fixture/artist-fixture.sql")
+class ArtistGroupQueryServiceTest extends ServiceTest {
+
+    @Autowired
+    private ArtistGroupQueryService artistGroupQueryService;
+
+    @Nested
+    @DisplayName("아티스트 그룹 목록 조회 시")
+    class GetGroupsTest {
+
+        private final PagingParams pagingParams = new PagingParams();
+
+        @Test
+        void 필요한_필드를_모두_조회한다() {
+            // when
+            List<ArtistGroupResponse> actual = artistGroupQueryService.findGroups(pagingParams);
+
+            // then
+            assertThat(actual.get(0))
+                    .isEqualTo(new ArtistGroupResponse(5L, "뉴진스", "image5.com"));
+        }
+
+        @Test
+        void 커서와_사이즈가_없는_경우를_조회한다() {
+            // when
+            List<ArtistGroupResponse> actual = artistGroupQueryService.findGroups(pagingParams);
+
+            // then
+            assertThat(actual)
+                    .map(ArtistGroupResponse::groupId)
+                    .containsExactly(5L, 6L, 7L, 8L, 2L, 11L);
+        }
+
+        @Test
+        void 사이즈만큼_조회한다() {
+            // given
+            pagingParams.setSize(10);
+
+            // when
+            List<ArtistGroupResponse> actual = artistGroupQueryService.findGroups(pagingParams);
+
+            // then
+            assertThat(actual)
+                    .map(ArtistGroupResponse::groupId)
+                    .containsExactly(5L, 6L, 7L, 8L, 2L, 11L, 12L, 3L, 1L, 9L);
+        }
+
+        @Test
+        void 커서_이후만큼_조회한다() {
+            // given
+            pagingParams.setCursor(11L);
+
+            // when
+            List<ArtistGroupResponse> actual = artistGroupQueryService.findGroups(pagingParams);
+
+            // then
+            assertThat(actual)
+                    .map(ArtistGroupResponse::groupId)
+                    .containsExactly(12L, 3L, 1L, 9L, 4L, 10L);
+        }
+    }
+}

--- a/src/test/java/com/birca/bircabackend/query/service/ArtistQueryServiceTest.java
+++ b/src/test/java/com/birca/bircabackend/query/service/ArtistQueryServiceTest.java
@@ -1,0 +1,46 @@
+package com.birca.bircabackend.query.service;
+
+import com.birca.bircabackend.query.dto.ArtistResponse;
+import com.birca.bircabackend.support.enviroment.ServiceTest;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.context.jdbc.Sql;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@Sql("/fixture/artist-fixture.sql")
+class ArtistQueryServiceTest extends ServiceTest {
+
+    @Autowired
+    private ArtistQueryService artistQueryService;
+
+    @Nested
+    @DisplayName("아티스트 그룹 멤버를")
+    class FindGroupMemberTest {
+
+        @Test
+        void 조회_한다() {
+            // given
+            Long btsId = 6L;
+
+            // when
+            List<ArtistResponse> actual = artistQueryService.findArtistByGroup(btsId);
+
+            // then
+            assertThat(actual)
+                    .containsOnly(
+                            new ArtistResponse(5L, "뷔", "image5.com"),
+                            new ArtistResponse(1L, "석진", "image1.com"),
+                            new ArtistResponse(7L, "슈가", "image7.com"),
+                            new ArtistResponse(2L, "정국", "image2.com"),
+                            new ArtistResponse(3L, "제이홉", "image3.com"),
+                            new ArtistResponse(6L, "지민", "image6.com"),
+                            new ArtistResponse(4L, "RM", "image4.com")
+                    );
+        }
+    }
+}

--- a/src/test/java/com/birca/bircabackend/support/enviroment/DocumentationTest.java
+++ b/src/test/java/com/birca/bircabackend/support/enviroment/DocumentationTest.java
@@ -4,6 +4,7 @@ import com.birca.bircabackend.command.auth.token.JwtTokenProvider;
 import com.birca.bircabackend.command.member.application.MemberService;
 import com.birca.bircabackend.common.exception.ErrorCode;
 import com.birca.bircabackend.query.service.ArtistGroupQueryService;
+import com.birca.bircabackend.query.service.ArtistQueryService;
 import com.birca.bircabackend.query.service.MemberQueryService;
 import com.birca.bircabackend.support.TestBearerTokenProvider;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -57,6 +58,9 @@ public class DocumentationTest {
 
     @MockBean
     protected ArtistGroupQueryService artistGroupQueryService;
+
+    @MockBean
+    protected ArtistQueryService artistQueryService;
 
     protected List<FieldDescriptor> getErrorDescriptor(ErrorCode[] errorCodes) {
         return Arrays.stream(errorCodes)

--- a/src/test/java/com/birca/bircabackend/support/enviroment/DocumentationTest.java
+++ b/src/test/java/com/birca/bircabackend/support/enviroment/DocumentationTest.java
@@ -3,6 +3,7 @@ package com.birca.bircabackend.support.enviroment;
 import com.birca.bircabackend.command.auth.token.JwtTokenProvider;
 import com.birca.bircabackend.command.member.application.MemberService;
 import com.birca.bircabackend.common.exception.ErrorCode;
+import com.birca.bircabackend.query.service.ArtistGroupQueryService;
 import com.birca.bircabackend.query.service.MemberQueryService;
 import com.birca.bircabackend.support.TestBearerTokenProvider;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -53,6 +54,9 @@ public class DocumentationTest {
 
     @MockBean
     protected MemberQueryService memberQueryService;
+
+    @MockBean
+    protected ArtistGroupQueryService artistGroupQueryService;
 
     protected List<FieldDescriptor> getErrorDescriptor(ErrorCode[] errorCodes) {
         return Arrays.stream(errorCodes)

--- a/src/test/resources/fixture/artist-fixture.sql
+++ b/src/test/resources/fixture/artist-fixture.sql
@@ -1,13 +1,28 @@
 INSERT INTO artist_group (id, name, image_url)
 VALUES (5, '뉴진스', 'image5.com'),
-    (6, '방탄소년단', 'image6.com'),
-    (7, '비비지', 'image7.com'),
-    (8, '세븐틴', 'image8.com'),
-    (2, '스테이시', 'image2.com'),
-    (11, '시스타', 'image11.com'),
-    (12, '시스타', 'image12.com'),
-    (3, '아이브', 'image3.com'),
-    (1, '에스파', 'image1.com'),
-    (9, '엑소', 'image9.com'),
-    (4, '케플러', 'image4.com'),
-    (10, '트와이스', 'image0.com');
+       (6, '방탄소년단', 'image6.com'),
+       (7, '비비지', 'image7.com'),
+       (8, '세븐틴', 'image8.com'),
+       (2, '스테이시', 'image2.com'),
+       (11, '시스타', 'image11.com'),
+       (12, '시스타', 'image12.com'),
+       (3, '아이브', 'image3.com'),
+       (1, '에스파', 'image1.com'),
+       (9, '엑소', 'image9.com'),
+       (4, '케플러', 'image4.com'),
+       (10, '트와이스', 'image0.com');
+
+INSERT INTO artist (id, group_id, name, image_url)
+VALUES (1, 6, '석진', 'image1.com'),
+       (2, 6, '정국', 'image2.com'),
+       (3, 6, '제이홉', 'image3.com'),
+       (4, 6, 'RM', 'image4.com'),
+       (5, 6, '뷔', 'image5.com'),
+       (6, 6, '지민', 'image6.com'),
+       (7, 6, '슈가', 'image7.com'),
+
+       (8, 5, '하니', 'image8.com'),
+       (9, 5, '해린', 'image9.com'),
+       (10, 5, '민지', 'image10.com'),
+       (11, 5, '다니엘', 'image11.com'),
+       (12, 5, '혜인', 'image12.com');

--- a/src/test/resources/fixture/artist-fixture.sql
+++ b/src/test/resources/fixture/artist-fixture.sql
@@ -1,0 +1,13 @@
+INSERT INTO artist_group (id, name, image_url)
+VALUES (5, '뉴진스', 'image5.com'),
+    (6, '방탄소년단', 'image6.com'),
+    (7, '비비지', 'image7.com'),
+    (8, '세븐틴', 'image8.com'),
+    (2, '스테이시', 'image2.com'),
+    (11, '시스타', 'image11.com'),
+    (12, '시스타', 'image12.com'),
+    (3, '아이브', 'image3.com'),
+    (1, '에스파', 'image1.com'),
+    (9, '엑소', 'image9.com'),
+    (4, '케플러', 'image4.com'),
+    (10, '트와이스', 'image0.com');


### PR DESCRIPTION
## 🌍 이슈 번호
- closed #13 

## 📝 구현 내용
- 아티스트 그룹 조회 기능 구현
- 아티스트 그룹의 멤버 조회 기능 구현

## 🍀 확인해야 할 부분
- 동적 쿼리를 사용해야 해서 querydsl 의존성을 추가했습니다.
