### PR TITLE
[FIX] 사업자등록증 번호 검증 수정

### DIFF
--- a/.github/workflows/cd-dev.yml
+++ b/.github/workflows/cd-dev.yml
@@ -56,4 +56,4 @@ jobs:
             sudo docker pull ${{ secrets.BIRCA_DEV_IMAGE }}
             sudo docker-compose -f docker-compose-dev.yml up -d
             sudo docker image prune -f
-            sudo docker volume prune
+            sudo docker volume prune -f

--- a/src/main/java/com/birca/bircabackend/command/cafe/domain/BusinessLicenseCode.java
+++ b/src/main/java/com/birca/bircabackend/command/cafe/domain/BusinessLicenseCode.java
@@ -8,7 +8,6 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 import static com.birca.bircabackend.command.cafe.exception.BusinessLicenseErrorCode.*;
-import static java.lang.String.valueOf;
 
 @Embeddable
 @NoArgsConstructor(access = AccessLevel.PROTECTED)

--- a/src/main/java/com/birca/bircabackend/command/cafe/domain/BusinessLicenseCode.java
+++ b/src/main/java/com/birca/bircabackend/command/cafe/domain/BusinessLicenseCode.java
@@ -21,42 +21,34 @@ public class BusinessLicenseCode {
     private static final int BUSINESS_LICENSE_PARTS = 3;
 
     @Column(nullable = false)
-    private Integer taxOfficeCode;
+    private String taxOfficeCode;
 
     @Column(nullable = false)
-    private Integer businessTypeCode;
+    private String businessTypeCode;
 
     @Column(nullable = false)
-    private Integer serialCode;
+    private String serialCode;
 
     public BusinessLicenseCode(String businessLicenseNumber) {
         String[] codes = businessLicenseNumber.split("-");
         validateBusinessLicenseNumberForm(codes);
-        this.taxOfficeCode = Integer.parseInt(codes[0]);
-        this.businessTypeCode = Integer.parseInt(codes[1]);
-        this.serialCode = Integer.parseInt(codes[2]);
-        validateCode(this.taxOfficeCode, this.businessTypeCode, this.serialCode);
+        this.taxOfficeCode = codes[0];
+        this.businessTypeCode = codes[1];
+        this.serialCode = codes[2];
     }
 
     private void validateBusinessLicenseNumberForm(String[] codes) {
         if (codes.length != BUSINESS_LICENSE_PARTS) {
             throw BusinessException.from(INVALID_BUSINESS_LICENSE_NUMBER_FORM);
         }
-    }
-
-    private void validateCode(Integer taxOfficeCode, Integer businessTypeCode, Integer serialCode) {
-        if (getCodeLength(taxOfficeCode) != TAX_OFFICE_CODE_LENGTH) {
+        if (codes[0].length() != TAX_OFFICE_CODE_LENGTH) {
             throw BusinessException.from(INVALID_TAX_OFFICE_CODE_LENGTH);
         }
-        if (getCodeLength(businessTypeCode) != BUSINESS_TYPE_CODE_LENGTH) {
+        if (codes[1].length() != BUSINESS_TYPE_CODE_LENGTH) {
             throw BusinessException.from(INVALID_BUSINESS_TYPE_CODE_LENGTH);
         }
-        if (getCodeLength(serialCode) != SERIAL_CODE_LENGTH) {
+        if (codes[2].length() != SERIAL_CODE_LENGTH) {
             throw BusinessException.from(INVALID_SERIAL_CODE_LENGTH);
         }
-    }
-
-    private int getCodeLength(Integer code) {
-        return valueOf(code).length();
     }
 }

--- a/src/main/resources/db/migration/V1__init.sql
+++ b/src/main/resources/db/migration/V1__init.sql
@@ -22,9 +22,9 @@ CREATE TABLE business_license
     owner_name         VARCHAR(255)          NOT NULL,
     cafe_name          VARCHAR(255)          NOT NULL,
     image_url          LONGTEXT              NOT NULL,
-    tax_office_code    INT                   NOT NULL,
-    business_type_code INT                   NOT NULL,
-    serial_code        INT                   NOT NULL,
+    tax_office_code    VARCHAR(255)          NOT NULL,
+    business_type_code VARCHAR(255)          NOT NULL,
+    serial_code        VARCHAR(255)          NOT NULL,
     address            VARCHAR(255)          NOT NULL,
     CONSTRAINT pk_businesslicense PRIMARY KEY (id)
 );

--- a/src/test/java/com/birca/bircabackend/command/cafe/application/BusinessLicenseServiceTest.java
+++ b/src/test/java/com/birca/bircabackend/command/cafe/application/BusinessLicenseServiceTest.java
@@ -47,9 +47,9 @@ class BusinessLicenseServiceTest extends ServiceTest {
         assertThat(findBusinessLicense.getCafeName()).isEqualTo("카페 벌스데이");
         assertThat(findBusinessLicense.getOwnerName()).isEqualTo("최민혁");
         assertThat(findBusinessLicense.getAddress()).isEqualTo("서울 마포구 와우산로29길 26-33 1층 커피 벌스데이");
-        assertThat(findBusinessLicense.getCode().getTaxOfficeCode()).isEqualTo(123);
-        assertThat(findBusinessLicense.getCode().getBusinessTypeCode()).isEqualTo(45);
-        assertThat(findBusinessLicense.getCode().getSerialCode()).isEqualTo(67890);
+        assertThat(findBusinessLicense.getCode().getTaxOfficeCode()).isEqualTo("123");
+        assertThat(findBusinessLicense.getCode().getBusinessTypeCode()).isEqualTo("45");
+        assertThat(findBusinessLicense.getCode().getSerialCode()).isEqualTo("67890");
     }
 
     @Test

--- a/src/test/java/com/birca/bircabackend/command/cafe/domain/BusinessLicenseCodeTest.java
+++ b/src/test/java/com/birca/bircabackend/command/cafe/domain/BusinessLicenseCodeTest.java
@@ -25,7 +25,7 @@ class BusinessLicenseCodeTest {
         @Test
         void 세무서_번호의_길이가_3이_아니면_예외가_발생한다() {
             //when then
-            assertThatThrownBy(() -> new BusinessLicenseCode("12-34-567890"))
+            assertThatThrownBy(() -> new BusinessLicenseCode("12-34-56789"))
                     .isInstanceOf(BusinessException.class)
                     .extracting("errorCode")
                     .isEqualTo(INVALID_TAX_OFFICE_CODE_LENGTH);
@@ -34,7 +34,7 @@ class BusinessLicenseCodeTest {
         @Test
         void 사업자_성격_번호의_길이가_2가_아니면_예외가_발생한다() {
             //when then
-            assertThatThrownBy(() -> new BusinessLicenseCode("123-4-567890"))
+            assertThatThrownBy(() -> new BusinessLicenseCode("123-4-56789"))
                     .isInstanceOf(BusinessException.class)
                     .extracting("errorCode")
                     .isEqualTo(INVALID_BUSINESS_TYPE_CODE_LENGTH);

--- a/src/test/java/com/birca/bircabackend/command/cafe/domain/BusinessLicenseTest.java
+++ b/src/test/java/com/birca/bircabackend/command/cafe/domain/BusinessLicenseTest.java
@@ -21,8 +21,8 @@ class BusinessLicenseTest {
         assertThat(businessLicense.getCafeName()).isEqualTo("커피 벌스데이");
         assertThat(businessLicense.getOwnerName()).isEqualTo("최민혁");
         assertThat(businessLicense.getAddress()).isEqualTo("서울 마포구 와우산로29길 26-33 1층 커피 벌스데이");
-        assertThat(businessLicense.getCode().getTaxOfficeCode()).isEqualTo(123);
-        assertThat(businessLicense.getCode().getBusinessTypeCode()).isEqualTo(45);
-        assertThat(businessLicense.getCode().getSerialCode()).isEqualTo(67890);
+        assertThat(businessLicense.getCode().getTaxOfficeCode()).isEqualTo("123");
+        assertThat(businessLicense.getCode().getBusinessTypeCode()).isEqualTo("45");
+        assertThat(businessLicense.getCode().getSerialCode()).isEqualTo("67890");
     }
 }


### PR DESCRIPTION
## 🌍 이슈 번호
* closed #41 

## 📝 구현 내용
* 사업자등록증 번호가 480-81-00511일 경우, 숫자로 변환하고 길이 검증을 하면 00511이 511로 바뀌어서 길이 검증에서 에러 발생
  * 변환없이 String으로 검증하고 저장되도록 수정

## 🍀 확인해야 할 부분
더 좋은 방식이 있다면 말씀해주세요!