### PR TITLE
[IFX] 카카오 로그인 로직 수정

### DIFF
--- a/src/main/java/com/birca/bircabackend/command/auth/application/MemberAuthRepository.java
+++ b/src/main/java/com/birca/bircabackend/command/auth/application/MemberAuthRepository.java
@@ -1,5 +1,6 @@
 package com.birca.bircabackend.command.auth.application;
 
+import com.birca.bircabackend.command.member.domain.IdentityKey;
 import com.birca.bircabackend.command.member.domain.Member;
 import org.springframework.data.repository.Repository;
 
@@ -7,5 +8,5 @@ import java.util.Optional;
 
 public interface MemberAuthRepository extends Repository<Member, Long> {
 
-    Optional<Member> findByEmailAndRegistrationId(String email, String registrationId);
+    Optional<Member> findByIdentityKey(IdentityKey identityKey);
 }

--- a/src/main/java/com/birca/bircabackend/command/auth/application/oauth/OAuthMember.java
+++ b/src/main/java/com/birca/bircabackend/command/auth/application/oauth/OAuthMember.java
@@ -1,10 +1,7 @@
 package com.birca.bircabackend.command.auth.application.oauth;
 
-import com.birca.bircabackend.command.member.domain.Member;
-
-public record OAuthMember(String email, String registrationId) {
-
-    public Member toMember() {
-        return Member.join(email, registrationId);
-    }
+public record OAuthMember(
+        String id,
+        String email,
+        String provider) {
 }

--- a/src/main/java/com/birca/bircabackend/command/auth/infrastructure/kakao/KakaoOAuthProvider.java
+++ b/src/main/java/com/birca/bircabackend/command/auth/infrastructure/kakao/KakaoOAuthProvider.java
@@ -21,6 +21,7 @@ public class KakaoOAuthProvider implements OAuthProvider {
     public OAuthMember getOAuthMember(String accessToken) {
         KakaoUserResponse response = callKakaoApi(accessToken);
         return new OAuthMember(
+                response.id(),
                 response.kakao_account().email(),
                 PROVIDER_NAME
         );

--- a/src/main/java/com/birca/bircabackend/command/auth/infrastructure/kakao/KakaoUserResponse.java
+++ b/src/main/java/com/birca/bircabackend/command/auth/infrastructure/kakao/KakaoUserResponse.java
@@ -1,6 +1,9 @@
 package com.birca.bircabackend.command.auth.infrastructure.kakao;
 
-public record KakaoUserResponse(KakaoAccount kakao_account) {
+public record KakaoUserResponse(
+        String id,
+        KakaoAccount kakao_account
+) {
     public record KakaoAccount(String email) {
     }
 }

--- a/src/main/java/com/birca/bircabackend/command/member/application/MemberService.java
+++ b/src/main/java/com/birca/bircabackend/command/member/application/MemberService.java
@@ -1,10 +1,7 @@
 package com.birca.bircabackend.command.member.application;
 
 import com.birca.bircabackend.command.auth.authorization.LoginMember;
-import com.birca.bircabackend.command.member.domain.Member;
-import com.birca.bircabackend.command.member.domain.MemberRepository;
-import com.birca.bircabackend.command.member.domain.MemberRole;
-import com.birca.bircabackend.command.member.domain.Nickname;
+import com.birca.bircabackend.command.member.domain.*;
 import com.birca.bircabackend.command.member.dto.NicknameRegisterRequest;
 import com.birca.bircabackend.command.member.dto.RoleChangeRequest;
 import com.birca.bircabackend.command.member.exception.MemberErrorCode;
@@ -26,13 +23,13 @@ public class MemberService {
     private final EntityUtil entityUtil;
 
     public void join(Member member) {
-        validateDuplicatedEmail(member);
+        validateDuplicatedIdentityKey(member.getIdentityKey());
         memberRepository.save(member);
     }
 
-    private void validateDuplicatedEmail(Member member) {
-        if (memberRepository.existsByEmail(member.getEmail())) {
-            throw BusinessException.from(MemberErrorCode.DUPLICATED_EMAIL);
+    private void validateDuplicatedIdentityKey(IdentityKey identityKey) {
+        if (memberRepository.existsByIdentityKey(identityKey)) {
+            throw BusinessException.from(MemberErrorCode.DUPLICATED_IDENTITY_KEY);
         }
     }
 

--- a/src/main/java/com/birca/bircabackend/command/member/domain/IdentityKey.java
+++ b/src/main/java/com/birca/bircabackend/command/member/domain/IdentityKey.java
@@ -1,0 +1,25 @@
+package com.birca.bircabackend.command.member.domain;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Embeddable;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Embeddable
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@Getter
+public class IdentityKey {
+
+    @Column(nullable = false)
+    private String socialId;
+
+    @Column(nullable = false)
+    private String socialProvider;
+
+    public static IdentityKey of(String socialId, String provider) {
+        return new IdentityKey(socialId, provider);
+    }
+}

--- a/src/main/java/com/birca/bircabackend/command/member/domain/Member.java
+++ b/src/main/java/com/birca/bircabackend/command/member/domain/Member.java
@@ -8,6 +8,10 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Entity
+@Table(uniqueConstraints = {@UniqueConstraint(
+        name = "UC_IDENTITY_KEY",
+        columnNames = {"socialId", "socialProvider"}
+)})
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
 @Getter
@@ -16,18 +20,19 @@ public class Member extends BaseEntity {
     @Embedded
     private Nickname nickname;
 
-    @Column(nullable = false, unique = true)
+    @Column(nullable = false)
     private String email;
 
     @Enumerated(EnumType.STRING)
-    @Column(name = "member_role")
+    @Column(name = "member_role", nullable = false)
     private MemberRole role;
 
     @Column(nullable = false)
-    private String registrationId;
+    @Embedded
+    private IdentityKey identityKey;
 
-    public static Member join(String email, String registrationId) {
-        return new Member(null, email, MemberRole.VISITANT, registrationId);
+    public static Member join(String email, IdentityKey identityKey) {
+        return new Member(null, email, MemberRole.VISITANT, identityKey);
     }
 
     public void changeRole(MemberRole role) {

--- a/src/main/java/com/birca/bircabackend/command/member/domain/MemberRepository.java
+++ b/src/main/java/com/birca/bircabackend/command/member/domain/MemberRepository.java
@@ -8,5 +8,5 @@ public interface MemberRepository extends Repository<Member, Long> {
 
     void save(Member member);
 
-    boolean existsByEmail(String email);
+    boolean existsByIdentityKey(IdentityKey identityKey);
 }

--- a/src/main/java/com/birca/bircabackend/command/member/domain/Nickname.java
+++ b/src/main/java/com/birca/bircabackend/command/member/domain/Nickname.java
@@ -24,7 +24,7 @@ public class Nickname {
     }
 
     private void validateInvalidNickname(String value) {
-        if (value.length() > MAX_LENGTH || value.isBlank()) {
+        if (value == null || value.length() > MAX_LENGTH || value.isBlank()) {
             throw BusinessException.from(MemberErrorCode.INVALID_NICKNAME);
         }
     }

--- a/src/main/java/com/birca/bircabackend/command/member/exception/MemberErrorCode.java
+++ b/src/main/java/com/birca/bircabackend/command/member/exception/MemberErrorCode.java
@@ -13,7 +13,7 @@ public enum MemberErrorCode implements ErrorCode {
     INVALID_NICKNAME(3002, 400, "닉네임은 비어있거나 10자를 넘을 수 없습니다."),
     INVALID_ROLE(3003, 400, "존재하지 않는 역할입니다."),
     MEMBER_NOT_FOUND(3004, 404, "존재하지 않는 회원입니다."),
-    DUPLICATED_EMAIL(3005, 400, "이미 가입된 이메일입니다.")
+    DUPLICATED_IDENTITY_KEY(3005, 400, "이미 가입된 소셜 계정입니다.")
 
     ;
 

--- a/src/main/resources/db/migration/V1__init.sql
+++ b/src/main/resources/db/migration/V1__init.sql
@@ -1,18 +1,19 @@
 CREATE TABLE member
 (
-    id          BIGINT AUTO_INCREMENT NOT NULL,
-    nickname    VARCHAR(255)          NULL,
-    email       VARCHAR(255)          NOT NULL,
-    registration_id VARCHAR(255)      NOT NULL,
-    member_role VARCHAR(255)          NULL,
+    id              BIGINT AUTO_INCREMENT NOT NULL,
+    email           VARCHAR(255)          NOT NULL,
+    member_role     VARCHAR(255)          NOT NULL,
+    nickname        VARCHAR(255)          NULL,
+    social_id       VARCHAR(255)          NOT NULL,
+    social_provider VARCHAR(255)          NOT NULL,
     CONSTRAINT pk_member PRIMARY KEY (id)
 );
 
 ALTER TABLE member
-    ADD CONSTRAINT uc_member_nickname UNIQUE (nickname);
+    ADD CONSTRAINT UC_IDENTITY_KEY UNIQUE (social_id, social_provider);
 
 ALTER TABLE member
-    ADD CONSTRAINT uc_member_email UNIQUE (email);
+    ADD CONSTRAINT uc_member_nickname UNIQUE (nickname);
 
 CREATE TABLE business_license
 (

--- a/src/main/resources/logback-spring.xml
+++ b/src/main/resources/logback-spring.xml
@@ -5,7 +5,7 @@
     <property name="LOG_PATTERN"
               value="%magenta([%X{CORRELATION_ID:-NO CORRELATION ID}]) %yellow([%d{yyyy-MM-dd HH:mm:ss}]) %green(%thread) %highlight(%-5level) %boldWhite([%C.%M:%L]) %n : %msg%n"/>
 
-    <springProfile name="local">
+    <springProfile name="!prod">
         <appender name="CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
             <encoder>
                 <pattern>${LOG_PATTERN}</pattern>

--- a/src/main/resources/static/docs/api.html
+++ b/src/main/resources/static/docs/api.html
@@ -477,6 +477,12 @@ body.book #toc,body.book #preamble,body.book h1.sect0,body.book .sect1>h2{page-b
 <li><a href="#_에러_코드_4">에러 코드</a></li>
 </ul>
 </li>
+<li><a href="#_생일_카페_api">생일 카페 API</a>
+<ul class="sectlevel2">
+<li><a href="#_생일_카페_등록">생일 카페 등록</a></li>
+<li><a href="#_에러_코드_5">에러 코드</a></li>
+</ul>
+</li>
 </ul>
 </div>
 </div>
@@ -611,7 +617,7 @@ Content-Length: 97
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">POST /api/v1/members/role-change HTTP/1.1
 Content-Type: application/json;charset=UTF-8
-Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwiaWF0IjoxNzA3Mjg4ODg1LCJleHAiOjE3MDcyOTA2ODV9.iq9cHYcIQ1O0Iag7HaT2BGQTe0n4qsDCq9cbRdzcCSc
+Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwiaWF0IjoxNzA3NDg0NTkxLCJleHAiOjE3MDc0ODYzOTF9.YCNcT0l6gEL3s58qiUmVAJsfLit4DlIFj3kcTqyFRAs
 Content-Length: 21
 Host: www.api.birca.com
 
@@ -641,7 +647,7 @@ Vary: Access-Control-Request-Headers</code></pre>
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">GET /api/v1/join/check-nickname?nickname=does HTTP/1.1
 Content-Type: application/json;charset=UTF-8
-Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwiaWF0IjoxNzA3Mjg4ODg1LCJleHAiOjE3MDcyOTA2ODV9.iq9cHYcIQ1O0Iag7HaT2BGQTe0n4qsDCq9cbRdzcCSc
+Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwiaWF0IjoxNzA3NDg0NTkxLCJleHAiOjE3MDc0ODYzOTF9.YCNcT0l6gEL3s58qiUmVAJsfLit4DlIFj3kcTqyFRAs
 Host: www.api.birca.com</code></pre>
 </div>
 </div>
@@ -715,7 +721,7 @@ Content-Length: 16
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">POST /api/v1/join/register-nickname HTTP/1.1
 Content-Type: application/json;charset=UTF-8
-Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwiaWF0IjoxNzA3Mjg4ODg1LCJleHAiOjE3MDcyOTA2ODV9.iq9cHYcIQ1O0Iag7HaT2BGQTe0n4qsDCq9cbRdzcCSc
+Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwiaWF0IjoxNzA3NDg0NTkxLCJleHAiOjE3MDc0ODYzOTF9.YCNcT0l6gEL3s58qiUmVAJsfLit4DlIFj3kcTqyFRAs
 Content-Length: 30
 Host: www.api.birca.com
 
@@ -784,7 +790,7 @@ Vary: Access-Control-Request-Headers</code></pre>
   },
   "3005" : {
     "httpStatus" : 400,
-    "message" : "이미 가입된 이메일입니다."
+    "message" : "이미 가입된 소셜 계정입니다."
   }
 }</code></pre>
 </div>
@@ -803,7 +809,7 @@ Vary: Access-Control-Request-Headers</code></pre>
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">GET /api/v1/artist-groups?cursor=10&amp;size=3 HTTP/1.1
 Content-Type: application/json;charset=UTF-8
-Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwiaWF0IjoxNzA3Mjg4ODg1LCJleHAiOjE3MDcyOTA2ODV9.iq9cHYcIQ1O0Iag7HaT2BGQTe0n4qsDCq9cbRdzcCSc
+Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwiaWF0IjoxNzA3NDg0NTkxLCJleHAiOjE3MDc0ODYzOTF9.YCNcT0l6gEL3s58qiUmVAJsfLit4DlIFj3kcTqyFRAs
 Host: www.api.birca.com</code></pre>
 </div>
 </div>
@@ -903,7 +909,7 @@ Content-Length: 250
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">GET /api/v1/artist-groups/1/artists HTTP/1.1
 Content-Type: application/json;charset=UTF-8
-Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwiaWF0IjoxNzA3Mjg4ODg1LCJleHAiOjE3MDcyOTA2ODV9.iq9cHYcIQ1O0Iag7HaT2BGQTe0n4qsDCq9cbRdzcCSc
+Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwiaWF0IjoxNzA3NDg0NTkxLCJleHAiOjE3MDc0ODYzOTF9.YCNcT0l6gEL3s58qiUmVAJsfLit4DlIFj3kcTqyFRAs
 Host: www.api.birca.com</code></pre>
 </div>
 </div>
@@ -1016,7 +1022,7 @@ Content-Length: 565
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">POST /api/v1/artists/favorite HTTP/1.1
 Content-Type: application/json;charset=UTF-8
-Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwiaWF0IjoxNzA3Mjg4ODg0LCJleHAiOjE3MDcyOTA2ODR9.bme9okQJiD8k4Ebd-C6yyW88crSVFVzqGwq8NL-FqiE
+Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwiaWF0IjoxNzA3NDg0NTkwLCJleHAiOjE3MDc0ODYzOTB9.BuS2Hui0FMWfED-sdQlkk8ifS3QUR2jtNi9PK1tyzXg
 Content-Length: 20
 Host: www.api.birca.com
 
@@ -1070,7 +1076,7 @@ Vary: Access-Control-Request-Headers</code></pre>
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">POST /api/v1/artists/interest HTTP/1.1
 Content-Type: application/json;charset=UTF-8
-Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwiaWF0IjoxNzA3Mjg4ODg0LCJleHAiOjE3MDcyOTA2ODR9.bme9okQJiD8k4Ebd-C6yyW88crSVFVzqGwq8NL-FqiE
+Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwiaWF0IjoxNzA3NDg0NTkwLCJleHAiOjE3MDc0ODYzOTB9.BuS2Hui0FMWfED-sdQlkk8ifS3QUR2jtNi9PK1tyzXg
 Content-Length: 68
 Host: www.api.birca.com
 
@@ -1154,7 +1160,7 @@ Vary: Access-Control-Request-Headers</code></pre>
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">POST /api/v1/cafes/license-read HTTP/1.1
 Content-Type: multipart/form-data;charset=UTF-8; boundary=6o2knFse3p53ty9dmcQvWAIx1zInP11uCfbm
-Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwiaWF0IjoxNzA3Mjg4ODg1LCJleHAiOjE3MDcyOTA2ODV9.iq9cHYcIQ1O0Iag7HaT2BGQTe0n4qsDCq9cbRdzcCSc
+Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwiaWF0IjoxNzA3NDg0NTkxLCJleHAiOjE3MDc0ODYzOTF9.YCNcT0l6gEL3s58qiUmVAJsfLit4DlIFj3kcTqyFRAs
 Host: www.api.birca.com
 
 --6o2knFse3p53ty9dmcQvWAIx1zInP11uCfbm
@@ -1234,7 +1240,7 @@ Content-Length: 120
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">POST /api/v1/cafes/apply HTTP/1.1
 Content-Type: multipart/form-data;charset=UTF-8; boundary=6o2knFse3p53ty9dmcQvWAIx1zInP11uCfbm
-Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwiaWF0IjoxNzA3Mjg4ODg1LCJleHAiOjE3MDcyOTA2ODV9.iq9cHYcIQ1O0Iag7HaT2BGQTe0n4qsDCq9cbRdzcCSc
+Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwiaWF0IjoxNzA3NDg0NTkxLCJleHAiOjE3MDc0ODYzOTF9.YCNcT0l6gEL3s58qiUmVAJsfLit4DlIFj3kcTqyFRAs
 Host: www.api.birca.com
 
 --6o2knFse3p53ty9dmcQvWAIx1zInP11uCfbm
@@ -1305,11 +1311,117 @@ Vary: Access-Control-Request-Headers</code></pre>
 </div>
 </div>
 </div>
+<div class="sect1">
+<h2 id="_생일_카페_api"><a class="link" href="#_생일_카페_api">생일 카페 API</a></h2>
+<div class="sectionbody">
+<div class="sect2">
+<h3 id="_생일_카페_등록"><a class="link" href="#_생일_카페_등록">생일 카페 등록</a></h3>
+<div class="sect3">
+<h4 id="_생일_카페_등록_http_request"><a class="link" href="#_생일_카페_등록_http_request">HTTP request</a></h4>
+<div class="listingblock">
+<div class="content">
+<pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">POST /api/v1/birthday-cafes HTTP/1.1
+Content-Type: application/json;charset=UTF-8
+Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwiaWF0IjoxNzA3NDg0NTkwLCJleHAiOjE3MDc0ODYzOTB9.BuS2Hui0FMWfED-sdQlkk8ifS3QUR2jtNi9PK1tyzXg
+Content-Length: 179
+Host: www.api.birca.com
+
+{
+  "artistId" : 1,
+  "startDate" : "2024-02-08T00:00:00",
+  "endDate" : "2024-02-10T00:00:00",
+  "minimumVisitant" : 5,
+  "maximumVisitant" : 10,
+  "twitterAccount" : "@ChaseM"
+}</code></pre>
+</div>
+</div>
+</div>
+<div class="sect3">
+<h4 id="_생일_카페_등록_request_fields"><a class="link" href="#_생일_카페_등록_request_fields">Request fields</a></h4>
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 33.3333%;">
+<col style="width: 33.3333%;">
+<col style="width: 33.3334%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">Path</th>
+<th class="tableblock halign-left valign-top">Type</th>
+<th class="tableblock halign-left valign-top">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>artistId</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Number</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">생일인 아티스트 ID</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>startDate</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">생일 카페 시작일</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>endDate</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">생일 카페 마지막일</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>minimumVisitant</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Number</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">생일 카페 최소 방문자 인원</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>maximumVisitant</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Number</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">생일 카페 최대 방문자 인원</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>twitterAccount</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">생일 카페 트위터 계정</p></td>
+</tr>
+</tbody>
+</table>
+</div>
+<div class="sect3">
+<h4 id="_생일_카페_등록_http_response"><a class="link" href="#_생일_카페_등록_http_response">HTTP response</a></h4>
+<div class="listingblock">
+<div class="content">
+<pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">HTTP/1.1 200 OK
+Vary: Origin
+Vary: Access-Control-Request-Method
+Vary: Access-Control-Request-Headers</code></pre>
+</div>
+</div>
+</div>
+</div>
+<div class="sect2">
+<h3 id="_에러_코드_5"><a class="link" href="#_에러_코드_5">에러 코드</a></h3>
+<div class="listingblock">
+<div class="content">
+<pre class="highlightjs highlight nowrap"><code class="language-json hljs" data-lang="json">{
+  "5001" : {
+    "httpStatus" : 400,
+    "message" : "생일카페 시작일은 종료일 보다 앞일 수 없습니다."
+  },
+  "5002" : {
+    "httpStatus" : 400,
+    "message" : "최소 방문자는 최대 방문자 보다 클 수 없고 자연수여야 합니다."
+  }
+}</code></pre>
+</div>
+</div>
+</div>
+</div>
+</div>
 </div>
 <div id="footer">
 <div id="footer-text">
 Version 0.0.1-SNAPSHOT<br>
-Last updated 2024-02-07 12:08:47 +0900
+Last updated 2024-02-09 18:42:53 +0900
 </div>
 </div>
 <script src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/9.18.3/highlight.min.js"></script>

--- a/src/test/java/com/birca/bircabackend/command/auth/application/AuthServiceTest.java
+++ b/src/test/java/com/birca/bircabackend/command/auth/application/AuthServiceTest.java
@@ -3,8 +3,6 @@ package com.birca.bircabackend.command.auth.application;
 import com.birca.bircabackend.command.auth.application.oauth.OAuthMember;
 import com.birca.bircabackend.command.auth.dto.LoginResponse;
 import com.birca.bircabackend.command.member.domain.MemberRole;
-import com.birca.bircabackend.command.member.exception.MemberErrorCode;
-import com.birca.bircabackend.common.exception.BusinessException;
 import com.birca.bircabackend.support.enviroment.ServiceTest;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
@@ -12,7 +10,6 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.assertAll;
 
 class AuthServiceTest extends ServiceTest {
@@ -24,7 +21,7 @@ class AuthServiceTest extends ServiceTest {
     @DisplayName("소셜 로그인을")
     class LoginTest {
 
-        private final OAuthMember oAuthMember = new OAuthMember("ldk@gmail.com", "kakao");
+        private final OAuthMember oAuthMember = new OAuthMember("2435", "ldk@gmail.com", "kakao");
 
         @Test
         void 처음_가입한_회원이_한다() {
@@ -53,19 +50,6 @@ class AuthServiceTest extends ServiceTest {
                     assertThat(response.isNewMember())::isFalse,
                     () -> assertThat(response.lastRole()).isEqualTo(MemberRole.VISITANT.name())
             );
-        }
-
-        @Test
-        void 중복된_이메일로_다른_소셜_로그인_제공사와_하지_못한다() {
-            // given
-            authService.login(oAuthMember);
-            OAuthMember duplicatedEmailMember = new OAuthMember(oAuthMember.email(), "apple");
-
-            // when then
-            assertThatThrownBy(() -> authService.login(duplicatedEmailMember))
-                    .isInstanceOf(BusinessException.class)
-                    .extracting("errorCode")
-                    .isEqualTo(MemberErrorCode.DUPLICATED_EMAIL);
         }
     }
 }

--- a/src/test/java/com/birca/bircabackend/command/member/application/MemberServiceTest.java
+++ b/src/test/java/com/birca/bircabackend/command/member/application/MemberServiceTest.java
@@ -2,6 +2,7 @@ package com.birca.bircabackend.command.member.application;
 
 import com.birca.bircabackend.command.auth.authorization.LoginMember;
 import com.birca.bircabackend.command.member.MemberFixtureRepository;
+import com.birca.bircabackend.command.member.domain.IdentityKey;
 import com.birca.bircabackend.command.member.domain.Member;
 import com.birca.bircabackend.command.member.dto.NicknameRegisterRequest;
 import com.birca.bircabackend.command.member.dto.RoleChangeRequest;
@@ -117,7 +118,7 @@ class MemberServiceTest extends ServiceTest {
     class JoinTest {
 
         private final String email = "ldk@naver.com";
-        private final Member joinMember = Member.join(email, "kakao");
+        private final Member joinMember = Member.join(email, IdentityKey.of("1234", "kakao"));
 
         @Test
         void 한다() {
@@ -133,7 +134,7 @@ class MemberServiceTest extends ServiceTest {
         void 이미_가입된_이메일로_하지_못한다() {
             // given
             memberService.join(joinMember);
-            Member newJoinMember = Member.join(email, "apple");
+            Member newJoinMember = Member.join(email, IdentityKey.of("2322", "apple"));
 
             // when then
             assertThatThrownBy(() -> memberService.join(newJoinMember))

--- a/src/test/java/com/birca/bircabackend/command/member/application/MemberServiceTest.java
+++ b/src/test/java/com/birca/bircabackend/command/member/application/MemberServiceTest.java
@@ -117,8 +117,9 @@ class MemberServiceTest extends ServiceTest {
     @DisplayName("회원 가입을")
     class JoinTest {
 
+        private final IdentityKey identityKey = IdentityKey.of("1234", "kakao");
         private final String email = "ldk@naver.com";
-        private final Member joinMember = Member.join(email, IdentityKey.of("1234", "kakao"));
+        private final Member joinMember = Member.join(email, identityKey);
 
         @Test
         void 한다() {
@@ -131,16 +132,16 @@ class MemberServiceTest extends ServiceTest {
         }
 
         @Test
-        void 이미_가입된_이메일로_하지_못한다() {
+        void 이미_가입된_소셜_계정으로는_하지_못_한다() {
             // given
             memberService.join(joinMember);
-            Member newJoinMember = Member.join(email, IdentityKey.of("2322", "apple"));
+            Member newJoinMember = Member.join("diffent@email", identityKey);
 
             // when then
             assertThatThrownBy(() -> memberService.join(newJoinMember))
                     .isInstanceOf(BusinessException.class)
                     .extracting("errorCode")
-                    .isEqualTo(MemberErrorCode.DUPLICATED_EMAIL);
+                    .isEqualTo(MemberErrorCode.DUPLICATED_IDENTITY_KEY);
         }
     }
 }

--- a/src/test/java/com/birca/bircabackend/command/member/domain/MemberTest.java
+++ b/src/test/java/com/birca/bircabackend/command/member/domain/MemberTest.java
@@ -38,10 +38,10 @@ class MemberTest {
         void 방문자로_생성된다() {
             // given
             String email = "ldk@gmail.com";
-            String registrationId = "kakao";
+            IdentityKey identityKey = IdentityKey.of("2342", "kakao");
 
             // when
-            Member actual = Member.join(email, registrationId);
+            Member actual = Member.join(email, identityKey);
 
             // then
             assertThat(actual.getRole()).isEqualTo(MemberRole.VISITANT);

--- a/src/test/java/com/birca/bircabackend/support/enviroment/MockOAuthEnvironment.java
+++ b/src/test/java/com/birca/bircabackend/support/enviroment/MockOAuthEnvironment.java
@@ -14,7 +14,7 @@ public class MockOAuthEnvironment {
     private static final OAuthProvider MOCK_PROVIDER = new OAuthProvider() {
         @Override
         public OAuthMember getOAuthMember(String accessToken) {
-            return new OAuthMember("ldk@naver.com", "kakao");
+            return new OAuthMember("23243", "ldk@naver.com", "kakao");
         }
 
         @Override

--- a/src/test/resources/fixture/artist-fixture.sql
+++ b/src/test/resources/fixture/artist-fixture.sql
@@ -1,5 +1,5 @@
-INSERT INTO member (id, nickname, email, registration_id, member_role)
-VALUES (1, '더즈', 'ldk@gmail.com', 'kakao', 'VISITANT');
+INSERT INTO member (id, nickname, email, social_id, social_provider, member_role)
+VALUES (1, '더즈', 'ldk@gmail.com', '231323', 'kakao', 'VISITANT');
 
 INSERT INTO artist_group (id, name, image_url)
 VALUES (5, '뉴진스', 'image5.com'),

--- a/src/test/resources/fixture/birthday-cafe-fixture.sql
+++ b/src/test/resources/fixture/birthday-cafe-fixture.sql
@@ -1,5 +1,5 @@
-INSERT INTO member (id, nickname, email, registration_id, member_role)
-VALUES (1, '더즈', 'ldk@gmail.com', 'kakao', 'HOST');
+INSERT INTO member (id, nickname, email, social_id, social_provider, member_role)
+VALUES (1, '더즈', 'ldk@gmail.com', '231323', 'kakao', 'HOST');
 
 INSERT INTO artist (id, group_id, name, image_url)
 VALUES (1, null, '아이유', 'image1.com');

--- a/src/test/resources/fixture/member-fixture.sql
+++ b/src/test/resources/fixture/member-fixture.sql
@@ -1,2 +1,2 @@
-INSERT INTO member (id, nickname, email, registration_id, member_role)
-VALUES (1, '더즈', 'ldk@gmail.com', 'kakao', 'VISITANT');
+INSERT INTO member (id, nickname, email, social_id, social_provider, member_role)
+VALUES (1, '더즈', 'ldk@gmail.com', '231323', 'kakao', 'VISITANT');


### PR DESCRIPTION
## 🌍 이슈 번호
- closed #28 

## 📝 구현 내용
- 카카오 로그인 시 이메일이 아니라 카카오에서 제공하는 id 기준으로 사용자를 식별하도록 수정

## 🍀 확인해야 할 부분
