### PR TITLE
[FEAT] 최애/관심 아티스트 조회 기능

### DIFF
--- a/src/docs/asciidoc/api.adoc
+++ b/src/docs/asciidoc/api.adoc
@@ -38,9 +38,9 @@ operation::register-interest-artist[snippets='http-request,request-fields,http-r
 include::{snippets}/artist-error-Code/response-body.adoc[]
 
 === 최애 아티스트 조회
-operation::get-favorite-artist[snippets='http-request,http-response']
+operation::get-favorite-artist[snippets='http-request,http-response,response-fields']
 === 관심 아티스트 조회
-operation::get-interest-artists[snippets='http-request,http-response']
+operation::get-interest-artists[snippets='http-request,http-response,response-fields']
 
 
 == 사업자등록증 API

--- a/src/docs/asciidoc/api.adoc
+++ b/src/docs/asciidoc/api.adoc
@@ -37,6 +37,9 @@ operation::register-interest-artist[snippets='http-request,request-fields,http-r
 === 에러 코드
 include::{snippets}/artist-error-Code/response-body.adoc[]
 
+=== 최애 아티스트 조회
+operation::get-favorite-artist[snippets='http-request,http-response']
+
 == 사업자등록증 API
 === 사업자등록증 스캔
 operation::business-license-read[snippets='http-request,http-response,response-fields']

--- a/src/docs/asciidoc/api.adoc
+++ b/src/docs/asciidoc/api.adoc
@@ -39,6 +39,9 @@ include::{snippets}/artist-error-Code/response-body.adoc[]
 
 === 최애 아티스트 조회
 operation::get-favorite-artist[snippets='http-request,http-response']
+=== 관심 아티스트 조회
+operation::get-interest-artists[snippets='http-request,http-response']
+
 
 == 사업자등록증 API
 === 사업자등록증 스캔

--- a/src/main/java/com/birca/bircabackend/query/controller/FavoriteArtistQueryController.java
+++ b/src/main/java/com/birca/bircabackend/query/controller/FavoriteArtistQueryController.java
@@ -1,0 +1,24 @@
+package com.birca.bircabackend.query.controller;
+
+import com.birca.bircabackend.command.auth.authorization.LoginMember;
+import com.birca.bircabackend.command.auth.authorization.RequiredLogin;
+import com.birca.bircabackend.query.dto.ArtistResponse;
+import com.birca.bircabackend.query.service.FavoriteArtistQueryService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/v1")
+@RequiredArgsConstructor
+public class FavoriteArtistQueryController {
+
+    private final FavoriteArtistQueryService favoriteArtistQueryService;
+
+    @GetMapping("/artists/favorite")
+    @RequiredLogin
+    public ArtistResponse getFavoriteArtist(LoginMember loginMember) {
+        return favoriteArtistQueryService.findFavoriteArtist(loginMember);
+    }
+}

--- a/src/main/java/com/birca/bircabackend/query/controller/FavoriteArtistQueryController.java
+++ b/src/main/java/com/birca/bircabackend/query/controller/FavoriteArtistQueryController.java
@@ -10,13 +10,13 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
-@RequestMapping("/api/v1")
+@RequestMapping("/api")
 @RequiredArgsConstructor
 public class FavoriteArtistQueryController {
 
     private final FavoriteArtistQueryService favoriteArtistQueryService;
 
-    @GetMapping("/artists/favorite")
+    @GetMapping("/v1/artists/favorite")
     @RequiredLogin
     public ArtistResponse getFavoriteArtist(LoginMember loginMember) {
         return favoriteArtistQueryService.findFavoriteArtist(loginMember);

--- a/src/main/java/com/birca/bircabackend/query/controller/InterestArtistQueryController.java
+++ b/src/main/java/com/birca/bircabackend/query/controller/InterestArtistQueryController.java
@@ -12,13 +12,13 @@ import org.springframework.web.bind.annotation.RestController;
 import java.util.List;
 
 @RestController
-@RequestMapping("/api/v1")
+@RequestMapping("/api")
 @RequiredArgsConstructor
 public class InterestArtistQueryController {
 
     private final InterestArtistQueryService interestArtistQueryService;
 
-    @GetMapping("/artists/interest")
+    @GetMapping("/v1/artists/interest")
     @RequiredLogin
     public List<ArtistResponse> getInterestArtists(LoginMember loginMember) {
         return interestArtistQueryService.findInterestArtists(loginMember);

--- a/src/main/java/com/birca/bircabackend/query/controller/InterestArtistQueryController.java
+++ b/src/main/java/com/birca/bircabackend/query/controller/InterestArtistQueryController.java
@@ -1,0 +1,26 @@
+package com.birca.bircabackend.query.controller;
+
+import com.birca.bircabackend.command.auth.authorization.LoginMember;
+import com.birca.bircabackend.command.auth.authorization.RequiredLogin;
+import com.birca.bircabackend.query.dto.ArtistResponse;
+import com.birca.bircabackend.query.service.InterestArtistQueryService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/v1")
+@RequiredArgsConstructor
+public class InterestArtistQueryController {
+
+    private final InterestArtistQueryService interestArtistQueryService;
+
+    @GetMapping("/artists/interest")
+    @RequiredLogin
+    public List<ArtistResponse> getInterestArtists(LoginMember loginMember) {
+        return interestArtistQueryService.findInterestArtistIdsByFanId(loginMember);
+    }
+}

--- a/src/main/java/com/birca/bircabackend/query/controller/InterestArtistQueryController.java
+++ b/src/main/java/com/birca/bircabackend/query/controller/InterestArtistQueryController.java
@@ -21,6 +21,6 @@ public class InterestArtistQueryController {
     @GetMapping("/artists/interest")
     @RequiredLogin
     public List<ArtistResponse> getInterestArtists(LoginMember loginMember) {
-        return interestArtistQueryService.findInterestArtistIdsByFanId(loginMember);
+        return interestArtistQueryService.findInterestArtists(loginMember);
     }
 }

--- a/src/main/java/com/birca/bircabackend/query/dto/ArtistResponse.java
+++ b/src/main/java/com/birca/bircabackend/query/dto/ArtistResponse.java
@@ -11,4 +11,8 @@ public record ArtistResponse(
     public ArtistResponse(Artist artist) {
         this(artist.getId(), artist.getName(), artist.getImageUrl());
     }
+
+    public static ArtistResponse createEmpty() {
+        return new ArtistResponse(null, null, null);
+    }
 }

--- a/src/main/java/com/birca/bircabackend/query/repository/FavoriteArtistQueryRepository.java
+++ b/src/main/java/com/birca/bircabackend/query/repository/FavoriteArtistQueryRepository.java
@@ -9,6 +9,6 @@ import java.util.Optional;
 
 public interface FavoriteArtistQueryRepository extends Repository<FavoriteArtist, Long> {
 
-    @Query("SELECT a FROM Artist a WHERE a.id = (SELECT i.artistId FROM FavoriteArtist i WHERE i.fanId = :fanId)")
+    @Query("SELECT a FROM Artist a JOIN FavoriteArtist fa ON a.id = fa.artistId WHERE fa.fanId = :fanId")
     Optional<Artist> findFavoriteArtistByFanId(Long fanId);
 }

--- a/src/main/java/com/birca/bircabackend/query/repository/FavoriteArtistQueryRepository.java
+++ b/src/main/java/com/birca/bircabackend/query/repository/FavoriteArtistQueryRepository.java
@@ -1,0 +1,11 @@
+package com.birca.bircabackend.query.repository;
+
+import com.birca.bircabackend.command.artist.domain.FavoriteArtist;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.Repository;
+
+public interface FavoriteArtistQueryRepository extends Repository<FavoriteArtist, Long> {
+
+    @Query("SELECT f.artistId FROM FavoriteArtist f WHERE f.fanId = :fanId")
+    Long findArtistIdByFanId(Long fanId);
+}

--- a/src/main/java/com/birca/bircabackend/query/repository/FavoriteArtistQueryRepository.java
+++ b/src/main/java/com/birca/bircabackend/query/repository/FavoriteArtistQueryRepository.java
@@ -10,5 +10,5 @@ import java.util.Optional;
 public interface FavoriteArtistQueryRepository extends Repository<FavoriteArtist, Long> {
 
     @Query("SELECT a FROM Artist a WHERE a.id = (SELECT i.artistId FROM FavoriteArtist i WHERE i.fanId = :fanId)")
-    Optional<Artist> findArtistIdByFanId(Long fanId);
+    Optional<Artist> findFavoriteArtistByFanId(Long fanId);
 }

--- a/src/main/java/com/birca/bircabackend/query/repository/FavoriteArtistQueryRepository.java
+++ b/src/main/java/com/birca/bircabackend/query/repository/FavoriteArtistQueryRepository.java
@@ -1,11 +1,14 @@
 package com.birca.bircabackend.query.repository;
 
+import com.birca.bircabackend.command.artist.domain.Artist;
 import com.birca.bircabackend.command.artist.domain.FavoriteArtist;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.Repository;
 
+import java.util.Optional;
+
 public interface FavoriteArtistQueryRepository extends Repository<FavoriteArtist, Long> {
 
-    @Query("SELECT f.artistId FROM FavoriteArtist f WHERE f.fanId = :fanId")
-    Long findArtistIdByFanId(Long fanId);
+    @Query("SELECT a FROM Artist a WHERE a.id = (SELECT i.artistId FROM FavoriteArtist i WHERE i.fanId = :fanId)")
+    Optional<Artist> findArtistIdByFanId(Long fanId);
 }

--- a/src/main/java/com/birca/bircabackend/query/repository/InterestArtistQueryRepository.java
+++ b/src/main/java/com/birca/bircabackend/query/repository/InterestArtistQueryRepository.java
@@ -9,6 +9,6 @@ import java.util.List;
 
 public interface InterestArtistQueryRepository extends Repository<InterestArtist, Long> {
 
-    @Query("SELECT a FROM Artist a WHERE a.id IN (SELECT i.artistId FROM InterestArtist i WHERE i.fanId = :fanId)")
+    @Query("SELECT a FROM Artist a JOIN InterestArtist i ON a.id = i.artistId WHERE i.fanId = :fanId")
     List<Artist> findInterestArtistsByFanId(Long fanId);
 }

--- a/src/main/java/com/birca/bircabackend/query/repository/InterestArtistQueryRepository.java
+++ b/src/main/java/com/birca/bircabackend/query/repository/InterestArtistQueryRepository.java
@@ -1,4 +1,4 @@
-package com.birca.bircabackend.query.repository.config;
+package com.birca.bircabackend.query.repository;
 
 import com.birca.bircabackend.command.artist.domain.InterestArtist;
 import org.springframework.data.jpa.repository.Query;

--- a/src/main/java/com/birca/bircabackend/query/repository/InterestArtistQueryRepository.java
+++ b/src/main/java/com/birca/bircabackend/query/repository/InterestArtistQueryRepository.java
@@ -1,5 +1,6 @@
 package com.birca.bircabackend.query.repository;
 
+import com.birca.bircabackend.command.artist.domain.Artist;
 import com.birca.bircabackend.command.artist.domain.InterestArtist;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.Repository;
@@ -8,6 +9,6 @@ import java.util.List;
 
 public interface InterestArtistQueryRepository extends Repository<InterestArtist, Long> {
 
-    @Query("SELECT i.artistId FROM InterestArtist i WHERE i.fanId = :fanId")
-    List<Long> findInterestArtistIdsByFanId(Long fanId);
+    @Query("SELECT a FROM Artist a WHERE a.id IN (SELECT i.artistId FROM InterestArtist i WHERE i.fanId = :fanId)")
+    List<Artist> findInterestArtistsByFanId(Long fanId);
 }

--- a/src/main/java/com/birca/bircabackend/query/repository/config/InterestArtistQueryRepository.java
+++ b/src/main/java/com/birca/bircabackend/query/repository/config/InterestArtistQueryRepository.java
@@ -1,0 +1,13 @@
+package com.birca.bircabackend.query.repository.config;
+
+import com.birca.bircabackend.command.artist.domain.InterestArtist;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.Repository;
+
+import java.util.List;
+
+public interface InterestArtistQueryRepository extends Repository<InterestArtist, Long> {
+
+    @Query("SELECT i.artistId FROM InterestArtist i WHERE i.fanId = :fanId")
+    List<Long> findInterestArtistIdsByFanId(Long fanId);
+}

--- a/src/main/java/com/birca/bircabackend/query/service/FavoriteArtistQueryService.java
+++ b/src/main/java/com/birca/bircabackend/query/service/FavoriteArtistQueryService.java
@@ -1,9 +1,6 @@
 package com.birca.bircabackend.query.service;
 
-import com.birca.bircabackend.command.artist.domain.Artist;
-import com.birca.bircabackend.command.artist.exception.ArtistErrorCode;
 import com.birca.bircabackend.command.auth.authorization.LoginMember;
-import com.birca.bircabackend.common.EntityUtil;
 import com.birca.bircabackend.query.dto.ArtistResponse;
 import com.birca.bircabackend.query.repository.FavoriteArtistQueryRepository;
 import lombok.RequiredArgsConstructor;
@@ -16,11 +13,10 @@ import org.springframework.transaction.annotation.Transactional;
 public class FavoriteArtistQueryService {
 
     private final FavoriteArtistQueryRepository favoriteArtistQueryRepository;
-    private final EntityUtil entityUtil;
 
     public ArtistResponse findFavoriteArtist(LoginMember loginMember) {
-        Long artistId = favoriteArtistQueryRepository.findArtistIdByFanId(loginMember.id());
-        Artist artist = entityUtil.getEntity(Artist.class, artistId, ArtistErrorCode.NOT_EXIST_ARTIST);
-        return new ArtistResponse(artist);
+        return favoriteArtistQueryRepository.findArtistIdByFanId(loginMember.id())
+                .map(ArtistResponse::new)
+                .orElseGet(ArtistResponse::createEmpty);
     }
 }

--- a/src/main/java/com/birca/bircabackend/query/service/FavoriteArtistQueryService.java
+++ b/src/main/java/com/birca/bircabackend/query/service/FavoriteArtistQueryService.java
@@ -1,11 +1,15 @@
 package com.birca.bircabackend.query.service;
 
 import com.birca.bircabackend.command.auth.authorization.LoginMember;
+import com.birca.bircabackend.command.member.domain.Member;
+import com.birca.bircabackend.common.EntityUtil;
 import com.birca.bircabackend.query.dto.ArtistResponse;
 import com.birca.bircabackend.query.repository.FavoriteArtistQueryRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import static com.birca.bircabackend.command.member.exception.MemberErrorCode.MEMBER_NOT_FOUND;
 
 @Service
 @Transactional(readOnly = true)
@@ -13,9 +17,11 @@ import org.springframework.transaction.annotation.Transactional;
 public class FavoriteArtistQueryService {
 
     private final FavoriteArtistQueryRepository favoriteArtistQueryRepository;
+    private final EntityUtil entityUtil;
 
     public ArtistResponse findFavoriteArtist(LoginMember loginMember) {
-        return favoriteArtistQueryRepository.findFavoriteArtistByFanId(loginMember.id())
+        Member member = entityUtil.getEntity(Member.class, loginMember.id(), MEMBER_NOT_FOUND);
+        return favoriteArtistQueryRepository.findFavoriteArtistByFanId(member.getId())
                 .map(ArtistResponse::new)
                 .orElseGet(ArtistResponse::createEmpty);
     }

--- a/src/main/java/com/birca/bircabackend/query/service/FavoriteArtistQueryService.java
+++ b/src/main/java/com/birca/bircabackend/query/service/FavoriteArtistQueryService.java
@@ -15,7 +15,7 @@ public class FavoriteArtistQueryService {
     private final FavoriteArtistQueryRepository favoriteArtistQueryRepository;
 
     public ArtistResponse findFavoriteArtist(LoginMember loginMember) {
-        return favoriteArtistQueryRepository.findArtistIdByFanId(loginMember.id())
+        return favoriteArtistQueryRepository.findFavoriteArtistByFanId(loginMember.id())
                 .map(ArtistResponse::new)
                 .orElseGet(ArtistResponse::createEmpty);
     }

--- a/src/main/java/com/birca/bircabackend/query/service/FavoriteArtistQueryService.java
+++ b/src/main/java/com/birca/bircabackend/query/service/FavoriteArtistQueryService.java
@@ -1,0 +1,26 @@
+package com.birca.bircabackend.query.service;
+
+import com.birca.bircabackend.command.artist.domain.Artist;
+import com.birca.bircabackend.command.artist.exception.ArtistErrorCode;
+import com.birca.bircabackend.command.auth.authorization.LoginMember;
+import com.birca.bircabackend.common.EntityUtil;
+import com.birca.bircabackend.query.dto.ArtistResponse;
+import com.birca.bircabackend.query.repository.FavoriteArtistQueryRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+public class FavoriteArtistQueryService {
+
+    private final FavoriteArtistQueryRepository favoriteArtistQueryRepository;
+    private final EntityUtil entityUtil;
+
+    public ArtistResponse findFavoriteArtist(LoginMember loginMember) {
+        Long artistId = favoriteArtistQueryRepository.findArtistIdByFanId(loginMember.id());
+        Artist artist = entityUtil.getEntity(Artist.class, artistId, ArtistErrorCode.NOT_EXIST_ARTIST);
+        return new ArtistResponse(artist);
+    }
+}

--- a/src/main/java/com/birca/bircabackend/query/service/InterestArtistQueryService.java
+++ b/src/main/java/com/birca/bircabackend/query/service/InterestArtistQueryService.java
@@ -1,9 +1,6 @@
 package com.birca.bircabackend.query.service;
 
-import com.birca.bircabackend.command.artist.domain.Artist;
-import com.birca.bircabackend.command.artist.exception.ArtistErrorCode;
 import com.birca.bircabackend.command.auth.authorization.LoginMember;
-import com.birca.bircabackend.common.EntityUtil;
 import com.birca.bircabackend.query.dto.ArtistResponse;
 import com.birca.bircabackend.query.repository.InterestArtistQueryRepository;
 import lombok.RequiredArgsConstructor;
@@ -18,12 +15,10 @@ import java.util.List;
 public class InterestArtistQueryService {
 
     private final InterestArtistQueryRepository interestArtistQueryRepository;
-    private final EntityUtil entityUtil;
 
     public List<ArtistResponse> findInterestArtists(LoginMember loginMember) {
-        List<Long> artistIds = interestArtistQueryRepository.findInterestArtistIdsByFanId(loginMember.id());
-        return artistIds.stream()
-                .map(artistId -> entityUtil.getEntity(Artist.class, artistId, ArtistErrorCode.NOT_EXIST_ARTIST))
+        return interestArtistQueryRepository.findInterestArtistsByFanId(loginMember.id())
+                .stream()
                 .map(ArtistResponse::new)
                 .toList();
     }

--- a/src/main/java/com/birca/bircabackend/query/service/InterestArtistQueryService.java
+++ b/src/main/java/com/birca/bircabackend/query/service/InterestArtistQueryService.java
@@ -1,0 +1,30 @@
+package com.birca.bircabackend.query.service;
+
+import com.birca.bircabackend.command.artist.domain.Artist;
+import com.birca.bircabackend.command.artist.exception.ArtistErrorCode;
+import com.birca.bircabackend.command.auth.authorization.LoginMember;
+import com.birca.bircabackend.common.EntityUtil;
+import com.birca.bircabackend.query.dto.ArtistResponse;
+import com.birca.bircabackend.query.repository.config.InterestArtistQueryRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Service
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+public class InterestArtistQueryService {
+
+    private final InterestArtistQueryRepository interestArtistQueryRepository;
+    private final EntityUtil entityUtil;
+
+    public List<ArtistResponse> findInterestArtistIdsByFanId(LoginMember loginMember) {
+        List<Long> artistIds = interestArtistQueryRepository.findInterestArtistIdsByFanId(loginMember.id());
+        return artistIds.stream()
+                .map(artistId -> entityUtil.getEntity(Artist.class, artistId, ArtistErrorCode.NOT_EXIST_ARTIST))
+                .map(ArtistResponse::new)
+                .toList();
+    }
+}

--- a/src/main/java/com/birca/bircabackend/query/service/InterestArtistQueryService.java
+++ b/src/main/java/com/birca/bircabackend/query/service/InterestArtistQueryService.java
@@ -20,7 +20,7 @@ public class InterestArtistQueryService {
     private final InterestArtistQueryRepository interestArtistQueryRepository;
     private final EntityUtil entityUtil;
 
-    public List<ArtistResponse> findInterestArtistIdsByFanId(LoginMember loginMember) {
+    public List<ArtistResponse> findInterestArtists(LoginMember loginMember) {
         List<Long> artistIds = interestArtistQueryRepository.findInterestArtistIdsByFanId(loginMember.id());
         return artistIds.stream()
                 .map(artistId -> entityUtil.getEntity(Artist.class, artistId, ArtistErrorCode.NOT_EXIST_ARTIST))

--- a/src/main/java/com/birca/bircabackend/query/service/InterestArtistQueryService.java
+++ b/src/main/java/com/birca/bircabackend/query/service/InterestArtistQueryService.java
@@ -5,7 +5,7 @@ import com.birca.bircabackend.command.artist.exception.ArtistErrorCode;
 import com.birca.bircabackend.command.auth.authorization.LoginMember;
 import com.birca.bircabackend.common.EntityUtil;
 import com.birca.bircabackend.query.dto.ArtistResponse;
-import com.birca.bircabackend.query.repository.config.InterestArtistQueryRepository;
+import com.birca.bircabackend.query.repository.InterestArtistQueryRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;

--- a/src/main/java/com/birca/bircabackend/query/service/InterestArtistQueryService.java
+++ b/src/main/java/com/birca/bircabackend/query/service/InterestArtistQueryService.java
@@ -1,6 +1,8 @@
 package com.birca.bircabackend.query.service;
 
 import com.birca.bircabackend.command.auth.authorization.LoginMember;
+import com.birca.bircabackend.command.member.domain.Member;
+import com.birca.bircabackend.common.EntityUtil;
 import com.birca.bircabackend.query.dto.ArtistResponse;
 import com.birca.bircabackend.query.repository.InterestArtistQueryRepository;
 import lombok.RequiredArgsConstructor;
@@ -9,15 +11,19 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 
+import static com.birca.bircabackend.command.member.exception.MemberErrorCode.MEMBER_NOT_FOUND;
+
 @Service
 @Transactional(readOnly = true)
 @RequiredArgsConstructor
 public class InterestArtistQueryService {
 
     private final InterestArtistQueryRepository interestArtistQueryRepository;
+    private final EntityUtil entityUtil;
 
     public List<ArtistResponse> findInterestArtists(LoginMember loginMember) {
-        return interestArtistQueryRepository.findInterestArtistsByFanId(loginMember.id())
+        Member member = entityUtil.getEntity(Member.class, loginMember.id(), MEMBER_NOT_FOUND);
+        return interestArtistQueryRepository.findInterestArtistsByFanId(member.getId())
                 .stream()
                 .map(ArtistResponse::new)
                 .toList();

--- a/src/main/resources/static/docs/api.html
+++ b/src/main/resources/static/docs/api.html
@@ -620,7 +620,7 @@ Content-Length: 97
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">POST /api/v1/members/role-change HTTP/1.1
 Content-Type: application/json;charset=UTF-8
-Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwiaWF0IjoxNzA4OTExODI5LCJleHAiOjE3MDg5MTM2Mjl9.aWFIhWvKJZgQFfol0jMGC6NizF_-DqqfN49i7hrgtz8
+Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwiaWF0IjoxNzA4OTI3ODk4LCJleHAiOjE3MDg5Mjk2OTh9.h2CqXsbLB93oZ00iCdPWYmnDT2Lj6MBw_CYzJOBQjy8
 Content-Length: 21
 Host: www.api.birca.com
 
@@ -650,7 +650,7 @@ Vary: Access-Control-Request-Headers</code></pre>
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">GET /api/v1/join/check-nickname?nickname=does HTTP/1.1
 Content-Type: application/json;charset=UTF-8
-Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwiaWF0IjoxNzA4OTExODMyLCJleHAiOjE3MDg5MTM2MzJ9.UU9ZMDU8pyrs9UVNV0Jh_oIcobc6wJZlJFLD7fuFCsw
+Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwiaWF0IjoxNzA4OTI3OTAwLCJleHAiOjE3MDg5Mjk3MDB9.IZvI3NPZQWpJIo6BYfaR0NxaBShrY6k9EBfrnAxY7P0
 Host: www.api.birca.com</code></pre>
 </div>
 </div>
@@ -724,7 +724,7 @@ Content-Length: 16
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">POST /api/v1/join/register-nickname HTTP/1.1
 Content-Type: application/json;charset=UTF-8
-Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwiaWF0IjoxNzA4OTExODI5LCJleHAiOjE3MDg5MTM2Mjl9.aWFIhWvKJZgQFfol0jMGC6NizF_-DqqfN49i7hrgtz8
+Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwiaWF0IjoxNzA4OTI3ODk4LCJleHAiOjE3MDg5Mjk2OTh9.h2CqXsbLB93oZ00iCdPWYmnDT2Lj6MBw_CYzJOBQjy8
 Content-Length: 30
 Host: www.api.birca.com
 
@@ -812,7 +812,7 @@ Vary: Access-Control-Request-Headers</code></pre>
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">GET /api/v1/artist-groups?cursor=10&amp;size=3 HTTP/1.1
 Content-Type: application/json;charset=UTF-8
-Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwiaWF0IjoxNzA4OTExODMyLCJleHAiOjE3MDg5MTM2MzJ9.UU9ZMDU8pyrs9UVNV0Jh_oIcobc6wJZlJFLD7fuFCsw
+Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwiaWF0IjoxNzA4OTI3OTAwLCJleHAiOjE3MDg5Mjk3MDB9.IZvI3NPZQWpJIo6BYfaR0NxaBShrY6k9EBfrnAxY7P0
 Host: www.api.birca.com</code></pre>
 </div>
 </div>
@@ -912,7 +912,7 @@ Content-Length: 250
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">GET /api/v1/artist-groups/1/artists HTTP/1.1
 Content-Type: application/json;charset=UTF-8
-Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwiaWF0IjoxNzA4OTExODMyLCJleHAiOjE3MDg5MTM2MzJ9.UU9ZMDU8pyrs9UVNV0Jh_oIcobc6wJZlJFLD7fuFCsw
+Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwiaWF0IjoxNzA4OTI3OTAwLCJleHAiOjE3MDg5Mjk3MDB9.IZvI3NPZQWpJIo6BYfaR0NxaBShrY6k9EBfrnAxY7P0
 Host: www.api.birca.com</code></pre>
 </div>
 </div>
@@ -1025,7 +1025,7 @@ Content-Length: 565
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">GET /api/v1/artists/solo?cursor=12&amp;size=6 HTTP/1.1
 Content-Type: application/json;charset=UTF-8
-Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwiaWF0IjoxNzA4OTExODMyLCJleHAiOjE3MDg5MTM2MzJ9.UU9ZMDU8pyrs9UVNV0Jh_oIcobc6wJZlJFLD7fuFCsw
+Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwiaWF0IjoxNzA4OTI3OTAwLCJleHAiOjE3MDg5Mjk3MDB9.IZvI3NPZQWpJIo6BYfaR0NxaBShrY6k9EBfrnAxY7P0
 Host: www.api.birca.com</code></pre>
 </div>
 </div>
@@ -1137,7 +1137,7 @@ Content-Length: 518
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">POST /api/v1/artists/favorite HTTP/1.1
 Content-Type: application/json;charset=UTF-8
-Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwiaWF0IjoxNzA4OTExODI2LCJleHAiOjE3MDg5MTM2MjZ9.wOtCj45XeAvjDCZaYxNXBsdOMWKeddyZckfJLtXIFjQ
+Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwiaWF0IjoxNzA4OTI3ODk0LCJleHAiOjE3MDg5Mjk2OTR9.KAtH2Ke6812hsq2vs-Ktr6-nX-aLPyReNWaPbI2AqdM
 Content-Length: 20
 Host: www.api.birca.com
 
@@ -1191,7 +1191,7 @@ Vary: Access-Control-Request-Headers</code></pre>
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">POST /api/v1/artists/interest HTTP/1.1
 Content-Type: application/json;charset=UTF-8
-Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwiaWF0IjoxNzA4OTExODI2LCJleHAiOjE3MDg5MTM2MjZ9.wOtCj45XeAvjDCZaYxNXBsdOMWKeddyZckfJLtXIFjQ
+Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwiaWF0IjoxNzA4OTI3ODk0LCJleHAiOjE3MDg5Mjk2OTR9.KAtH2Ke6812hsq2vs-Ktr6-nX-aLPyReNWaPbI2AqdM
 Content-Length: 68
 Host: www.api.birca.com
 
@@ -1270,7 +1270,7 @@ Vary: Access-Control-Request-Headers</code></pre>
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">GET /api/v1/artists/favorite HTTP/1.1
 Content-Type: application/json;charset=UTF-8
-Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwiaWF0IjoxNzA4OTExODMyLCJleHAiOjE3MDg5MTM2MzJ9.UU9ZMDU8pyrs9UVNV0Jh_oIcobc6wJZlJFLD7fuFCsw
+Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwiaWF0IjoxNzA4OTI3OTAwLCJleHAiOjE3MDg5Mjk3MDB9.IZvI3NPZQWpJIo6BYfaR0NxaBShrY6k9EBfrnAxY7P0
 Host: www.api.birca.com</code></pre>
 </div>
 </div>
@@ -1294,6 +1294,40 @@ Content-Length: 81
 </div>
 </div>
 </div>
+<div class="sect3">
+<h4 id="_최애_아티스트_조회_response_fields"><a class="link" href="#_최애_아티스트_조회_response_fields">Response fields</a></h4>
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 33.3333%;">
+<col style="width: 33.3333%;">
+<col style="width: 33.3334%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">Path</th>
+<th class="tableblock halign-left valign-top">Type</th>
+<th class="tableblock halign-left valign-top">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>artistId</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Number</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">아티스트 ID</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>artistName</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">아티스트 이름</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>artistImage</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">아티스트 이미지 url</p></td>
+</tr>
+</tbody>
+</table>
+</div>
 </div>
 <div class="sect2">
 <h3 id="_관심_아티스트_조회"><a class="link" href="#_관심_아티스트_조회">관심 아티스트 조회</a></h3>
@@ -1303,7 +1337,7 @@ Content-Length: 81
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">GET /api/v1/artists/interest HTTP/1.1
 Content-Type: application/json;charset=UTF-8
-Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwiaWF0IjoxNzA4OTExODMyLCJleHAiOjE3MDg5MTM2MzJ9.UU9ZMDU8pyrs9UVNV0Jh_oIcobc6wJZlJFLD7fuFCsw
+Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwiaWF0IjoxNzA4OTI3OTAwLCJleHAiOjE3MDg5Mjk3MDB9.IZvI3NPZQWpJIo6BYfaR0NxaBShrY6k9EBfrnAxY7P0
 Host: www.api.birca.com</code></pre>
 </div>
 </div>
@@ -1343,6 +1377,40 @@ Content-Length: 416
 </div>
 </div>
 </div>
+<div class="sect3">
+<h4 id="_관심_아티스트_조회_response_fields"><a class="link" href="#_관심_아티스트_조회_response_fields">Response fields</a></h4>
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 33.3333%;">
+<col style="width: 33.3333%;">
+<col style="width: 33.3334%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">Path</th>
+<th class="tableblock halign-left valign-top">Type</th>
+<th class="tableblock halign-left valign-top">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>[].artistId</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Number</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">아티스트 ID</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>[].artistName</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">아티스트 이름</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>[].artistImage</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">아티스트 이미지 url</p></td>
+</tr>
+</tbody>
+</table>
+</div>
 </div>
 </div>
 </div>
@@ -1357,7 +1425,7 @@ Content-Length: 416
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">POST /api/v1/cafes/license-read HTTP/1.1
 Content-Type: multipart/form-data;charset=UTF-8; boundary=6o2knFse3p53ty9dmcQvWAIx1zInP11uCfbm
-Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwiaWF0IjoxNzA4OTExODI5LCJleHAiOjE3MDg5MTM2Mjl9.aWFIhWvKJZgQFfol0jMGC6NizF_-DqqfN49i7hrgtz8
+Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwiaWF0IjoxNzA4OTI3ODk3LCJleHAiOjE3MDg5Mjk2OTd9.9yLdG6LiK13TxzF-sYLOjgoN4vSGZn_5PdoCNziJQCY
 Host: www.api.birca.com
 
 --6o2knFse3p53ty9dmcQvWAIx1zInP11uCfbm
@@ -1443,7 +1511,7 @@ Content-Length: 141
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">POST /api/v1/cafes/apply HTTP/1.1
 Content-Type: multipart/form-data;charset=UTF-8; boundary=6o2knFse3p53ty9dmcQvWAIx1zInP11uCfbm
-Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwiaWF0IjoxNzA4OTExODI5LCJleHAiOjE3MDg5MTM2Mjl9.aWFIhWvKJZgQFfol0jMGC6NizF_-DqqfN49i7hrgtz8
+Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwiaWF0IjoxNzA4OTI3ODk3LCJleHAiOjE3MDg5Mjk2OTd9.9yLdG6LiK13TxzF-sYLOjgoN4vSGZn_5PdoCNziJQCY
 Host: www.api.birca.com
 
 --6o2knFse3p53ty9dmcQvWAIx1zInP11uCfbm
@@ -1529,7 +1597,7 @@ Vary: Access-Control-Request-Headers</code></pre>
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">POST /api/v1/birthday-cafes HTTP/1.1
 Content-Type: application/json;charset=UTF-8
-Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwiaWF0IjoxNzA4OTExODI3LCJleHAiOjE3MDg5MTM2Mjd9.6LkXbKjcyPn8CENDsY9JswkB-PZgPQ0pJAYalFQkjzA
+Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwiaWF0IjoxNzA4OTI3ODk1LCJleHAiOjE3MDg5Mjk2OTV9.Nl2h3kU4aBMmcsKR-xyr__fY539TJpBS9pCi6iBVKbs
 Content-Length: 179
 Host: www.api.birca.com
 
@@ -1628,7 +1696,7 @@ Vary: Access-Control-Request-Headers</code></pre>
 <div id="footer">
 <div id="footer-text">
 Version 0.0.1-SNAPSHOT<br>
-Last updated 2024-02-25 22:12:39 +0900
+Last updated 2024-02-26 14:48:50 +0900
 </div>
 </div>
 <script src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/9.18.3/highlight.min.js"></script>

--- a/src/main/resources/static/docs/api.html
+++ b/src/main/resources/static/docs/api.html
@@ -469,6 +469,8 @@ body.book #toc,body.book #preamble,body.book h1.sect0,body.book .sect1>h2{page-b
 <li><a href="#_최애_아티스트_등록">최애 아티스트 등록</a></li>
 <li><a href="#_관심_아티스트_등록">관심 아티스트 등록</a></li>
 <li><a href="#_에러_코드_3">에러 코드</a></li>
+<li><a href="#_최애_아티스트_조회">최애 아티스트 조회</a></li>
+<li><a href="#_관심_아티스트_조회">관심 아티스트 조회</a></li>
 </ul>
 </li>
 <li><a href="#_사업자등록증_api">사업자등록증 API</a>
@@ -618,7 +620,7 @@ Content-Length: 97
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">POST /api/v1/members/role-change HTTP/1.1
 Content-Type: application/json;charset=UTF-8
-Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwiaWF0IjoxNzA3NzQ1NTkzLCJleHAiOjE3MDc3NDczOTN9.zzrvJQrKZDDq76pm2rN4GCn7IAwVqf25TDmzKnHwkW0
+Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwiaWF0IjoxNzA4OTExODI5LCJleHAiOjE3MDg5MTM2Mjl9.aWFIhWvKJZgQFfol0jMGC6NizF_-DqqfN49i7hrgtz8
 Content-Length: 21
 Host: www.api.birca.com
 
@@ -648,7 +650,7 @@ Vary: Access-Control-Request-Headers</code></pre>
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">GET /api/v1/join/check-nickname?nickname=does HTTP/1.1
 Content-Type: application/json;charset=UTF-8
-Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwiaWF0IjoxNzA3NzQ1NTkzLCJleHAiOjE3MDc3NDczOTN9.zzrvJQrKZDDq76pm2rN4GCn7IAwVqf25TDmzKnHwkW0
+Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwiaWF0IjoxNzA4OTExODMyLCJleHAiOjE3MDg5MTM2MzJ9.UU9ZMDU8pyrs9UVNV0Jh_oIcobc6wJZlJFLD7fuFCsw
 Host: www.api.birca.com</code></pre>
 </div>
 </div>
@@ -722,7 +724,7 @@ Content-Length: 16
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">POST /api/v1/join/register-nickname HTTP/1.1
 Content-Type: application/json;charset=UTF-8
-Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwiaWF0IjoxNzA3NzQ1NTkzLCJleHAiOjE3MDc3NDczOTN9.zzrvJQrKZDDq76pm2rN4GCn7IAwVqf25TDmzKnHwkW0
+Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwiaWF0IjoxNzA4OTExODI5LCJleHAiOjE3MDg5MTM2Mjl9.aWFIhWvKJZgQFfol0jMGC6NizF_-DqqfN49i7hrgtz8
 Content-Length: 30
 Host: www.api.birca.com
 
@@ -810,7 +812,7 @@ Vary: Access-Control-Request-Headers</code></pre>
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">GET /api/v1/artist-groups?cursor=10&amp;size=3 HTTP/1.1
 Content-Type: application/json;charset=UTF-8
-Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwiaWF0IjoxNzA3NzQ1NTkzLCJleHAiOjE3MDc3NDczOTN9.zzrvJQrKZDDq76pm2rN4GCn7IAwVqf25TDmzKnHwkW0
+Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwiaWF0IjoxNzA4OTExODMyLCJleHAiOjE3MDg5MTM2MzJ9.UU9ZMDU8pyrs9UVNV0Jh_oIcobc6wJZlJFLD7fuFCsw
 Host: www.api.birca.com</code></pre>
 </div>
 </div>
@@ -910,7 +912,7 @@ Content-Length: 250
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">GET /api/v1/artist-groups/1/artists HTTP/1.1
 Content-Type: application/json;charset=UTF-8
-Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwiaWF0IjoxNzA3NzQ1NTkzLCJleHAiOjE3MDc3NDczOTN9.zzrvJQrKZDDq76pm2rN4GCn7IAwVqf25TDmzKnHwkW0
+Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwiaWF0IjoxNzA4OTExODMyLCJleHAiOjE3MDg5MTM2MzJ9.UU9ZMDU8pyrs9UVNV0Jh_oIcobc6wJZlJFLD7fuFCsw
 Host: www.api.birca.com</code></pre>
 </div>
 </div>
@@ -1023,7 +1025,7 @@ Content-Length: 565
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">GET /api/v1/artists/solo?cursor=12&amp;size=6 HTTP/1.1
 Content-Type: application/json;charset=UTF-8
-Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwiaWF0IjoxNzA3NzQ1NTkzLCJleHAiOjE3MDc3NDczOTN9.zzrvJQrKZDDq76pm2rN4GCn7IAwVqf25TDmzKnHwkW0
+Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwiaWF0IjoxNzA4OTExODMyLCJleHAiOjE3MDg5MTM2MzJ9.UU9ZMDU8pyrs9UVNV0Jh_oIcobc6wJZlJFLD7fuFCsw
 Host: www.api.birca.com</code></pre>
 </div>
 </div>
@@ -1044,7 +1046,7 @@ Host: www.api.birca.com</code></pre>
 <tbody>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><code>cursor</code></p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">이전에 쿼리된 마지막 groupId</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">이전에 쿼리된 마지막 artistId</p></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><code>size</code></p></td>
@@ -1135,7 +1137,7 @@ Content-Length: 518
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">POST /api/v1/artists/favorite HTTP/1.1
 Content-Type: application/json;charset=UTF-8
-Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwiaWF0IjoxNzA3NzQ1NTkwLCJleHAiOjE3MDc3NDczOTB9.U9ATXY5eHM7g1RjhbT1bT8VdheLVKZnhCM8w9YWIRFw
+Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwiaWF0IjoxNzA4OTExODI2LCJleHAiOjE3MDg5MTM2MjZ9.wOtCj45XeAvjDCZaYxNXBsdOMWKeddyZckfJLtXIFjQ
 Content-Length: 20
 Host: www.api.birca.com
 
@@ -1189,7 +1191,7 @@ Vary: Access-Control-Request-Headers</code></pre>
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">POST /api/v1/artists/interest HTTP/1.1
 Content-Type: application/json;charset=UTF-8
-Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwiaWF0IjoxNzA3NzQ1NTkwLCJleHAiOjE3MDc3NDczOTB9.U9ATXY5eHM7g1RjhbT1bT8VdheLVKZnhCM8w9YWIRFw
+Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwiaWF0IjoxNzA4OTExODI2LCJleHAiOjE3MDg5MTM2MjZ9.wOtCj45XeAvjDCZaYxNXBsdOMWKeddyZckfJLtXIFjQ
 Content-Length: 68
 Host: www.api.birca.com
 
@@ -1260,6 +1262,88 @@ Vary: Access-Control-Request-Headers</code></pre>
 </div>
 </div>
 </div>
+<div class="sect2">
+<h3 id="_최애_아티스트_조회"><a class="link" href="#_최애_아티스트_조회">최애 아티스트 조회</a></h3>
+<div class="sect3">
+<h4 id="_최애_아티스트_조회_http_request"><a class="link" href="#_최애_아티스트_조회_http_request">HTTP request</a></h4>
+<div class="listingblock">
+<div class="content">
+<pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">GET /api/v1/artists/favorite HTTP/1.1
+Content-Type: application/json;charset=UTF-8
+Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwiaWF0IjoxNzA4OTExODMyLCJleHAiOjE3MDg5MTM2MzJ9.UU9ZMDU8pyrs9UVNV0Jh_oIcobc6wJZlJFLD7fuFCsw
+Host: www.api.birca.com</code></pre>
+</div>
+</div>
+</div>
+<div class="sect3">
+<h4 id="_최애_아티스트_조회_http_response"><a class="link" href="#_최애_아티스트_조회_http_response">HTTP response</a></h4>
+<div class="listingblock">
+<div class="content">
+<pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">HTTP/1.1 200 OK
+Vary: Origin
+Vary: Access-Control-Request-Method
+Vary: Access-Control-Request-Headers
+Content-Type: application/json
+Content-Length: 81
+
+{
+  "artistId" : 10,
+  "artistName" : "민지",
+  "artistImage" : "image10.com"
+}</code></pre>
+</div>
+</div>
+</div>
+</div>
+<div class="sect2">
+<h3 id="_관심_아티스트_조회"><a class="link" href="#_관심_아티스트_조회">관심 아티스트 조회</a></h3>
+<div class="sect3">
+<h4 id="_관심_아티스트_조회_http_request"><a class="link" href="#_관심_아티스트_조회_http_request">HTTP request</a></h4>
+<div class="listingblock">
+<div class="content">
+<pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">GET /api/v1/artists/interest HTTP/1.1
+Content-Type: application/json;charset=UTF-8
+Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwiaWF0IjoxNzA4OTExODMyLCJleHAiOjE3MDg5MTM2MzJ9.UU9ZMDU8pyrs9UVNV0Jh_oIcobc6wJZlJFLD7fuFCsw
+Host: www.api.birca.com</code></pre>
+</div>
+</div>
+</div>
+<div class="sect3">
+<h4 id="_관심_아티스트_조회_http_response"><a class="link" href="#_관심_아티스트_조회_http_response">HTTP response</a></h4>
+<div class="listingblock">
+<div class="content">
+<pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">HTTP/1.1 200 OK
+Vary: Origin
+Vary: Access-Control-Request-Method
+Vary: Access-Control-Request-Headers
+Content-Type: application/json
+Content-Length: 416
+
+[ {
+  "artistId" : 8,
+  "artistName" : "하니",
+  "artistImage" : "image8.com"
+}, {
+  "artistId" : 9,
+  "artistName" : "해린",
+  "artistImage" : "image9.com"
+}, {
+  "artistId" : 10,
+  "artistName" : "민지",
+  "artistImage" : "image10.com"
+}, {
+  "artistId" : 11,
+  "artistName" : "다니엘",
+  "artistImage" : "image11.com"
+}, {
+  "artistId" : 12,
+  "artistName" : "혜인",
+  "artistImage" : "image12.com"
+} ]</code></pre>
+</div>
+</div>
+</div>
+</div>
 </div>
 </div>
 <div class="sect1">
@@ -1273,7 +1357,7 @@ Vary: Access-Control-Request-Headers</code></pre>
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">POST /api/v1/cafes/license-read HTTP/1.1
 Content-Type: multipart/form-data;charset=UTF-8; boundary=6o2knFse3p53ty9dmcQvWAIx1zInP11uCfbm
-Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwiaWF0IjoxNzA3NzQ1NTkzLCJleHAiOjE3MDc3NDczOTN9.zzrvJQrKZDDq76pm2rN4GCn7IAwVqf25TDmzKnHwkW0
+Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwiaWF0IjoxNzA4OTExODI5LCJleHAiOjE3MDg5MTM2Mjl9.aWFIhWvKJZgQFfol0jMGC6NizF_-DqqfN49i7hrgtz8
 Host: www.api.birca.com
 
 --6o2knFse3p53ty9dmcQvWAIx1zInP11uCfbm
@@ -1359,7 +1443,7 @@ Content-Length: 141
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">POST /api/v1/cafes/apply HTTP/1.1
 Content-Type: multipart/form-data;charset=UTF-8; boundary=6o2knFse3p53ty9dmcQvWAIx1zInP11uCfbm
-Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwiaWF0IjoxNzA3NzQ1NTkzLCJleHAiOjE3MDc3NDczOTN9.zzrvJQrKZDDq76pm2rN4GCn7IAwVqf25TDmzKnHwkW0
+Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwiaWF0IjoxNzA4OTExODI5LCJleHAiOjE3MDg5MTM2Mjl9.aWFIhWvKJZgQFfol0jMGC6NizF_-DqqfN49i7hrgtz8
 Host: www.api.birca.com
 
 --6o2knFse3p53ty9dmcQvWAIx1zInP11uCfbm
@@ -1445,7 +1529,7 @@ Vary: Access-Control-Request-Headers</code></pre>
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">POST /api/v1/birthday-cafes HTTP/1.1
 Content-Type: application/json;charset=UTF-8
-Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwiaWF0IjoxNzA3NzQ1NTkxLCJleHAiOjE3MDc3NDczOTF9.w4ihD1Zghyx3ZGupPeKqvcviEVMAYsP_ZN9AxTCXnGg
+Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwiaWF0IjoxNzA4OTExODI3LCJleHAiOjE3MDg5MTM2Mjd9.6LkXbKjcyPn8CENDsY9JswkB-PZgPQ0pJAYalFQkjzA
 Content-Length: 179
 Host: www.api.birca.com
 
@@ -1544,7 +1628,7 @@ Vary: Access-Control-Request-Headers</code></pre>
 <div id="footer">
 <div id="footer-text">
 Version 0.0.1-SNAPSHOT<br>
-Last updated 2024-02-12 11:33:23 +0900
+Last updated 2024-02-25 22:12:39 +0900
 </div>
 </div>
 <script src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/9.18.3/highlight.min.js"></script>

--- a/src/main/resources/static/docs/api.html
+++ b/src/main/resources/static/docs/api.html
@@ -620,7 +620,7 @@ Content-Length: 97
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">POST /api/v1/members/role-change HTTP/1.1
 Content-Type: application/json;charset=UTF-8
-Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwiaWF0IjoxNzA4OTI3ODk4LCJleHAiOjE3MDg5Mjk2OTh9.h2CqXsbLB93oZ00iCdPWYmnDT2Lj6MBw_CYzJOBQjy8
+Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwiaWF0IjoxNzA4OTI4ODU2LCJleHAiOjE3MDg5MzA2NTZ9.HKM4Ujzv3PVeR-BjZySBK1kO7knwP7U_N8D29xg0Xto
 Content-Length: 21
 Host: www.api.birca.com
 
@@ -650,7 +650,7 @@ Vary: Access-Control-Request-Headers</code></pre>
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">GET /api/v1/join/check-nickname?nickname=does HTTP/1.1
 Content-Type: application/json;charset=UTF-8
-Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwiaWF0IjoxNzA4OTI3OTAwLCJleHAiOjE3MDg5Mjk3MDB9.IZvI3NPZQWpJIo6BYfaR0NxaBShrY6k9EBfrnAxY7P0
+Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwiaWF0IjoxNzA4OTI4ODU5LCJleHAiOjE3MDg5MzA2NTl9.IuvAODS2jrW0MtFSxNn32sUj_d1OgGgeehu9Ko1wbWA
 Host: www.api.birca.com</code></pre>
 </div>
 </div>
@@ -724,7 +724,7 @@ Content-Length: 16
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">POST /api/v1/join/register-nickname HTTP/1.1
 Content-Type: application/json;charset=UTF-8
-Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwiaWF0IjoxNzA4OTI3ODk4LCJleHAiOjE3MDg5Mjk2OTh9.h2CqXsbLB93oZ00iCdPWYmnDT2Lj6MBw_CYzJOBQjy8
+Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwiaWF0IjoxNzA4OTI4ODU2LCJleHAiOjE3MDg5MzA2NTZ9.HKM4Ujzv3PVeR-BjZySBK1kO7knwP7U_N8D29xg0Xto
 Content-Length: 30
 Host: www.api.birca.com
 
@@ -812,7 +812,7 @@ Vary: Access-Control-Request-Headers</code></pre>
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">GET /api/v1/artist-groups?cursor=10&amp;size=3 HTTP/1.1
 Content-Type: application/json;charset=UTF-8
-Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwiaWF0IjoxNzA4OTI3OTAwLCJleHAiOjE3MDg5Mjk3MDB9.IZvI3NPZQWpJIo6BYfaR0NxaBShrY6k9EBfrnAxY7P0
+Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwiaWF0IjoxNzA4OTI4ODU5LCJleHAiOjE3MDg5MzA2NTl9.IuvAODS2jrW0MtFSxNn32sUj_d1OgGgeehu9Ko1wbWA
 Host: www.api.birca.com</code></pre>
 </div>
 </div>
@@ -912,7 +912,7 @@ Content-Length: 250
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">GET /api/v1/artist-groups/1/artists HTTP/1.1
 Content-Type: application/json;charset=UTF-8
-Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwiaWF0IjoxNzA4OTI3OTAwLCJleHAiOjE3MDg5Mjk3MDB9.IZvI3NPZQWpJIo6BYfaR0NxaBShrY6k9EBfrnAxY7P0
+Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwiaWF0IjoxNzA4OTI4ODU5LCJleHAiOjE3MDg5MzA2NTl9.IuvAODS2jrW0MtFSxNn32sUj_d1OgGgeehu9Ko1wbWA
 Host: www.api.birca.com</code></pre>
 </div>
 </div>
@@ -1025,7 +1025,7 @@ Content-Length: 565
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">GET /api/v1/artists/solo?cursor=12&amp;size=6 HTTP/1.1
 Content-Type: application/json;charset=UTF-8
-Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwiaWF0IjoxNzA4OTI3OTAwLCJleHAiOjE3MDg5Mjk3MDB9.IZvI3NPZQWpJIo6BYfaR0NxaBShrY6k9EBfrnAxY7P0
+Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwiaWF0IjoxNzA4OTI4ODU5LCJleHAiOjE3MDg5MzA2NTl9.IuvAODS2jrW0MtFSxNn32sUj_d1OgGgeehu9Ko1wbWA
 Host: www.api.birca.com</code></pre>
 </div>
 </div>
@@ -1137,7 +1137,7 @@ Content-Length: 518
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">POST /api/v1/artists/favorite HTTP/1.1
 Content-Type: application/json;charset=UTF-8
-Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwiaWF0IjoxNzA4OTI3ODk0LCJleHAiOjE3MDg5Mjk2OTR9.KAtH2Ke6812hsq2vs-Ktr6-nX-aLPyReNWaPbI2AqdM
+Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwiaWF0IjoxNzA4OTI4ODUzLCJleHAiOjE3MDg5MzA2NTN9.dqIFmGBqhVxFxJHAEk1eRuyTfTN06YEYMusC0JER8q0
 Content-Length: 20
 Host: www.api.birca.com
 
@@ -1191,7 +1191,7 @@ Vary: Access-Control-Request-Headers</code></pre>
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">POST /api/v1/artists/interest HTTP/1.1
 Content-Type: application/json;charset=UTF-8
-Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwiaWF0IjoxNzA4OTI3ODk0LCJleHAiOjE3MDg5Mjk2OTR9.KAtH2Ke6812hsq2vs-Ktr6-nX-aLPyReNWaPbI2AqdM
+Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwiaWF0IjoxNzA4OTI4ODUzLCJleHAiOjE3MDg5MzA2NTN9.dqIFmGBqhVxFxJHAEk1eRuyTfTN06YEYMusC0JER8q0
 Content-Length: 68
 Host: www.api.birca.com
 
@@ -1270,7 +1270,7 @@ Vary: Access-Control-Request-Headers</code></pre>
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">GET /api/v1/artists/favorite HTTP/1.1
 Content-Type: application/json;charset=UTF-8
-Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwiaWF0IjoxNzA4OTI3OTAwLCJleHAiOjE3MDg5Mjk3MDB9.IZvI3NPZQWpJIo6BYfaR0NxaBShrY6k9EBfrnAxY7P0
+Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwiaWF0IjoxNzA4OTI4ODU5LCJleHAiOjE3MDg5MzA2NTl9.IuvAODS2jrW0MtFSxNn32sUj_d1OgGgeehu9Ko1wbWA
 Host: www.api.birca.com</code></pre>
 </div>
 </div>
@@ -1313,17 +1313,17 @@ Content-Length: 81
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><code>artistId</code></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><code>Number</code></p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">아티스트 ID</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">최애 아티스트 ID</p></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><code>artistName</code></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">아티스트 이름</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">최애 아티스트 이름</p></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><code>artistImage</code></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">아티스트 이미지 url</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">최애 아티스트 이미지 url</p></td>
 </tr>
 </tbody>
 </table>
@@ -1337,7 +1337,7 @@ Content-Length: 81
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">GET /api/v1/artists/interest HTTP/1.1
 Content-Type: application/json;charset=UTF-8
-Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwiaWF0IjoxNzA4OTI3OTAwLCJleHAiOjE3MDg5Mjk3MDB9.IZvI3NPZQWpJIo6BYfaR0NxaBShrY6k9EBfrnAxY7P0
+Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwiaWF0IjoxNzA4OTI4ODU5LCJleHAiOjE3MDg5MzA2NTl9.IuvAODS2jrW0MtFSxNn32sUj_d1OgGgeehu9Ko1wbWA
 Host: www.api.birca.com</code></pre>
 </div>
 </div>
@@ -1396,17 +1396,17 @@ Content-Length: 416
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><code>[].artistId</code></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><code>Number</code></p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">아티스트 ID</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">관심 아티스트 ID</p></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><code>[].artistName</code></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">아티스트 이름</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">관심 아티스트 이름</p></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><code>[].artistImage</code></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">아티스트 이미지 url</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">관심 아티스트 이미지 url</p></td>
 </tr>
 </tbody>
 </table>
@@ -1425,7 +1425,7 @@ Content-Length: 416
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">POST /api/v1/cafes/license-read HTTP/1.1
 Content-Type: multipart/form-data;charset=UTF-8; boundary=6o2knFse3p53ty9dmcQvWAIx1zInP11uCfbm
-Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwiaWF0IjoxNzA4OTI3ODk3LCJleHAiOjE3MDg5Mjk2OTd9.9yLdG6LiK13TxzF-sYLOjgoN4vSGZn_5PdoCNziJQCY
+Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwiaWF0IjoxNzA4OTI4ODU2LCJleHAiOjE3MDg5MzA2NTZ9.HKM4Ujzv3PVeR-BjZySBK1kO7knwP7U_N8D29xg0Xto
 Host: www.api.birca.com
 
 --6o2knFse3p53ty9dmcQvWAIx1zInP11uCfbm
@@ -1511,7 +1511,7 @@ Content-Length: 141
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">POST /api/v1/cafes/apply HTTP/1.1
 Content-Type: multipart/form-data;charset=UTF-8; boundary=6o2knFse3p53ty9dmcQvWAIx1zInP11uCfbm
-Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwiaWF0IjoxNzA4OTI3ODk3LCJleHAiOjE3MDg5Mjk2OTd9.9yLdG6LiK13TxzF-sYLOjgoN4vSGZn_5PdoCNziJQCY
+Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwiaWF0IjoxNzA4OTI4ODU2LCJleHAiOjE3MDg5MzA2NTZ9.HKM4Ujzv3PVeR-BjZySBK1kO7knwP7U_N8D29xg0Xto
 Host: www.api.birca.com
 
 --6o2knFse3p53ty9dmcQvWAIx1zInP11uCfbm
@@ -1597,7 +1597,7 @@ Vary: Access-Control-Request-Headers</code></pre>
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">POST /api/v1/birthday-cafes HTTP/1.1
 Content-Type: application/json;charset=UTF-8
-Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwiaWF0IjoxNzA4OTI3ODk1LCJleHAiOjE3MDg5Mjk2OTV9.Nl2h3kU4aBMmcsKR-xyr__fY539TJpBS9pCi6iBVKbs
+Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwiaWF0IjoxNzA4OTI4ODU0LCJleHAiOjE3MDg5MzA2NTR9.WE0IOquFsZFMwPQKQqlnChJ18LaZYb97H2dZ41dkZNU
 Content-Length: 179
 Host: www.api.birca.com
 

--- a/src/test/java/com/birca/bircabackend/command/cafe/presentation/BusinessLicenseControllerTest.java
+++ b/src/test/java/com/birca/bircabackend/command/cafe/presentation/BusinessLicenseControllerTest.java
@@ -1,7 +1,6 @@
 package com.birca.bircabackend.command.cafe.presentation;
 
 import com.birca.bircabackend.command.auth.authorization.LoginMember;
-import com.birca.bircabackend.command.cafe.dto.BusinessLicenseInfoResponse;
 import com.birca.bircabackend.command.cafe.dto.BusinessLicenseResponse;
 import com.birca.bircabackend.command.cafe.exception.BusinessLicenseErrorCode;
 import com.birca.bircabackend.support.enviroment.DocumentationTest;
@@ -69,7 +68,6 @@ class BusinessLicenseControllerTest extends DocumentationTest {
                 ));
     }
 
-    //에러
     @Test
     void 사업자등록증을_저장한다() throws Exception {
         // given

--- a/src/test/java/com/birca/bircabackend/query/acceptance/FavoriteArtistQueryAcceptanceTest.java
+++ b/src/test/java/com/birca/bircabackend/query/acceptance/FavoriteArtistQueryAcceptanceTest.java
@@ -1,0 +1,35 @@
+package com.birca.bircabackend.query.acceptance;
+
+import com.birca.bircabackend.support.enviroment.AcceptanceTest;
+import io.restassured.RestAssured;
+import io.restassured.response.ExtractableResponse;
+import io.restassured.response.Response;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.jdbc.Sql;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@Sql("/fixture/favorite-artist-fixture.sql")
+public class FavoriteArtistQueryAcceptanceTest extends AcceptanceTest {
+
+    @Test
+    void 최애_아티스트를_조회한다() {
+        // given
+        Long memberId = 1L;
+
+        // when
+        ExtractableResponse<Response> response = RestAssured.given().log().all()
+                .when()
+                .contentType(MediaType.APPLICATION_JSON_VALUE)
+                .header(HttpHeaders.AUTHORIZATION, bearerTokenProvider.getToken(memberId))
+                .get("/api/v1/artists/favorite")
+                .then().log().all()
+                .extract();
+
+        // then
+        assertThat(response.statusCode()).isEqualTo(HttpStatus.OK.value());
+    }
+}

--- a/src/test/java/com/birca/bircabackend/query/acceptance/InterestArtistQueryAcceptanceTest.java
+++ b/src/test/java/com/birca/bircabackend/query/acceptance/InterestArtistQueryAcceptanceTest.java
@@ -1,0 +1,35 @@
+package com.birca.bircabackend.query.acceptance;
+
+import com.birca.bircabackend.support.enviroment.AcceptanceTest;
+import io.restassured.RestAssured;
+import io.restassured.response.ExtractableResponse;
+import io.restassured.response.Response;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.jdbc.Sql;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@Sql("/fixture/interest-artist-fixture.sql")
+public class InterestArtistQueryAcceptanceTest extends AcceptanceTest {
+
+    @Test
+    void 관심_아티스트_목록을_조회한다() {
+        // given
+        Long memberId = 1L;
+
+        // when
+        ExtractableResponse<Response> response = RestAssured.given().log().all()
+                .when()
+                .contentType(MediaType.APPLICATION_JSON_VALUE)
+                .header(HttpHeaders.AUTHORIZATION, bearerTokenProvider.getToken(memberId))
+                .get("/api/v1/artists/interest")
+                .then().log().all()
+                .extract();
+
+        // then
+        assertThat(response.statusCode()).isEqualTo(HttpStatus.OK.value());
+    }
+}

--- a/src/test/java/com/birca/bircabackend/query/controller/FavoriteArtistQueryControllerTest.java
+++ b/src/test/java/com/birca/bircabackend/query/controller/FavoriteArtistQueryControllerTest.java
@@ -1,0 +1,43 @@
+package com.birca.bircabackend.query.controller;
+
+import com.birca.bircabackend.query.dto.ArtistResponse;
+import com.birca.bircabackend.support.enviroment.DocumentationTest;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.restdocs.payload.JsonFieldType;
+import org.springframework.test.web.servlet.ResultActions;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.get;
+import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
+import static org.springframework.restdocs.payload.PayloadDocumentation.responseFields;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+class FavoriteArtistQueryControllerTest extends DocumentationTest {
+
+    @Test
+    void 최애_아티스트를_조회한다() throws Exception {
+        // given
+        given(favoriteArtistQueryService.findFavoriteArtist(any()))
+                .willReturn(new ArtistResponse(10L, "민지", "image10.com"));
+
+        // when
+        ResultActions result = mockMvc.perform(get("/api/v1/artists/favorite")
+                .contentType(MediaType.APPLICATION_JSON)
+                .header(HttpHeaders.AUTHORIZATION, bearerTokenProvider.getToken(1L))
+        );
+
+        // then
+        result.andExpect((status().isOk()))
+                .andDo(document("get-favorite-artist", HOST_INFO, DOCUMENT_RESPONSE,
+                        responseFields(
+                                fieldWithPath("artistId").type(JsonFieldType.NUMBER).description("아티스트 ID"),
+                                fieldWithPath("artistName").type(JsonFieldType.STRING).description("아티스트 이름"),
+                                fieldWithPath("artistImage").type(JsonFieldType.STRING).description("아티스트 이미지 url")
+                        )
+                ));
+    }
+}

--- a/src/test/java/com/birca/bircabackend/query/controller/FavoriteArtistQueryControllerTest.java
+++ b/src/test/java/com/birca/bircabackend/query/controller/FavoriteArtistQueryControllerTest.java
@@ -34,9 +34,9 @@ class FavoriteArtistQueryControllerTest extends DocumentationTest {
         result.andExpect((status().isOk()))
                 .andDo(document("get-favorite-artist", HOST_INFO, DOCUMENT_RESPONSE,
                         responseFields(
-                                fieldWithPath("artistId").type(JsonFieldType.NUMBER).description("아티스트 ID"),
-                                fieldWithPath("artistName").type(JsonFieldType.STRING).description("아티스트 이름"),
-                                fieldWithPath("artistImage").type(JsonFieldType.STRING).description("아티스트 이미지 url")
+                                fieldWithPath("artistId").type(JsonFieldType.NUMBER).description("최애 아티스트 ID"),
+                                fieldWithPath("artistName").type(JsonFieldType.STRING).description("최애 아티스트 이름"),
+                                fieldWithPath("artistImage").type(JsonFieldType.STRING).description("최애 아티스트 이미지 url")
                         )
                 ));
     }

--- a/src/test/java/com/birca/bircabackend/query/controller/InterestArtistQueryControllerTest.java
+++ b/src/test/java/com/birca/bircabackend/query/controller/InterestArtistQueryControllerTest.java
@@ -1,0 +1,52 @@
+package com.birca.bircabackend.query.controller;
+
+import com.birca.bircabackend.query.dto.ArtistResponse;
+import com.birca.bircabackend.support.enviroment.DocumentationTest;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.restdocs.payload.JsonFieldType;
+import org.springframework.test.web.servlet.ResultActions;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.get;
+import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
+import static org.springframework.restdocs.payload.PayloadDocumentation.responseFields;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+class InterestArtistQueryControllerTest extends DocumentationTest {
+
+    @Test
+    void 관심_아티스트_목록을_조회한다() throws Exception {
+        // given
+        given(interestArtistQueryService.findInterestArtistIdsByFanId(any()))
+                .willReturn(List.of(
+                        new ArtistResponse(8L, "하니", "image8.com"),
+                        new ArtistResponse(9L, "해린", "image9.com"),
+                        new ArtistResponse(10L, "민지", "image10.com"),
+                        new ArtistResponse(11L, "다니엘", "image11.com"),
+                        new ArtistResponse(12L, "혜인", "image12.com")
+                ));
+
+        // when
+        ResultActions result = mockMvc.perform(get("/api/v1/artists/interest")
+                .contentType(MediaType.APPLICATION_JSON)
+                .header(HttpHeaders.AUTHORIZATION, bearerTokenProvider.getToken(1L))
+        );
+
+        // then
+        result.andExpect((status().isOk()))
+                .andDo(document("get-interest-artists", HOST_INFO, DOCUMENT_RESPONSE,
+                        responseFields(
+                                fieldWithPath("[].artistId").type(JsonFieldType.NUMBER).description("아티스트 ID"),
+                                fieldWithPath("[].artistName").type(JsonFieldType.STRING).description("아티스트 이름"),
+                                fieldWithPath("[].artistImage").type(JsonFieldType.STRING).description("아티스트 이미지 url")
+                        )
+                ));
+    }
+}

--- a/src/test/java/com/birca/bircabackend/query/controller/InterestArtistQueryControllerTest.java
+++ b/src/test/java/com/birca/bircabackend/query/controller/InterestArtistQueryControllerTest.java
@@ -42,9 +42,9 @@ class InterestArtistQueryControllerTest extends DocumentationTest {
         result.andExpect((status().isOk()))
                 .andDo(document("get-interest-artists", HOST_INFO, DOCUMENT_RESPONSE,
                         responseFields(
-                                fieldWithPath("[].artistId").type(JsonFieldType.NUMBER).description("아티스트 ID"),
-                                fieldWithPath("[].artistName").type(JsonFieldType.STRING).description("아티스트 이름"),
-                                fieldWithPath("[].artistImage").type(JsonFieldType.STRING).description("아티스트 이미지 url")
+                                fieldWithPath("[].artistId").type(JsonFieldType.NUMBER).description("관심 아티스트 ID"),
+                                fieldWithPath("[].artistName").type(JsonFieldType.STRING).description("관심 아티스트 이름"),
+                                fieldWithPath("[].artistImage").type(JsonFieldType.STRING).description("관심 아티스트 이미지 url")
                         )
                 ));
     }

--- a/src/test/java/com/birca/bircabackend/query/controller/InterestArtistQueryControllerTest.java
+++ b/src/test/java/com/birca/bircabackend/query/controller/InterestArtistQueryControllerTest.java
@@ -10,7 +10,6 @@ import org.springframework.test.web.servlet.ResultActions;
 
 import java.util.List;
 
-import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
 import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
@@ -24,7 +23,7 @@ class InterestArtistQueryControllerTest extends DocumentationTest {
     @Test
     void 관심_아티스트_목록을_조회한다() throws Exception {
         // given
-        given(interestArtistQueryService.findInterestArtistIdsByFanId(any()))
+        given(interestArtistQueryService.findInterestArtists(any()))
                 .willReturn(List.of(
                         new ArtistResponse(8L, "하니", "image8.com"),
                         new ArtistResponse(9L, "해린", "image9.com"),

--- a/src/test/java/com/birca/bircabackend/query/service/FavoriteArtistQueryServiceTest.java
+++ b/src/test/java/com/birca/bircabackend/query/service/FavoriteArtistQueryServiceTest.java
@@ -2,6 +2,8 @@ package com.birca.bircabackend.query.service;
 
 
 import com.birca.bircabackend.command.auth.authorization.LoginMember;
+import com.birca.bircabackend.command.member.exception.MemberErrorCode;
+import com.birca.bircabackend.common.exception.BusinessException;
 import com.birca.bircabackend.query.dto.ArtistResponse;
 import com.birca.bircabackend.support.enviroment.ServiceTest;
 import org.junit.jupiter.api.Test;
@@ -9,6 +11,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.test.context.jdbc.Sql;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 @Sql("/fixture/favorite-artist-fixture.sql")
 class FavoriteArtistQueryServiceTest extends ServiceTest {
@@ -38,5 +41,14 @@ class FavoriteArtistQueryServiceTest extends ServiceTest {
 
         // then
         assertThat(actual).isEqualTo(new ArtistResponse(null, null, null));
+    }
+
+    @Test
+    void 존재하지_않은_회원이_관심_아티스트_목록을_조회하면_예외가_발생한다() {
+        // when then
+        assertThatThrownBy(() -> favoriteArtistQueryService.findFavoriteArtist(new LoginMember(100L)))
+                .isInstanceOf(BusinessException.class)
+                .extracting("errorCode")
+                .isEqualTo(MemberErrorCode.MEMBER_NOT_FOUND);
     }
 }

--- a/src/test/java/com/birca/bircabackend/query/service/FavoriteArtistQueryServiceTest.java
+++ b/src/test/java/com/birca/bircabackend/query/service/FavoriteArtistQueryServiceTest.java
@@ -1,0 +1,30 @@
+package com.birca.bircabackend.query.service;
+
+
+import com.birca.bircabackend.command.auth.authorization.LoginMember;
+import com.birca.bircabackend.query.dto.ArtistResponse;
+import com.birca.bircabackend.support.enviroment.ServiceTest;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.context.jdbc.Sql;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@Sql("/fixture/favorite-artist-fixture.sql")
+class FavoriteArtistQueryServiceTest extends ServiceTest {
+
+    @Autowired
+    private FavoriteArtistQueryService favoriteArtistQueryService;
+
+    @Test
+    void 최애_아티스트를_조회한다() {
+        // given
+        LoginMember loginMember = new LoginMember(1L);
+
+        // when
+        ArtistResponse actual = favoriteArtistQueryService.findFavoriteArtist(loginMember);
+
+        // then
+        assertThat(actual).isEqualTo(new ArtistResponse(10L, "민지", "image10.com"));
+    }
+}

--- a/src/test/java/com/birca/bircabackend/query/service/FavoriteArtistQueryServiceTest.java
+++ b/src/test/java/com/birca/bircabackend/query/service/FavoriteArtistQueryServiceTest.java
@@ -44,7 +44,7 @@ class FavoriteArtistQueryServiceTest extends ServiceTest {
     }
 
     @Test
-    void 존재하지_않은_회원이_관심_아티스트_목록을_조회하면_예외가_발생한다() {
+    void 존재하지_않은_회원이_최애_아티스트_목록을_조회하면_예외가_발생한다() {
         // when then
         assertThatThrownBy(() -> favoriteArtistQueryService.findFavoriteArtist(new LoginMember(100L)))
                 .isInstanceOf(BusinessException.class)

--- a/src/test/java/com/birca/bircabackend/query/service/FavoriteArtistQueryServiceTest.java
+++ b/src/test/java/com/birca/bircabackend/query/service/FavoriteArtistQueryServiceTest.java
@@ -27,4 +27,16 @@ class FavoriteArtistQueryServiceTest extends ServiceTest {
         // then
         assertThat(actual).isEqualTo(new ArtistResponse(10L, "민지", "image10.com"));
     }
+
+    @Test
+    void 최애_아티스트가_없는_경우를_조회한다() {
+        // given
+        LoginMember loginMember = new LoginMember(2L);
+
+        // when
+        ArtistResponse actual = favoriteArtistQueryService.findFavoriteArtist(loginMember);
+
+        // then
+        assertThat(actual).isEqualTo(new ArtistResponse(null, null, null));
+    }
 }

--- a/src/test/java/com/birca/bircabackend/query/service/InterestArtistQueryServiceTest.java
+++ b/src/test/java/com/birca/bircabackend/query/service/InterestArtistQueryServiceTest.java
@@ -1,6 +1,9 @@
 package com.birca.bircabackend.query.service;
 
+import com.birca.bircabackend.command.artist.exception.ArtistErrorCode;
 import com.birca.bircabackend.command.auth.authorization.LoginMember;
+import com.birca.bircabackend.command.member.exception.MemberErrorCode;
+import com.birca.bircabackend.common.exception.BusinessException;
 import com.birca.bircabackend.query.dto.ArtistResponse;
 import com.birca.bircabackend.support.enviroment.ServiceTest;
 import org.junit.jupiter.api.Test;
@@ -10,6 +13,7 @@ import org.springframework.test.context.jdbc.Sql;
 import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 @Sql("/fixture/interest-artist-fixture.sql")
 class InterestArtistQueryServiceTest extends ServiceTest {
@@ -20,8 +24,7 @@ class InterestArtistQueryServiceTest extends ServiceTest {
     @Test
     void 관심_아티스트_목록을_조회한다() {
         // when
-        List<ArtistResponse> actual
-                = interestArtistQueryService.findInterestArtists(new LoginMember(1L));
+        List<ArtistResponse> actual = interestArtistQueryService.findInterestArtists(new LoginMember(1L));
 
         // then
         assertThat(actual)
@@ -32,5 +35,14 @@ class InterestArtistQueryServiceTest extends ServiceTest {
                         new ArtistResponse(11L, "다니엘", "image11.com"),
                         new ArtistResponse(12L, "혜인", "image12.com")
                 );
+    }
+
+    @Test
+    void 존재하지_않은_회원이_관심_아티스트_목록을_조회하면_예외가_발생한다() {
+        // when then
+        assertThatThrownBy(() -> interestArtistQueryService.findInterestArtists(new LoginMember(100L)))
+                .isInstanceOf(BusinessException.class)
+                .extracting("errorCode")
+                .isEqualTo(MemberErrorCode.MEMBER_NOT_FOUND);
     }
 }

--- a/src/test/java/com/birca/bircabackend/query/service/InterestArtistQueryServiceTest.java
+++ b/src/test/java/com/birca/bircabackend/query/service/InterestArtistQueryServiceTest.java
@@ -21,7 +21,7 @@ class InterestArtistQueryServiceTest extends ServiceTest {
     void 관심_아티스트_목록을_조회한다() {
         // when
         List<ArtistResponse> actual
-                = interestArtistQueryService.findInterestArtistIdsByFanId(new LoginMember(1L));
+                = interestArtistQueryService.findInterestArtists(new LoginMember(1L));
 
         // then
         assertThat(actual)

--- a/src/test/java/com/birca/bircabackend/query/service/InterestArtistQueryServiceTest.java
+++ b/src/test/java/com/birca/bircabackend/query/service/InterestArtistQueryServiceTest.java
@@ -33,5 +33,4 @@ class InterestArtistQueryServiceTest extends ServiceTest {
                         new ArtistResponse(12L, "혜인", "image12.com")
                 );
     }
-
 }

--- a/src/test/java/com/birca/bircabackend/query/service/InterestArtistQueryServiceTest.java
+++ b/src/test/java/com/birca/bircabackend/query/service/InterestArtistQueryServiceTest.java
@@ -1,0 +1,37 @@
+package com.birca.bircabackend.query.service;
+
+import com.birca.bircabackend.command.auth.authorization.LoginMember;
+import com.birca.bircabackend.query.dto.ArtistResponse;
+import com.birca.bircabackend.support.enviroment.ServiceTest;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.context.jdbc.Sql;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@Sql("/fixture/interest-artist-fixture.sql")
+class InterestArtistQueryServiceTest extends ServiceTest {
+
+    @Autowired
+    private InterestArtistQueryService interestArtistQueryService;
+
+    @Test
+    void 관심_아티스트_목록을_조회한다() {
+        // when
+        List<ArtistResponse> actual
+                = interestArtistQueryService.findInterestArtistIdsByFanId(new LoginMember(1L));
+
+        // then
+        assertThat(actual)
+                .containsOnly(
+                        new ArtistResponse(8L, "하니", "image8.com"),
+                        new ArtistResponse(9L, "해린", "image9.com"),
+                        new ArtistResponse(10L, "민지", "image10.com"),
+                        new ArtistResponse(11L, "다니엘", "image11.com"),
+                        new ArtistResponse(12L, "혜인", "image12.com")
+                );
+    }
+
+}

--- a/src/test/java/com/birca/bircabackend/support/enviroment/DocumentationTest.java
+++ b/src/test/java/com/birca/bircabackend/support/enviroment/DocumentationTest.java
@@ -12,6 +12,7 @@ import com.birca.bircabackend.common.exception.ErrorCode;
 import com.birca.bircabackend.common.log.TimeLogTemplate;
 import com.birca.bircabackend.query.service.ArtistGroupQueryService;
 import com.birca.bircabackend.query.service.ArtistQueryService;
+import com.birca.bircabackend.query.service.FavoriteArtistQueryService;
 import com.birca.bircabackend.query.service.MemberQueryService;
 import com.birca.bircabackend.support.TestBearerTokenProvider;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -85,6 +86,9 @@ public class DocumentationTest {
 
     @MockBean
     protected BusinessLicenseFacade businessLicenseFacade;
+
+    @MockBean
+    protected FavoriteArtistQueryService favoriteArtistQueryService;
 
     protected List<FieldDescriptor> getErrorDescriptor(ErrorCode[] errorCodes) {
         return Arrays.stream(errorCodes)

--- a/src/test/java/com/birca/bircabackend/support/enviroment/DocumentationTest.java
+++ b/src/test/java/com/birca/bircabackend/support/enviroment/DocumentationTest.java
@@ -10,10 +10,7 @@ import com.birca.bircabackend.command.auth.application.token.JwtTokenProvider;
 import com.birca.bircabackend.command.member.application.MemberService;
 import com.birca.bircabackend.common.exception.ErrorCode;
 import com.birca.bircabackend.common.log.TimeLogTemplate;
-import com.birca.bircabackend.query.service.ArtistGroupQueryService;
-import com.birca.bircabackend.query.service.ArtistQueryService;
-import com.birca.bircabackend.query.service.FavoriteArtistQueryService;
-import com.birca.bircabackend.query.service.MemberQueryService;
+import com.birca.bircabackend.query.service.*;
 import com.birca.bircabackend.support.TestBearerTokenProvider;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -89,6 +86,9 @@ public class DocumentationTest {
 
     @MockBean
     protected FavoriteArtistQueryService favoriteArtistQueryService;
+
+    @MockBean
+    protected InterestArtistQueryService interestArtistQueryService;
 
     protected List<FieldDescriptor> getErrorDescriptor(ErrorCode[] errorCodes) {
         return Arrays.stream(errorCodes)

--- a/src/test/resources/fixture/favorite-artist-fixture.sql
+++ b/src/test/resources/fixture/favorite-artist-fixture.sql
@@ -1,0 +1,15 @@
+INSERT INTO member (id, nickname, email, social_id, social_provider, member_role)
+VALUES (1, '더즈', 'ldk@gmail.com', '231323', 'kakao', 'VISITANT');
+
+INSERT INTO artist_group (id, name, image_url)
+VALUES (5, '뉴진스', 'image5.com');
+
+INSERT INTO artist (id, group_id, name, image_url)
+VALUES (8, 5, '하니', 'image8.com'),
+       (9, 5, '해린', 'image9.com'),
+       (10, 5, '민지', 'image10.com'),
+       (11, 5, '다니엘', 'image11.com'),
+       (12, 5, '혜인', 'image12.com');
+
+INSERT INTO favorite_artist (id, fan_id, artist_id)
+VALUES (1, 1, 10);

--- a/src/test/resources/fixture/favorite-artist-fixture.sql
+++ b/src/test/resources/fixture/favorite-artist-fixture.sql
@@ -1,6 +1,9 @@
 INSERT INTO member (id, nickname, email, social_id, social_provider, member_role)
 VALUES (1, '더즈', 'ldk@gmail.com', '231323', 'kakao', 'VISITANT');
 
+INSERT INTO member (id, nickname, email, social_id, social_provider, member_role)
+VALUES (2, '민혁', 'alsgur@gmail.com', '543194', 'kakao', 'VISITANT');
+
 INSERT INTO artist_group (id, name, image_url)
 VALUES (5, '뉴진스', 'image5.com');
 

--- a/src/test/resources/fixture/interest-artist-fixture.sql
+++ b/src/test/resources/fixture/interest-artist-fixture.sql
@@ -1,0 +1,19 @@
+INSERT INTO member (id, nickname, email, social_id, social_provider, member_role)
+VALUES (1, '더즈', 'ldk@gmail.com', '231323', 'kakao', 'VISITANT');
+
+INSERT INTO artist_group (id, name, image_url)
+VALUES (5, '뉴진스', 'image5.com');
+
+INSERT INTO artist (id, group_id, name, image_url)
+VALUES (8, 5, '하니', 'image8.com'),
+       (9, 5, '해린', 'image9.com'),
+       (10, 5, '민지', 'image10.com'),
+       (11, 5, '다니엘', 'image11.com'),
+       (12, 5, '혜인', 'image12.com');
+
+INSERT INTO interest_artist (id, fan_id, artist_id)
+VALUES (1, 1, 8),
+       (2, 1, 9),
+       (3, 1, 10),
+       (4, 1, 11),
+       (5, 1, 12);


### PR DESCRIPTION
## 🌍 이슈 번호
* closed #43 

## 📝 구현 내용
* 최애/관심 아티스트 조회

## 🍀 확인해야 할 부분
최애/관심 아티스트 반환 dto를 모두 기존에 있던 `ArtistResponse` 를 사용했는데, 개별로 dto를 생성하는게 좋을까요?

아시겠지만 온보딩에서 최애/관심 아티스트는 나중에 선택할 수 있어서, 최애 아티스트의 경우 조회 시 값이 없을 때 null을 반환했는데 더 좋은 방법이 있다면 말씀해주세요 ~