### PR TITLE
[FEAT] 생일 카페 상태 변경 구현 (특전 재고, 혼잡, 공개도)

### DIFF
--- a/src/docs/asciidoc/api.adoc
+++ b/src/docs/asciidoc/api.adoc
@@ -56,5 +56,7 @@ include::{snippets}/business-license-error-Code/response-body.adoc[]
 operation::register-birthday-cafe[snippets='http-request,request-fields,http-response']
 === 생일 카페 대관 신청 취소
 operation::cancel-birthday-cafe[snippets='http-request,path-parameters,http-response']
+=== 생일 카페 상태 변경
+operation::birthday-cafe-state-update[snippets='http-request,request-fields,path-parameters,http-response']
 === 에러 코드
 include::{snippets}/birthday-cafe-error-Code/response-body.adoc[]

--- a/src/docs/asciidoc/api.adoc
+++ b/src/docs/asciidoc/api.adoc
@@ -34,8 +34,6 @@ operation::get-artists-solo[snippets='http-request,query-parameters,http-respons
 operation::register-favorite-artist[snippets='http-request,request-fields,http-response']
 === 관심 아티스트 등록
 operation::register-interest-artist[snippets='http-request,request-fields,http-response']
-=== 에러 코드
-include::{snippets}/artist-error-Code/response-body.adoc[]
 
 === 최애 아티스트 조회
 operation::get-favorite-artist[snippets='http-request,http-response,response-fields']
@@ -44,6 +42,8 @@ operation::get-interest-artists[snippets='http-request,http-response,response-fi
 
 === 아티스트 검색
 operation::search-artist[snippets='http-request,http-response']
+=== 에러 코드
+include::{snippets}/artist-error-Code/response-body.adoc[]
 
 == 사업자등록증 API
 === 사업자등록증 스캔

--- a/src/main/java/com/birca/bircabackend/command/birca/application/BirthdayCafeService.java
+++ b/src/main/java/com/birca/bircabackend/command/birca/application/BirthdayCafeService.java
@@ -3,11 +3,9 @@ package com.birca.bircabackend.command.birca.application;
 import com.birca.bircabackend.command.auth.authorization.LoginMember;
 import com.birca.bircabackend.command.birca.domain.BirthdayCafe;
 import com.birca.bircabackend.command.birca.domain.BirthdayCafeRepository;
-import com.birca.bircabackend.command.birca.domain.value.PhoneNumber;
-import com.birca.bircabackend.command.birca.domain.value.ProgressState;
-import com.birca.bircabackend.command.birca.domain.value.Schedule;
-import com.birca.bircabackend.command.birca.domain.value.Visitants;
+import com.birca.bircabackend.command.birca.domain.value.*;
 import com.birca.bircabackend.command.birca.dto.ApplyRentalRequest;
+import com.birca.bircabackend.command.birca.dto.StateChangeRequest;
 import com.birca.bircabackend.common.EntityUtil;
 import com.birca.bircabackend.common.exception.BusinessException;
 import lombok.RequiredArgsConstructor;
@@ -55,7 +53,21 @@ public class BirthdayCafeService {
         birthdayCafe.cancelRental(loginMember.id());
     }
 
-    public void changeState(Long birthdayCafeId, String stateName, LoginMember loginMember) {
+    public void changeSpecialGoodsStockState(Long birthdayCafeId, LoginMember loginMember, StateChangeRequest request) {
         BirthdayCafe birthdayCafe = entityUtil.getEntity(BirthdayCafe.class, birthdayCafeId, NOT_FOUND);
+        SpecialGoodsStockState state = SpecialGoodsStockState.valueOf(request.state());
+        birthdayCafe.changeState(state, loginMember.id());
+    }
+
+    public void changeCongestionState(Long birthdayCafeId, LoginMember loginMember, StateChangeRequest request) {
+        BirthdayCafe birthdayCafe = entityUtil.getEntity(BirthdayCafe.class, birthdayCafeId, NOT_FOUND);
+        CongestionState state = CongestionState.valueOf(request.state());
+        birthdayCafe.changeState(state, loginMember.id());
+    }
+
+    public void changeVisibility(Long birthdayCafeId, LoginMember loginMember, StateChangeRequest request) {
+        BirthdayCafe birthdayCafe = entityUtil.getEntity(BirthdayCafe.class, birthdayCafeId, NOT_FOUND);
+        Visibility state = Visibility.valueOf(request.state());
+        birthdayCafe.changeState(state, loginMember.id());
     }
 }

--- a/src/main/java/com/birca/bircabackend/command/birca/application/BirthdayCafeService.java
+++ b/src/main/java/com/birca/bircabackend/command/birca/application/BirthdayCafeService.java
@@ -54,4 +54,8 @@ public class BirthdayCafeService {
         BirthdayCafe birthdayCafe = entityUtil.getEntity(BirthdayCafe.class, birthdayCafeId, NOT_FOUND);
         birthdayCafe.cancelRental(loginMember.id());
     }
+
+    public void changeState(Long birthdayCafeId, String stateName, LoginMember loginMember) {
+
+    }
 }

--- a/src/main/java/com/birca/bircabackend/command/birca/application/BirthdayCafeService.java
+++ b/src/main/java/com/birca/bircabackend/command/birca/application/BirthdayCafeService.java
@@ -56,6 +56,6 @@ public class BirthdayCafeService {
     }
 
     public void changeState(Long birthdayCafeId, String stateName, LoginMember loginMember) {
-
+        BirthdayCafe birthdayCafe = entityUtil.getEntity(BirthdayCafe.class, birthdayCafeId, NOT_FOUND);
     }
 }

--- a/src/main/java/com/birca/bircabackend/command/birca/domain/BirthdayCafe.java
+++ b/src/main/java/com/birca/bircabackend/command/birca/domain/BirthdayCafe.java
@@ -90,19 +90,19 @@ public class BirthdayCafe extends BaseEntity {
         progressState = ProgressState.RENTAL_CANCELED;
     }
 
-    public void changeSpecialGoodsStockState(SpecialGoodsStockState state, Long memberId) {
+    public void changeState(SpecialGoodsStockState state, Long memberId) {
         validateIsHost(memberId);
         validateIsInProgressState();
         this.specialGoodsStockState = state;
     }
 
-    public void changeCongestionState(CongestionState state, Long memberId) {
+    public void changeState(CongestionState state, Long memberId) {
         validateIsHost(memberId);
         validateIsInProgressState();
         this.congestionState = state;
     }
 
-    public void changeVisibility(Visibility visibility, Long memberId) {
+    public void changeState(Visibility visibility, Long memberId) {
         validateIsHost(memberId);
         if (progressState.isRentalPending()) {
             throw BusinessException.from(INVALID_STATE_CHANGE);

--- a/src/main/java/com/birca/bircabackend/command/birca/domain/BirthdayCafe.java
+++ b/src/main/java/com/birca/bircabackend/command/birca/domain/BirthdayCafe.java
@@ -9,8 +9,7 @@ import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
-import static com.birca.bircabackend.command.birca.exception.BirthdayCafeErrorCode.INVALID_CANCEL_RENTAL;
-import static com.birca.bircabackend.command.birca.exception.BirthdayCafeErrorCode.UNAUTHORIZED_CANCEL;
+import static com.birca.bircabackend.command.birca.exception.BirthdayCafeErrorCode.*;
 
 @Entity
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
@@ -85,13 +84,27 @@ public class BirthdayCafe extends BaseEntity {
         if (!progressState.isRentalPending()) {
             throw BusinessException.from(INVALID_CANCEL_RENTAL);
         }
-        if (!isAuthorizedMember(memberId)) {
+        if (!(isHost(memberId) || isOwner(memberId))) {
             throw BusinessException.from(UNAUTHORIZED_CANCEL);
         }
         progressState = ProgressState.RENTAL_CANCELED;
     }
 
-    private boolean isAuthorizedMember(Long memberId) {
-        return memberId.equals(hostId) || memberId.equals(cafeOwnerId);
+    public void changeSpecialGoodsStockState(SpecialGoodsStockState state, Long memberId) {
+        if (progressState != ProgressState.IN_PROGRESS) {
+            throw BusinessException.from(INVALID_STATE_CHANGE);
+        }
+        if (!isHost(memberId)) {
+            throw BusinessException.from(UNAUTHORIZED_STATE_CHANGE);
+        }
+        this.specialGoodsStockState = state;
+    }
+
+    private boolean isOwner(Long memberId) {
+        return memberId.equals(cafeOwnerId);
+    }
+
+    private boolean isHost(Long memberId) {
+        return memberId.equals(hostId);
     }
 }

--- a/src/main/java/com/birca/bircabackend/command/birca/domain/BirthdayCafe.java
+++ b/src/main/java/com/birca/bircabackend/command/birca/domain/BirthdayCafe.java
@@ -91,15 +91,23 @@ public class BirthdayCafe extends BaseEntity {
     }
 
     public void changeSpecialGoodsStockState(SpecialGoodsStockState state, Long memberId) {
-        validateIsInProgressState();
         validateIsHost(memberId);
+        validateIsInProgressState();
         this.specialGoodsStockState = state;
     }
 
     public void changeCongestionState(CongestionState state, Long memberId) {
-        validateIsInProgressState();
         validateIsHost(memberId);
+        validateIsInProgressState();
         this.congestionState = state;
+    }
+
+    public void changeVisibility(Visibility visibility, Long memberId) {
+        validateIsHost(memberId);
+        if (progressState.isRentalPending()) {
+            throw BusinessException.from(INVALID_STATE_CHANGE);
+        }
+        this.visibility = visibility;
     }
 
     private void validateIsInProgressState() {

--- a/src/main/java/com/birca/bircabackend/command/birca/domain/BirthdayCafe.java
+++ b/src/main/java/com/birca/bircabackend/command/birca/domain/BirthdayCafe.java
@@ -91,13 +91,27 @@ public class BirthdayCafe extends BaseEntity {
     }
 
     public void changeSpecialGoodsStockState(SpecialGoodsStockState state, Long memberId) {
+        validateIsInProgressState();
+        validateIsHost(memberId);
+        this.specialGoodsStockState = state;
+    }
+
+    public void changeCongestionState(CongestionState state, Long memberId) {
+        validateIsInProgressState();
+        validateIsHost(memberId);
+        this.congestionState = state;
+    }
+
+    private void validateIsInProgressState() {
         if (progressState != ProgressState.IN_PROGRESS) {
             throw BusinessException.from(INVALID_STATE_CHANGE);
         }
+    }
+
+    private void validateIsHost(Long memberId) {
         if (!isHost(memberId)) {
             throw BusinessException.from(UNAUTHORIZED_STATE_CHANGE);
         }
-        this.specialGoodsStockState = state;
     }
 
     private boolean isOwner(Long memberId) {

--- a/src/main/java/com/birca/bircabackend/command/birca/dto/StateChangeRequest.java
+++ b/src/main/java/com/birca/bircabackend/command/birca/dto/StateChangeRequest.java
@@ -1,0 +1,4 @@
+package com.birca.bircabackend.command.birca.dto;
+
+public record StateChangeRequest(String state) {
+}

--- a/src/main/java/com/birca/bircabackend/command/birca/exception/BirthdayCafeErrorCode.java
+++ b/src/main/java/com/birca/bircabackend/command/birca/exception/BirthdayCafeErrorCode.java
@@ -15,7 +15,9 @@ public enum BirthdayCafeErrorCode implements ErrorCode {
     INVALID_PHONE_NUMBER(5004, 400, "올바르지 않은 연락처 형식입니다."),
     INVALID_CANCEL_RENTAL(5005, 400, "대관 대기 상태에서만 취소할 수 있습니다."),
     NOT_FOUND(5006, 404, "존재하지 않는 생일 카페입니다."),
-    UNAUTHORIZED_CANCEL(5007, 400, "대관 취소 권한이 없는 회원입니다.")
+    UNAUTHORIZED_CANCEL(5007, 400, "대관 취소 권한이 없는 회원입니다."),
+    INVALID_STATE_CHANGE(5008, 400, "현재 상태로는 해당 상태를 변경할 수 없습니다."),
+    UNAUTHORIZED_STATE_CHANGE(5009, 400, "상태 변경 권한이 없는 회원입니다.")
 
     ;
 

--- a/src/main/java/com/birca/bircabackend/command/birca/presentation/BirthdayCafeController.java
+++ b/src/main/java/com/birca/bircabackend/command/birca/presentation/BirthdayCafeController.java
@@ -29,4 +29,13 @@ public class BirthdayCafeController {
         birthdayCafeService.cancelRental(birthdayCafeId, loginMember);
         return ResponseEntity.ok().build();
     }
+
+    @PatchMapping("/v1/birthday-cafes/{birthdayCafeId}/{stateName}")
+    @RequiredLogin
+    public ResponseEntity<Void> changeState(@PathVariable Long birthdayCafeId,
+                                            @PathVariable String stateName,
+                                            LoginMember loginMember) {
+        birthdayCafeService.changeState(birthdayCafeId, stateName, loginMember);
+        return ResponseEntity.ok().build();
+    }
 }

--- a/src/main/java/com/birca/bircabackend/command/birca/presentation/BirthdayCafeController.java
+++ b/src/main/java/com/birca/bircabackend/command/birca/presentation/BirthdayCafeController.java
@@ -4,6 +4,7 @@ import com.birca.bircabackend.command.auth.authorization.LoginMember;
 import com.birca.bircabackend.command.auth.authorization.RequiredLogin;
 import com.birca.bircabackend.command.birca.application.BirthdayCafeService;
 import com.birca.bircabackend.command.birca.dto.ApplyRentalRequest;
+import com.birca.bircabackend.command.birca.dto.StateChangeRequest;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
@@ -30,12 +31,30 @@ public class BirthdayCafeController {
         return ResponseEntity.ok().build();
     }
 
-    @PatchMapping("/v1/birthday-cafes/{birthdayCafeId}/{stateName}")
+    @PatchMapping("/v1/birthday-cafes/{birthdayCafeId}/specialGoods")
     @RequiredLogin
-    public ResponseEntity<Void> changeState(@PathVariable Long birthdayCafeId,
-                                            @PathVariable String stateName,
-                                            LoginMember loginMember) {
-        birthdayCafeService.changeState(birthdayCafeId, stateName, loginMember);
+    public ResponseEntity<Void> changeSpecialGoodsStockState(@PathVariable Long birthdayCafeId,
+                                                             LoginMember loginMember,
+                                                             @RequestBody StateChangeRequest request) {
+        birthdayCafeService.changeSpecialGoodsStockState(birthdayCafeId, loginMember, request);
+        return ResponseEntity.ok().build();
+    }
+
+    @PatchMapping("/v1/birthday-cafes/{birthdayCafeId}/congestion")
+    @RequiredLogin
+    public ResponseEntity<Void> changeCongestionState(@PathVariable Long birthdayCafeId,
+                                                      LoginMember loginMember,
+                                                      @RequestBody StateChangeRequest request) {
+        birthdayCafeService.changeCongestionState(birthdayCafeId, loginMember, request);
+        return ResponseEntity.ok().build();
+    }
+
+    @PatchMapping("/v1/birthday-cafes/{birthdayCafeId}/visibility")
+    @RequiredLogin
+    public ResponseEntity<Void> changeVisibilityState(@PathVariable Long birthdayCafeId,
+                                                      LoginMember loginMember,
+                                                      @RequestBody StateChangeRequest request) {
+        birthdayCafeService.changeVisibility(birthdayCafeId, loginMember, request);
         return ResponseEntity.ok().build();
     }
 }

--- a/src/main/resources/static/docs/api.html
+++ b/src/main/resources/static/docs/api.html
@@ -468,10 +468,10 @@ body.book #toc,body.book #preamble,body.book h1.sect0,body.book .sect1>h2{page-b
 <li><a href="#_솔로_아티스트_목록_조회">솔로 아티스트 목록 조회</a></li>
 <li><a href="#_최애_아티스트_등록">최애 아티스트 등록</a></li>
 <li><a href="#_관심_아티스트_등록">관심 아티스트 등록</a></li>
-<li><a href="#_에러_코드_3">에러 코드</a></li>
 <li><a href="#_최애_아티스트_조회">최애 아티스트 조회</a></li>
 <li><a href="#_관심_아티스트_조회">관심 아티스트 조회</a></li>
 <li><a href="#_아티스트_검색">아티스트 검색</a></li>
+<li><a href="#_에러_코드_3">에러 코드</a></li>
 </ul>
 </li>
 <li><a href="#_사업자등록증_api">사업자등록증 API</a>
@@ -485,6 +485,7 @@ body.book #toc,body.book #preamble,body.book h1.sect0,body.book .sect1>h2{page-b
 <ul class="sectlevel2">
 <li><a href="#_생일_카페_대관_신청">생일 카페 대관 신청</a></li>
 <li><a href="#_생일_카페_대관_신청_취소">생일 카페 대관 신청 취소</a></li>
+<li><a href="#_생일_카페_상태_변경">생일 카페 상태 변경</a></li>
 <li><a href="#_생일_카페_찜하기">생일 카페 찜하기</a></li>
 <li><a href="#_생일_카페_찜하기_취소">생일 카페 찜하기 취소</a></li>
 <li><a href="#_에러_코드_5">에러 코드</a></li>
@@ -629,7 +630,7 @@ Content-Length: 97
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">POST /api/v1/members/role-change HTTP/1.1
 Content-Type: application/json;charset=UTF-8
-Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwiaWF0IjoxNzA5MzcwMTQ3LCJleHAiOjE3MDkzNzE5NDd9.eJQZ-0XwAGX7Lr0r1HOnFbrVTxEJ9XZc9nHTlNDtZ7o
+Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwiaWF0IjoxNzA5NDQxOTE0LCJleHAiOjE3MDk0NDM3MTR9.ieb0JLOefTRU1JciixwoYyb_-3SOUjUygyRMpPt139o
 Content-Length: 21
 Host: www.api.birca.com
 
@@ -659,7 +660,7 @@ Vary: Access-Control-Request-Headers</code></pre>
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">GET /api/v1/join/check-nickname?nickname=does HTTP/1.1
 Content-Type: application/json;charset=UTF-8
-Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwiaWF0IjoxNzA5MzcwMTQ5LCJleHAiOjE3MDkzNzE5NDl9.rZOP7ZLLju7YR9euBCb7eXonkgYrKoIW2hGpYNOrM4Y
+Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwiaWF0IjoxNzA5NDQxOTE2LCJleHAiOjE3MDk0NDM3MTZ9.-5Jk8xp0qBJj1EfERon-HLv__ftRcn8emElICnH85is
 Host: www.api.birca.com</code></pre>
 </div>
 </div>
@@ -733,7 +734,7 @@ Content-Length: 16
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">POST /api/v1/join/register-nickname HTTP/1.1
 Content-Type: application/json;charset=UTF-8
-Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwiaWF0IjoxNzA5MzcwMTQ3LCJleHAiOjE3MDkzNzE5NDd9.eJQZ-0XwAGX7Lr0r1HOnFbrVTxEJ9XZc9nHTlNDtZ7o
+Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwiaWF0IjoxNzA5NDQxOTE0LCJleHAiOjE3MDk0NDM3MTR9.ieb0JLOefTRU1JciixwoYyb_-3SOUjUygyRMpPt139o
 Content-Length: 30
 Host: www.api.birca.com
 
@@ -821,7 +822,7 @@ Vary: Access-Control-Request-Headers</code></pre>
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">GET /api/v1/artist-groups?cursor=10&amp;size=3 HTTP/1.1
 Content-Type: application/json;charset=UTF-8
-Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwiaWF0IjoxNzA5MzcwMTQ5LCJleHAiOjE3MDkzNzE5NDl9.rZOP7ZLLju7YR9euBCb7eXonkgYrKoIW2hGpYNOrM4Y
+Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwiaWF0IjoxNzA5NDQxOTE2LCJleHAiOjE3MDk0NDM3MTZ9.-5Jk8xp0qBJj1EfERon-HLv__ftRcn8emElICnH85is
 Host: www.api.birca.com</code></pre>
 </div>
 </div>
@@ -921,7 +922,7 @@ Content-Length: 250
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">GET /api/v1/artist-groups/1/artists HTTP/1.1
 Content-Type: application/json;charset=UTF-8
-Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwiaWF0IjoxNzA5MzcwMTQ5LCJleHAiOjE3MDkzNzE5NDl9.rZOP7ZLLju7YR9euBCb7eXonkgYrKoIW2hGpYNOrM4Y
+Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwiaWF0IjoxNzA5NDQxOTE2LCJleHAiOjE3MDk0NDM3MTZ9.-5Jk8xp0qBJj1EfERon-HLv__ftRcn8emElICnH85is
 Host: www.api.birca.com</code></pre>
 </div>
 </div>
@@ -1034,7 +1035,7 @@ Content-Length: 565
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">GET /api/v1/artists/solo?cursor=12&amp;size=6 HTTP/1.1
 Content-Type: application/json;charset=UTF-8
-Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwiaWF0IjoxNzA5MzcwMTQ5LCJleHAiOjE3MDkzNzE5NDl9.rZOP7ZLLju7YR9euBCb7eXonkgYrKoIW2hGpYNOrM4Y
+Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwiaWF0IjoxNzA5NDQxOTE2LCJleHAiOjE3MDk0NDM3MTZ9.-5Jk8xp0qBJj1EfERon-HLv__ftRcn8emElICnH85is
 Host: www.api.birca.com</code></pre>
 </div>
 </div>
@@ -1146,7 +1147,7 @@ Content-Length: 518
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">POST /api/v1/artists/favorite HTTP/1.1
 Content-Type: application/json;charset=UTF-8
-Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwiaWF0IjoxNzA5MzcwMTQ0LCJleHAiOjE3MDkzNzE5NDR9.jaCDqlMRePcu7DP5Vgy3cCTkX-SB1I9thlfxLHkkoxE
+Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwiaWF0IjoxNzA5NDQxOTEyLCJleHAiOjE3MDk0NDM3MTJ9.ftaQaxhMRNHYm2jbNBr1mMW_wNSlc4oQlFRd78ui9D4
 Content-Length: 20
 Host: www.api.birca.com
 
@@ -1200,7 +1201,7 @@ Vary: Access-Control-Request-Headers</code></pre>
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">POST /api/v1/artists/interest HTTP/1.1
 Content-Type: application/json;charset=UTF-8
-Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwiaWF0IjoxNzA5MzcwMTQ0LCJleHAiOjE3MDkzNzE5NDR9.jaCDqlMRePcu7DP5Vgy3cCTkX-SB1I9thlfxLHkkoxE
+Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwiaWF0IjoxNzA5NDQxOTEyLCJleHAiOjE3MDk0NDM3MTJ9.ftaQaxhMRNHYm2jbNBr1mMW_wNSlc4oQlFRd78ui9D4
 Content-Length: 68
 Host: www.api.birca.com
 
@@ -1251,27 +1252,6 @@ Vary: Access-Control-Request-Headers</code></pre>
 </div>
 </div>
 <div class="sect2">
-<h3 id="_에러_코드_3"><a class="link" href="#_에러_코드_3">에러 코드</a></h3>
-<div class="listingblock">
-<div class="content">
-<pre class="highlightjs highlight nowrap"><code class="language-json hljs" data-lang="json">{
-  "4001" : {
-    "httpStatus" : 400,
-    "message" : "관심 아티스트는 10명까지 등록할 수 있습니다."
-  },
-  "4002" : {
-    "httpStatus" : 404,
-    "message" : "존재하지 않는 아티스트입니다."
-  },
-  "4003" : {
-    "httpStatus" : 400,
-    "message" : "관심 아티스트는 중복으로 등록할 수 없습니다."
-  }
-}</code></pre>
-</div>
-</div>
-</div>
-<div class="sect2">
 <h3 id="_최애_아티스트_조회"><a class="link" href="#_최애_아티스트_조회">최애 아티스트 조회</a></h3>
 <div class="sect3">
 <h4 id="_최애_아티스트_조회_http_request"><a class="link" href="#_최애_아티스트_조회_http_request">HTTP request</a></h4>
@@ -1279,7 +1259,7 @@ Vary: Access-Control-Request-Headers</code></pre>
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">GET /api/v1/artists/favorite HTTP/1.1
 Content-Type: application/json;charset=UTF-8
-Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwiaWF0IjoxNzA5MzcwMTQ5LCJleHAiOjE3MDkzNzE5NDl9.rZOP7ZLLju7YR9euBCb7eXonkgYrKoIW2hGpYNOrM4Y
+Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwiaWF0IjoxNzA5NDQxOTE2LCJleHAiOjE3MDk0NDM3MTZ9.-5Jk8xp0qBJj1EfERon-HLv__ftRcn8emElICnH85is
 Host: www.api.birca.com</code></pre>
 </div>
 </div>
@@ -1346,7 +1326,7 @@ Content-Length: 81
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">GET /api/v1/artists/interest HTTP/1.1
 Content-Type: application/json;charset=UTF-8
-Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwiaWF0IjoxNzA5MzcwMTQ5LCJleHAiOjE3MDkzNzE5NDl9.rZOP7ZLLju7YR9euBCb7eXonkgYrKoIW2hGpYNOrM4Y
+Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwiaWF0IjoxNzA5NDQxOTE2LCJleHAiOjE3MDk0NDM3MTZ9.-5Jk8xp0qBJj1EfERon-HLv__ftRcn8emElICnH85is
 Host: www.api.birca.com</code></pre>
 </div>
 </div>
@@ -1429,7 +1409,7 @@ Content-Length: 416
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">GET /api/v1/artists/search?name=%EB%A7%88%ED%81%AC HTTP/1.1
 Content-Type: application/json;charset=UTF-8
-Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwiaWF0IjoxNzA5MzcwMTQ5LCJleHAiOjE3MDkzNzE5NDl9.rZOP7ZLLju7YR9euBCb7eXonkgYrKoIW2hGpYNOrM4Y
+Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwiaWF0IjoxNzA5NDQxOTE2LCJleHAiOjE3MDk0NDM3MTZ9.-5Jk8xp0qBJj1EfERon-HLv__ftRcn8emElICnH85is
 Host: www.api.birca.com</code></pre>
 </div>
 </div>
@@ -1460,6 +1440,27 @@ Content-Length: 225
 </div>
 </div>
 </div>
+<div class="sect2">
+<h3 id="_에러_코드_3"><a class="link" href="#_에러_코드_3">에러 코드</a></h3>
+<div class="listingblock">
+<div class="content">
+<pre class="highlightjs highlight nowrap"><code class="language-json hljs" data-lang="json">{
+  "4001" : {
+    "httpStatus" : 400,
+    "message" : "관심 아티스트는 10명까지 등록할 수 있습니다."
+  },
+  "4002" : {
+    "httpStatus" : 404,
+    "message" : "존재하지 않는 아티스트입니다."
+  },
+  "4003" : {
+    "httpStatus" : 400,
+    "message" : "관심 아티스트는 중복으로 등록할 수 없습니다."
+  }
+}</code></pre>
+</div>
+</div>
+</div>
 </div>
 </div>
 <div class="sect1">
@@ -1473,7 +1474,7 @@ Content-Length: 225
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">POST /api/v1/cafes/license-read HTTP/1.1
 Content-Type: multipart/form-data;charset=UTF-8; boundary=6o2knFse3p53ty9dmcQvWAIx1zInP11uCfbm
-Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwiaWF0IjoxNzA5MzcwMTQ3LCJleHAiOjE3MDkzNzE5NDd9.eJQZ-0XwAGX7Lr0r1HOnFbrVTxEJ9XZc9nHTlNDtZ7o
+Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwiaWF0IjoxNzA5NDQxOTE0LCJleHAiOjE3MDk0NDM3MTR9.ieb0JLOefTRU1JciixwoYyb_-3SOUjUygyRMpPt139o
 Host: www.api.birca.com
 
 --6o2knFse3p53ty9dmcQvWAIx1zInP11uCfbm
@@ -1559,7 +1560,7 @@ Content-Length: 141
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">POST /api/v1/cafes/apply HTTP/1.1
 Content-Type: multipart/form-data;charset=UTF-8; boundary=6o2knFse3p53ty9dmcQvWAIx1zInP11uCfbm
-Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwiaWF0IjoxNzA5MzcwMTQ3LCJleHAiOjE3MDkzNzE5NDd9.eJQZ-0XwAGX7Lr0r1HOnFbrVTxEJ9XZc9nHTlNDtZ7o
+Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwiaWF0IjoxNzA5NDQxOTE0LCJleHAiOjE3MDk0NDM3MTR9.ieb0JLOefTRU1JciixwoYyb_-3SOUjUygyRMpPt139o
 Host: www.api.birca.com
 
 --6o2knFse3p53ty9dmcQvWAIx1zInP11uCfbm
@@ -1645,7 +1646,7 @@ Vary: Access-Control-Request-Headers</code></pre>
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">POST /api/v1/birthday-cafes HTTP/1.1
 Content-Type: application/json;charset=UTF-8
-Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwiaWF0IjoxNzA5MzcwMTQ1LCJleHAiOjE3MDkzNzE5NDV9.scQ_GWJGWmvma9ervNDUpwOulZ9mfn1TFyWfsBahrMY
+Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwiaWF0IjoxNzA5NDQxOTEzLCJleHAiOjE3MDk0NDM3MTN9.1ft2QhlOPseEgXlFm1h8ZTnutuoH8YnT897un19Fz2M
 Content-Length: 234
 Host: www.api.birca.com
 
@@ -1741,7 +1742,7 @@ Vary: Access-Control-Request-Headers</code></pre>
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">POST /api/v1/birthday-cafes/1/cancel HTTP/1.1
 Content-Type: application/json;charset=UTF-8
-Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwiaWF0IjoxNzA5MzcwMTQ1LCJleHAiOjE3MDkzNzE5NDV9.scQ_GWJGWmvma9ervNDUpwOulZ9mfn1TFyWfsBahrMY
+Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwiaWF0IjoxNzA5NDQxOTEzLCJleHAiOjE3MDk0NDM3MTN9.1ft2QhlOPseEgXlFm1h8ZTnutuoH8YnT897un19Fz2M
 Host: www.api.birca.com</code></pre>
 </div>
 </div>
@@ -1781,6 +1782,86 @@ Vary: Access-Control-Request-Headers</code></pre>
 </div>
 </div>
 <div class="sect2">
+<h3 id="_생일_카페_상태_변경"><a class="link" href="#_생일_카페_상태_변경">생일 카페 상태 변경</a></h3>
+<div class="sect3">
+<h4 id="_생일_카페_상태_변경_http_request"><a class="link" href="#_생일_카페_상태_변경_http_request">HTTP request</a></h4>
+<div class="listingblock">
+<div class="content">
+<pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">PATCH /api/v1/birthday-cafes/1/congestion HTTP/1.1
+Content-Type: application/json;charset=UTF-8
+Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwiaWF0IjoxNzA5NDQxOTEzLCJleHAiOjE3MDk0NDM3MTN9.1ft2QhlOPseEgXlFm1h8ZTnutuoH8YnT897un19Fz2M
+Content-Length: 26
+Host: www.api.birca.com
+
+{
+  "state" : "MODERATE"
+}</code></pre>
+</div>
+</div>
+</div>
+<div class="sect3">
+<h4 id="_생일_카페_상태_변경_request_fields"><a class="link" href="#_생일_카페_상태_변경_request_fields">Request fields</a></h4>
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 33.3333%;">
+<col style="width: 33.3333%;">
+<col style="width: 33.3334%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">Path</th>
+<th class="tableblock halign-left valign-top">Type</th>
+<th class="tableblock halign-left valign-top">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>state</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">변경할 상태 값</p></td>
+</tr>
+</tbody>
+</table>
+</div>
+<div class="sect3">
+<h4 id="_생일_카페_상태_변경_path_parameters"><a class="link" href="#_생일_카페_상태_변경_path_parameters">Path parameters</a></h4>
+<table class="tableblock frame-all grid-all stretch">
+<caption class="title">Table 1. /api/v1/birthday-cafes/{birthdayCafeId}/{stateName}</caption>
+<colgroup>
+<col style="width: 50%;">
+<col style="width: 50%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">Parameter</th>
+<th class="tableblock halign-left valign-top">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>birthdayCafeId</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">취소할 생일 카페 ID</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>stateName</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">변경할 상태 이름 (specialGoods, congestion, visibility)</p></td>
+</tr>
+</tbody>
+</table>
+</div>
+<div class="sect3">
+<h4 id="_생일_카페_상태_변경_http_response"><a class="link" href="#_생일_카페_상태_변경_http_response">HTTP response</a></h4>
+<div class="listingblock">
+<div class="content">
+<pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">HTTP/1.1 200 OK
+Vary: Origin
+Vary: Access-Control-Request-Method
+Vary: Access-Control-Request-Headers</code></pre>
+</div>
+</div>
+</div>
+</div>
+<div class="sect2">
 <h3 id="_생일_카페_찜하기"><a class="link" href="#_생일_카페_찜하기">생일 카페 찜하기</a></h3>
 <div class="sect3">
 <h4 id="_생일_카페_찜하기_http_request"><a class="link" href="#_생일_카페_찜하기_http_request">HTTP request</a></h4>
@@ -1788,7 +1869,7 @@ Vary: Access-Control-Request-Headers</code></pre>
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">POST /api/v1/birthday-cafes/1/like HTTP/1.1
 Content-Type: application/json;charset=UTF-8
-Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwiaWF0IjoxNzA5MzcwMTQxLCJleHAiOjE3MDkzNzE5NDF9.rGGrXzYBSvRbWLnkezWDgng4-MkDm_0NQ2IErwuNRe4
+Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwiaWF0IjoxNzA5NDQxOTEzLCJleHAiOjE3MDk0NDM3MTN9.1ft2QhlOPseEgXlFm1h8ZTnutuoH8YnT897un19Fz2M
 Host: www.api.birca.com</code></pre>
 </div>
 </div>
@@ -1835,7 +1916,7 @@ Vary: Access-Control-Request-Headers</code></pre>
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">DELETE /api/v1/birthday-cafes/1/like HTTP/1.1
 Content-Type: application/json;charset=UTF-8
-Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwiaWF0IjoxNzA5MzcwMTQxLCJleHAiOjE3MDkzNzE5NDF9.rGGrXzYBSvRbWLnkezWDgng4-MkDm_0NQ2IErwuNRe4
+Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwiaWF0IjoxNzA5NDQxOTEzLCJleHAiOjE3MDk0NDM3MTN9.1ft2QhlOPseEgXlFm1h8ZTnutuoH8YnT897un19Fz2M
 Host: www.api.birca.com</code></pre>
 </div>
 </div>
@@ -1879,6 +1960,22 @@ Vary: Access-Control-Request-Headers</code></pre>
 <div class="listingblock">
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-json hljs" data-lang="json">{
+  "5008" : {
+    "httpStatus" : 400,
+    "message" : "대관 대기, 취소 상태에서는 찜하기를할 수 없습니다."
+  },
+  "5009" : {
+    "httpStatus" : 400,
+    "message" : "찜하지 않은 생일 카페는 찜을 취소할 수 없습니다."
+  },
+  "5010" : {
+    "httpStatus" : 400,
+    "message" : "현재 상태로는 해당 상태를 변경할 수 없습니다."
+  },
+  "5011" : {
+    "httpStatus" : 400,
+    "message" : "상태 변경 권한이 없는 회원입니다."
+  },
   "5001" : {
     "httpStatus" : 400,
     "message" : "생일카페 시작일은 종료일 보다 앞일 수 없습니다."
@@ -1924,7 +2021,7 @@ Vary: Access-Control-Request-Headers</code></pre>
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">GET /api/v1/cafes/search?name=%EC%BB%A4%ED%94%BC HTTP/1.1
 Content-Type: application/json;charset=UTF-8
-Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwiaWF0IjoxNzA5MzcwMTQ5LCJleHAiOjE3MDkzNzE5NDl9.rZOP7ZLLju7YR9euBCb7eXonkgYrKoIW2hGpYNOrM4Y
+Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwiaWF0IjoxNzA5NDQxOTE2LCJleHAiOjE3MDk0NDM3MTZ9.-5Jk8xp0qBJj1EfERon-HLv__ftRcn8emElICnH85is
 Host: www.api.birca.com</code></pre>
 </div>
 </div>
@@ -1957,7 +2054,7 @@ Content-Length: 106
 <div id="footer">
 <div id="footer-text">
 Version 0.0.1-SNAPSHOT<br>
-Last updated 2024-03-02 18:02:11 +0900
+Last updated 2024-03-03 13:58:16 +0900
 </div>
 </div>
 <script src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/9.18.3/highlight.min.js"></script>

--- a/src/test/java/com/birca/bircabackend/command/birca/acceptance/BirthdayCafeAcceptanceTest.java
+++ b/src/test/java/com/birca/bircabackend/command/birca/acceptance/BirthdayCafeAcceptanceTest.java
@@ -19,8 +19,11 @@ import static org.assertj.core.api.Assertions.assertThat;
 @Sql("/fixture/birthday-cafe-fixture.sql")
 public class BirthdayCafeAcceptanceTest extends AcceptanceTest {
 
-    private static final Long MEMBER_ID = 1L;
-    private static final ApplyRentalRequest REQUEST = new ApplyRentalRequest(
+    private static final Long HOST_1_ID = 1L;
+    private static final Long HOST_2_ID = 2L;
+    private static final Long RENTAL_PENDING_CAFE = 1L;
+    private static final Long IN_PROGRESS_CAFE = 2L;
+    private static final ApplyRentalRequest APPLY_RENTAL_REQUEST = new ApplyRentalRequest(
             1L,
             1L,
             LocalDateTime.of(2024, 2, 8, 0, 0, 0),
@@ -36,8 +39,8 @@ public class BirthdayCafeAcceptanceTest extends AcceptanceTest {
         // when
         ExtractableResponse<Response> response = RestAssured.given().log().all()
                 .contentType(MediaType.APPLICATION_JSON_VALUE)
-                .header(HttpHeaders.AUTHORIZATION, bearerTokenProvider.getToken(MEMBER_ID))
-                .body(REQUEST)
+                .header(HttpHeaders.AUTHORIZATION, bearerTokenProvider.getToken(HOST_2_ID))
+                .body(APPLY_RENTAL_REQUEST)
                 .post("/api/v1/birthday-cafes")
                 .then().log().all()
                 .extract();
@@ -48,20 +51,11 @@ public class BirthdayCafeAcceptanceTest extends AcceptanceTest {
 
     @Test
     void 생일_카페_대관을_취소한다() {
-        // given
-        RestAssured.given().log().all()
-                .contentType(MediaType.APPLICATION_JSON_VALUE)
-                .header(HttpHeaders.AUTHORIZATION, bearerTokenProvider.getToken(MEMBER_ID))
-                .body(REQUEST)
-                .post("/api/v1/birthday-cafes")
-                .then().log().all()
-                .extract();
-
         // when
         ExtractableResponse<Response> response = RestAssured.given().log().all()
                 .contentType(MediaType.APPLICATION_JSON_VALUE)
-                .header(HttpHeaders.AUTHORIZATION, bearerTokenProvider.getToken(MEMBER_ID))
-                .post("/api/v1/birthday-cafes/{birthdayCafeId}/cancel", 1)
+                .header(HttpHeaders.AUTHORIZATION, bearerTokenProvider.getToken(HOST_1_ID))
+                .post("/api/v1/birthday-cafes/{birthdayCafeId}/cancel", RENTAL_PENDING_CAFE)
                 .then().log().all()
                 .extract();
 
@@ -74,8 +68,8 @@ public class BirthdayCafeAcceptanceTest extends AcceptanceTest {
         // given
         RestAssured.given().log().all()
                 .contentType(MediaType.APPLICATION_JSON_VALUE)
-                .header(HttpHeaders.AUTHORIZATION, bearerTokenProvider.getToken(MEMBER_ID))
-                .body(REQUEST)
+                .header(HttpHeaders.AUTHORIZATION, bearerTokenProvider.getToken(HOST_1_ID))
+                .body(APPLY_RENTAL_REQUEST)
                 .post("/api/v1/birthday-cafes")
                 .then().log().all()
                 .extract();
@@ -85,9 +79,9 @@ public class BirthdayCafeAcceptanceTest extends AcceptanceTest {
         // when
         ExtractableResponse<Response> response = RestAssured.given().log().all()
                 .contentType(MediaType.APPLICATION_JSON_VALUE)
-                .header(HttpHeaders.AUTHORIZATION, bearerTokenProvider.getToken(MEMBER_ID))
+                .header(HttpHeaders.AUTHORIZATION, bearerTokenProvider.getToken(HOST_1_ID))
                 .body(request)
-                .patch("/api/v1/birthday-cafes/{birthdayCafeId}/specialGoods", 1)
+                .patch("/api/v1/birthday-cafes/{birthdayCafeId}/specialGoods", IN_PROGRESS_CAFE)
                 .then().log().all()
                 .extract();
 
@@ -100,8 +94,8 @@ public class BirthdayCafeAcceptanceTest extends AcceptanceTest {
         // given
         RestAssured.given().log().all()
                 .contentType(MediaType.APPLICATION_JSON_VALUE)
-                .header(HttpHeaders.AUTHORIZATION, bearerTokenProvider.getToken(MEMBER_ID))
-                .body(REQUEST)
+                .header(HttpHeaders.AUTHORIZATION, bearerTokenProvider.getToken(HOST_1_ID))
+                .body(APPLY_RENTAL_REQUEST)
                 .post("/api/v1/birthday-cafes")
                 .then().log().all()
                 .extract();
@@ -111,9 +105,9 @@ public class BirthdayCafeAcceptanceTest extends AcceptanceTest {
         // when
         ExtractableResponse<Response> response = RestAssured.given().log().all()
                 .contentType(MediaType.APPLICATION_JSON_VALUE)
-                .header(HttpHeaders.AUTHORIZATION, bearerTokenProvider.getToken(MEMBER_ID))
+                .header(HttpHeaders.AUTHORIZATION, bearerTokenProvider.getToken(HOST_1_ID))
                 .body(request)
-                .patch("/api/v1/birthday-cafes/{birthdayCafeId}/congestion", 1)
+                .patch("/api/v1/birthday-cafes/{birthdayCafeId}/congestion", IN_PROGRESS_CAFE)
                 .then().log().all()
                 .extract();
 
@@ -126,8 +120,8 @@ public class BirthdayCafeAcceptanceTest extends AcceptanceTest {
         // given
         RestAssured.given().log().all()
                 .contentType(MediaType.APPLICATION_JSON_VALUE)
-                .header(HttpHeaders.AUTHORIZATION, bearerTokenProvider.getToken(MEMBER_ID))
-                .body(REQUEST)
+                .header(HttpHeaders.AUTHORIZATION, bearerTokenProvider.getToken(HOST_1_ID))
+                .body(APPLY_RENTAL_REQUEST)
                 .post("/api/v1/birthday-cafes")
                 .then().log().all()
                 .extract();
@@ -137,9 +131,9 @@ public class BirthdayCafeAcceptanceTest extends AcceptanceTest {
         // when
         ExtractableResponse<Response> response = RestAssured.given().log().all()
                 .contentType(MediaType.APPLICATION_JSON_VALUE)
-                .header(HttpHeaders.AUTHORIZATION, bearerTokenProvider.getToken(MEMBER_ID))
+                .header(HttpHeaders.AUTHORIZATION, bearerTokenProvider.getToken(HOST_1_ID))
                 .body(request)
-                .patch("/api/v1/birthday-cafes/{birthdayCafeId}/visibility", 1)
+                .patch("/api/v1/birthday-cafes/{birthdayCafeId}/visibility", IN_PROGRESS_CAFE)
                 .then().log().all()
                 .extract();
 

--- a/src/test/java/com/birca/bircabackend/command/birca/acceptance/BirthdayCafeAcceptanceTest.java
+++ b/src/test/java/com/birca/bircabackend/command/birca/acceptance/BirthdayCafeAcceptanceTest.java
@@ -86,6 +86,7 @@ public class BirthdayCafeAcceptanceTest extends AcceptanceTest {
         ExtractableResponse<Response> response = RestAssured.given().log().all()
                 .contentType(MediaType.APPLICATION_JSON_VALUE)
                 .header(HttpHeaders.AUTHORIZATION, bearerTokenProvider.getToken(MEMBER_ID))
+                .body(request)
                 .patch("/api/v1/birthday-cafes/{birthdayCafeId}/specialGoods", 1)
                 .then().log().all()
                 .extract();
@@ -111,6 +112,7 @@ public class BirthdayCafeAcceptanceTest extends AcceptanceTest {
         ExtractableResponse<Response> response = RestAssured.given().log().all()
                 .contentType(MediaType.APPLICATION_JSON_VALUE)
                 .header(HttpHeaders.AUTHORIZATION, bearerTokenProvider.getToken(MEMBER_ID))
+                .body(request)
                 .patch("/api/v1/birthday-cafes/{birthdayCafeId}/congestion", 1)
                 .then().log().all()
                 .extract();
@@ -136,6 +138,7 @@ public class BirthdayCafeAcceptanceTest extends AcceptanceTest {
         ExtractableResponse<Response> response = RestAssured.given().log().all()
                 .contentType(MediaType.APPLICATION_JSON_VALUE)
                 .header(HttpHeaders.AUTHORIZATION, bearerTokenProvider.getToken(MEMBER_ID))
+                .body(request)
                 .patch("/api/v1/birthday-cafes/{birthdayCafeId}/visibility", 1)
                 .then().log().all()
                 .extract();

--- a/src/test/java/com/birca/bircabackend/command/birca/acceptance/BirthdayCafeAcceptanceTest.java
+++ b/src/test/java/com/birca/bircabackend/command/birca/acceptance/BirthdayCafeAcceptanceTest.java
@@ -1,6 +1,7 @@
 package com.birca.bircabackend.command.birca.acceptance;
 
 import com.birca.bircabackend.command.birca.dto.ApplyRentalRequest;
+import com.birca.bircabackend.command.birca.dto.StateChangeRequest;
 import com.birca.bircabackend.support.enviroment.AcceptanceTest;
 import io.restassured.RestAssured;
 import io.restassured.response.ExtractableResponse;
@@ -61,6 +62,81 @@ public class BirthdayCafeAcceptanceTest extends AcceptanceTest {
                 .contentType(MediaType.APPLICATION_JSON_VALUE)
                 .header(HttpHeaders.AUTHORIZATION, bearerTokenProvider.getToken(MEMBER_ID))
                 .post("/api/v1/birthday-cafes/{birthdayCafeId}/cancel", 1)
+                .then().log().all()
+                .extract();
+
+        // then
+        assertThat(response.statusCode()).isEqualTo(HttpStatus.OK.value());
+    }
+
+    @Test
+    void 생일_카페_특전_상태를_변경한다() {
+        // given
+        RestAssured.given().log().all()
+                .contentType(MediaType.APPLICATION_JSON_VALUE)
+                .header(HttpHeaders.AUTHORIZATION, bearerTokenProvider.getToken(MEMBER_ID))
+                .body(REQUEST)
+                .post("/api/v1/birthday-cafes")
+                .then().log().all()
+                .extract();
+
+        StateChangeRequest request = new StateChangeRequest("SCARCE");
+
+        // when
+        ExtractableResponse<Response> response = RestAssured.given().log().all()
+                .contentType(MediaType.APPLICATION_JSON_VALUE)
+                .header(HttpHeaders.AUTHORIZATION, bearerTokenProvider.getToken(MEMBER_ID))
+                .patch("/api/v1/birthday-cafes/{birthdayCafeId}/specialGoods", 1)
+                .then().log().all()
+                .extract();
+
+        // then
+        assertThat(response.statusCode()).isEqualTo(HttpStatus.OK.value());
+    }
+
+    @Test
+    void 생일_카페_혼잡도_상태를_변경한다() {
+        // given
+        RestAssured.given().log().all()
+                .contentType(MediaType.APPLICATION_JSON_VALUE)
+                .header(HttpHeaders.AUTHORIZATION, bearerTokenProvider.getToken(MEMBER_ID))
+                .body(REQUEST)
+                .post("/api/v1/birthday-cafes")
+                .then().log().all()
+                .extract();
+
+        StateChangeRequest request = new StateChangeRequest("MODERATE");
+
+        // when
+        ExtractableResponse<Response> response = RestAssured.given().log().all()
+                .contentType(MediaType.APPLICATION_JSON_VALUE)
+                .header(HttpHeaders.AUTHORIZATION, bearerTokenProvider.getToken(MEMBER_ID))
+                .patch("/api/v1/birthday-cafes/{birthdayCafeId}/congestion", 1)
+                .then().log().all()
+                .extract();
+
+        // then
+        assertThat(response.statusCode()).isEqualTo(HttpStatus.OK.value());
+    }
+
+    @Test
+    void 생일_카페_공개_상태를_변경한다() {
+        // given
+        RestAssured.given().log().all()
+                .contentType(MediaType.APPLICATION_JSON_VALUE)
+                .header(HttpHeaders.AUTHORIZATION, bearerTokenProvider.getToken(MEMBER_ID))
+                .body(REQUEST)
+                .post("/api/v1/birthday-cafes")
+                .then().log().all()
+                .extract();
+
+        StateChangeRequest request = new StateChangeRequest("PUBLIC");
+
+        // when
+        ExtractableResponse<Response> response = RestAssured.given().log().all()
+                .contentType(MediaType.APPLICATION_JSON_VALUE)
+                .header(HttpHeaders.AUTHORIZATION, bearerTokenProvider.getToken(MEMBER_ID))
+                .patch("/api/v1/birthday-cafes/{birthdayCafeId}/visibility", 1)
                 .then().log().all()
                 .extract();
 

--- a/src/test/java/com/birca/bircabackend/command/birca/domain/BirthdayCafeTest.java
+++ b/src/test/java/com/birca/bircabackend/command/birca/domain/BirthdayCafeTest.java
@@ -131,4 +131,51 @@ class BirthdayCafeTest {
                     .isEqualTo(BirthdayCafeErrorCode.INVALID_CANCEL_RENTAL);
         }
     }
+
+    @Nested
+    @DisplayName("특전 재고 상태 변경은")
+    class SpecialGoodsStateChangeTest {
+
+        @Test
+        void 진행_중인_생일_카페면_가능하다() {
+            // given
+            BirthdayCafe birthdayCafe = new BirthdayCafe(
+                    HOST_ID, ARTIST_ID, CAFE_ID, CAFE_OWNER_ID, SCHEDULE, VISITANTS, TWITTER_ACCOUNT, HOST_PHONE_NUMBER,
+                    ProgressState.IN_PROGRESS, Visibility.PRIVATE, CongestionState.SMOOTH, SpecialGoodsStockState.ABUNDANT);
+
+            // when
+            birthdayCafe.changeSpecialGoodsStockState(SpecialGoodsStockState.SCARCE, HOST_ID);
+
+            // then
+            assertThat(birthdayCafe.getSpecialGoodsStockState()).isEqualTo(SpecialGoodsStockState.SCARCE);
+        }
+
+        @ParameterizedTest
+        @EnumSource(mode = EXCLUDE, names = "IN_PROGRESS")
+        void 진행_중이_아닌_생일_카페면_불가능하다(ProgressState progressState) {
+            // given
+            BirthdayCafe birthdayCafe = new BirthdayCafe(
+                    HOST_ID, ARTIST_ID, CAFE_ID, CAFE_OWNER_ID, SCHEDULE, VISITANTS, TWITTER_ACCOUNT, HOST_PHONE_NUMBER,
+                    progressState, Visibility.PRIVATE, CongestionState.SMOOTH, SpecialGoodsStockState.ABUNDANT);
+
+            // when then
+            assertThatThrownBy(() -> birthdayCafe.changeSpecialGoodsStockState(SpecialGoodsStockState.SCARCE, HOST_ID))
+                    .isInstanceOf(BusinessException.class)
+                    .extracting("errorCode")
+                    .isEqualTo(BirthdayCafeErrorCode.INVALID_STATE_CHANGE);
+        }
+
+        @Test
+        void 주최자만_가능하다() {
+            // given
+            BirthdayCafe birthdayCafe = new BirthdayCafe(
+                    HOST_ID, ARTIST_ID, CAFE_ID, CAFE_OWNER_ID, SCHEDULE, VISITANTS, TWITTER_ACCOUNT, HOST_PHONE_NUMBER,
+                    ProgressState.IN_PROGRESS, Visibility.PRIVATE, CongestionState.SMOOTH, SpecialGoodsStockState.ABUNDANT);
+
+            assertThatThrownBy(() -> birthdayCafe.changeSpecialGoodsStockState(SpecialGoodsStockState.SCARCE, 100L))
+                    .isInstanceOf(BusinessException.class)
+                    .extracting("errorCode")
+                    .isEqualTo(BirthdayCafeErrorCode.UNAUTHORIZED_STATE_CHANGE);
+        }
+    }
 }

--- a/src/test/java/com/birca/bircabackend/command/birca/domain/BirthdayCafeTest.java
+++ b/src/test/java/com/birca/bircabackend/command/birca/domain/BirthdayCafeTest.java
@@ -225,4 +225,52 @@ class BirthdayCafeTest {
                     .isEqualTo(BirthdayCafeErrorCode.UNAUTHORIZED_STATE_CHANGE);
         }
     }
+
+    @Nested
+    @DisplayName("공개 상태 변경은")
+    class VisibilityChangeTest {
+
+        @ParameterizedTest
+        @EnumSource(mode = EXCLUDE, names = "RENTAL_PENDING")
+        void 대관_대기가_아닌_생일_카페면_가능하다(ProgressState progressState) {
+            // given
+            BirthdayCafe birthdayCafe = new BirthdayCafe(
+                    HOST_ID, ARTIST_ID, CAFE_ID, CAFE_OWNER_ID, SCHEDULE, VISITANTS, TWITTER_ACCOUNT, HOST_PHONE_NUMBER,
+                    progressState, Visibility.PRIVATE, CongestionState.SMOOTH, SpecialGoodsStockState.ABUNDANT);
+
+            // when
+            birthdayCafe.changeVisibility(Visibility.PUBLIC, HOST_ID);
+
+            // then
+            assertThat(birthdayCafe.getVisibility()).isEqualTo(Visibility.PUBLIC);
+        }
+
+        @Test
+        void 대관_대기인_생일_카페면_불가능하다() {
+            // given
+            BirthdayCafe birthdayCafe = new BirthdayCafe(
+                    HOST_ID, ARTIST_ID, CAFE_ID, CAFE_OWNER_ID, SCHEDULE, VISITANTS, TWITTER_ACCOUNT, HOST_PHONE_NUMBER,
+                    ProgressState.RENTAL_PENDING, Visibility.PRIVATE, CongestionState.SMOOTH, SpecialGoodsStockState.ABUNDANT);
+
+            // when then
+            assertThatThrownBy(() -> birthdayCafe.changeVisibility(Visibility.PUBLIC, HOST_ID))
+                    .isInstanceOf(BusinessException.class)
+                    .extracting("errorCode")
+                    .isEqualTo(BirthdayCafeErrorCode.INVALID_STATE_CHANGE);
+        }
+
+        @Test
+        void 주최자만_가능하다() {
+            // given
+            BirthdayCafe birthdayCafe = new BirthdayCafe(
+                    HOST_ID, ARTIST_ID, CAFE_ID, CAFE_OWNER_ID, SCHEDULE, VISITANTS, TWITTER_ACCOUNT, HOST_PHONE_NUMBER,
+                    ProgressState.IN_PROGRESS, Visibility.PRIVATE, CongestionState.SMOOTH, SpecialGoodsStockState.ABUNDANT);
+
+            // when then
+            assertThatThrownBy(() -> birthdayCafe.changeVisibility(Visibility.PUBLIC, 100L))
+                    .isInstanceOf(BusinessException.class)
+                    .extracting("errorCode")
+                    .isEqualTo(BirthdayCafeErrorCode.UNAUTHORIZED_STATE_CHANGE);
+        }
+    }
 }

--- a/src/test/java/com/birca/bircabackend/command/birca/domain/BirthdayCafeTest.java
+++ b/src/test/java/com/birca/bircabackend/command/birca/domain/BirthdayCafeTest.java
@@ -178,4 +178,51 @@ class BirthdayCafeTest {
                     .isEqualTo(BirthdayCafeErrorCode.UNAUTHORIZED_STATE_CHANGE);
         }
     }
+
+    @Nested
+    @DisplayName("혼잡도 상태 변경은")
+    class CongestionStateChangeTest {
+        @Test
+        void 진행_중인_생일_카페면_가능하다() {
+            // given
+            BirthdayCafe birthdayCafe = new BirthdayCafe(
+                    HOST_ID, ARTIST_ID, CAFE_ID, CAFE_OWNER_ID, SCHEDULE, VISITANTS, TWITTER_ACCOUNT, HOST_PHONE_NUMBER,
+                    ProgressState.IN_PROGRESS, Visibility.PRIVATE, CongestionState.SMOOTH, SpecialGoodsStockState.ABUNDANT);
+
+            // when
+            birthdayCafe.changeCongestionState(CongestionState.MODERATE, HOST_ID);
+
+            // then
+            assertThat(birthdayCafe.getCongestionState()).isEqualTo(CongestionState.MODERATE);
+        }
+
+        @ParameterizedTest
+        @EnumSource(mode = EXCLUDE, names = "IN_PROGRESS")
+        void 진행_중이_아닌_생일_카페면_불가능하다(ProgressState progressState) {
+            // given
+            BirthdayCafe birthdayCafe = new BirthdayCafe(
+                    HOST_ID, ARTIST_ID, CAFE_ID, CAFE_OWNER_ID, SCHEDULE, VISITANTS, TWITTER_ACCOUNT, HOST_PHONE_NUMBER,
+                    progressState, Visibility.PRIVATE, CongestionState.SMOOTH, SpecialGoodsStockState.ABUNDANT);
+
+            // when then
+            assertThatThrownBy(() -> birthdayCafe.changeCongestionState(CongestionState.MODERATE, HOST_ID))
+                    .isInstanceOf(BusinessException.class)
+                    .extracting("errorCode")
+                    .isEqualTo(BirthdayCafeErrorCode.INVALID_STATE_CHANGE);
+        }
+
+        @Test
+        void 주최자만_가능하다() {
+            // given
+            BirthdayCafe birthdayCafe = new BirthdayCafe(
+                    HOST_ID, ARTIST_ID, CAFE_ID, CAFE_OWNER_ID, SCHEDULE, VISITANTS, TWITTER_ACCOUNT, HOST_PHONE_NUMBER,
+                    ProgressState.IN_PROGRESS, Visibility.PRIVATE, CongestionState.SMOOTH, SpecialGoodsStockState.ABUNDANT);
+
+            // when then
+            assertThatThrownBy(() -> birthdayCafe.changeCongestionState(CongestionState.MODERATE, 100L))
+                    .isInstanceOf(BusinessException.class)
+                    .extracting("errorCode")
+                    .isEqualTo(BirthdayCafeErrorCode.UNAUTHORIZED_STATE_CHANGE);
+        }
+    }
 }

--- a/src/test/java/com/birca/bircabackend/command/birca/domain/BirthdayCafeTest.java
+++ b/src/test/java/com/birca/bircabackend/command/birca/domain/BirthdayCafeTest.java
@@ -144,7 +144,7 @@ class BirthdayCafeTest {
                     ProgressState.IN_PROGRESS, Visibility.PRIVATE, CongestionState.SMOOTH, SpecialGoodsStockState.ABUNDANT);
 
             // when
-            birthdayCafe.changeSpecialGoodsStockState(SpecialGoodsStockState.SCARCE, HOST_ID);
+            birthdayCafe.changeState(SpecialGoodsStockState.SCARCE, HOST_ID);
 
             // then
             assertThat(birthdayCafe.getSpecialGoodsStockState()).isEqualTo(SpecialGoodsStockState.SCARCE);
@@ -159,7 +159,7 @@ class BirthdayCafeTest {
                     progressState, Visibility.PRIVATE, CongestionState.SMOOTH, SpecialGoodsStockState.ABUNDANT);
 
             // when then
-            assertThatThrownBy(() -> birthdayCafe.changeSpecialGoodsStockState(SpecialGoodsStockState.SCARCE, HOST_ID))
+            assertThatThrownBy(() -> birthdayCafe.changeState(SpecialGoodsStockState.SCARCE, HOST_ID))
                     .isInstanceOf(BusinessException.class)
                     .extracting("errorCode")
                     .isEqualTo(BirthdayCafeErrorCode.INVALID_STATE_CHANGE);
@@ -172,7 +172,7 @@ class BirthdayCafeTest {
                     HOST_ID, ARTIST_ID, CAFE_ID, CAFE_OWNER_ID, SCHEDULE, VISITANTS, TWITTER_ACCOUNT, HOST_PHONE_NUMBER,
                     ProgressState.IN_PROGRESS, Visibility.PRIVATE, CongestionState.SMOOTH, SpecialGoodsStockState.ABUNDANT);
 
-            assertThatThrownBy(() -> birthdayCafe.changeSpecialGoodsStockState(SpecialGoodsStockState.SCARCE, 100L))
+            assertThatThrownBy(() -> birthdayCafe.changeState(SpecialGoodsStockState.SCARCE, 100L))
                     .isInstanceOf(BusinessException.class)
                     .extracting("errorCode")
                     .isEqualTo(BirthdayCafeErrorCode.UNAUTHORIZED_STATE_CHANGE);
@@ -190,7 +190,7 @@ class BirthdayCafeTest {
                     ProgressState.IN_PROGRESS, Visibility.PRIVATE, CongestionState.SMOOTH, SpecialGoodsStockState.ABUNDANT);
 
             // when
-            birthdayCafe.changeCongestionState(CongestionState.MODERATE, HOST_ID);
+            birthdayCafe.changeState(CongestionState.MODERATE, HOST_ID);
 
             // then
             assertThat(birthdayCafe.getCongestionState()).isEqualTo(CongestionState.MODERATE);
@@ -205,7 +205,7 @@ class BirthdayCafeTest {
                     progressState, Visibility.PRIVATE, CongestionState.SMOOTH, SpecialGoodsStockState.ABUNDANT);
 
             // when then
-            assertThatThrownBy(() -> birthdayCafe.changeCongestionState(CongestionState.MODERATE, HOST_ID))
+            assertThatThrownBy(() -> birthdayCafe.changeState(CongestionState.MODERATE, HOST_ID))
                     .isInstanceOf(BusinessException.class)
                     .extracting("errorCode")
                     .isEqualTo(BirthdayCafeErrorCode.INVALID_STATE_CHANGE);
@@ -219,7 +219,7 @@ class BirthdayCafeTest {
                     ProgressState.IN_PROGRESS, Visibility.PRIVATE, CongestionState.SMOOTH, SpecialGoodsStockState.ABUNDANT);
 
             // when then
-            assertThatThrownBy(() -> birthdayCafe.changeCongestionState(CongestionState.MODERATE, 100L))
+            assertThatThrownBy(() -> birthdayCafe.changeState(CongestionState.MODERATE, 100L))
                     .isInstanceOf(BusinessException.class)
                     .extracting("errorCode")
                     .isEqualTo(BirthdayCafeErrorCode.UNAUTHORIZED_STATE_CHANGE);
@@ -239,7 +239,7 @@ class BirthdayCafeTest {
                     progressState, Visibility.PRIVATE, CongestionState.SMOOTH, SpecialGoodsStockState.ABUNDANT);
 
             // when
-            birthdayCafe.changeVisibility(Visibility.PUBLIC, HOST_ID);
+            birthdayCafe.changeState(Visibility.PUBLIC, HOST_ID);
 
             // then
             assertThat(birthdayCafe.getVisibility()).isEqualTo(Visibility.PUBLIC);
@@ -253,7 +253,7 @@ class BirthdayCafeTest {
                     ProgressState.RENTAL_PENDING, Visibility.PRIVATE, CongestionState.SMOOTH, SpecialGoodsStockState.ABUNDANT);
 
             // when then
-            assertThatThrownBy(() -> birthdayCafe.changeVisibility(Visibility.PUBLIC, HOST_ID))
+            assertThatThrownBy(() -> birthdayCafe.changeState(Visibility.PUBLIC, HOST_ID))
                     .isInstanceOf(BusinessException.class)
                     .extracting("errorCode")
                     .isEqualTo(BirthdayCafeErrorCode.INVALID_STATE_CHANGE);
@@ -267,7 +267,7 @@ class BirthdayCafeTest {
                     ProgressState.IN_PROGRESS, Visibility.PRIVATE, CongestionState.SMOOTH, SpecialGoodsStockState.ABUNDANT);
 
             // when then
-            assertThatThrownBy(() -> birthdayCafe.changeVisibility(Visibility.PUBLIC, 100L))
+            assertThatThrownBy(() -> birthdayCafe.changeState(Visibility.PUBLIC, 100L))
                     .isInstanceOf(BusinessException.class)
                     .extracting("errorCode")
                     .isEqualTo(BirthdayCafeErrorCode.UNAUTHORIZED_STATE_CHANGE);

--- a/src/test/java/com/birca/bircabackend/command/birca/presentation/BirthdayCafeControllerTest.java
+++ b/src/test/java/com/birca/bircabackend/command/birca/presentation/BirthdayCafeControllerTest.java
@@ -18,7 +18,7 @@ import static org.springframework.restdocs.payload.PayloadDocumentation.*;
 import static org.springframework.restdocs.request.RequestDocumentation.parameterWithName;
 import static org.springframework.restdocs.request.RequestDocumentation.pathParameters;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.patch;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 public class BirthdayCafeControllerTest extends DocumentationTest {

--- a/src/test/java/com/birca/bircabackend/command/birca/presentation/BirthdayCafeControllerTest.java
+++ b/src/test/java/com/birca/bircabackend/command/birca/presentation/BirthdayCafeControllerTest.java
@@ -1,6 +1,7 @@
 package com.birca.bircabackend.command.birca.presentation;
 
 import com.birca.bircabackend.command.birca.dto.ApplyRentalRequest;
+import com.birca.bircabackend.command.birca.dto.StateChangeRequest;
 import com.birca.bircabackend.command.birca.exception.BirthdayCafeErrorCode;
 import com.birca.bircabackend.support.enviroment.DocumentationTest;
 import org.junit.jupiter.api.Test;
@@ -17,6 +18,7 @@ import static org.springframework.restdocs.payload.PayloadDocumentation.*;
 import static org.springframework.restdocs.request.RequestDocumentation.parameterWithName;
 import static org.springframework.restdocs.request.RequestDocumentation.pathParameters;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 public class BirthdayCafeControllerTest extends DocumentationTest {
@@ -76,6 +78,35 @@ public class BirthdayCafeControllerTest extends DocumentationTest {
                 .andDo(document("cancel-birthday-cafe", HOST_INFO, DOCUMENT_RESPONSE,
                         pathParameters(
                                 parameterWithName("birthdayCafeId").description("취소할 생일 카페 ID")
+                        )
+                ));
+    }
+
+    @Test
+    void 생일_카페_상태를_변경한다() throws Exception {
+        // given
+        Long birthdayCafeId = 1L;
+        String stateName = "congestion";
+        StateChangeRequest request = new StateChangeRequest("MODERATE");
+
+        // when
+        ResultActions result = mockMvc.perform(
+                patch("/api/v1/birthday-cafes/{birthdayCafeId}/{stateName}", birthdayCafeId, stateName)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request))
+                        .header(HttpHeaders.AUTHORIZATION, bearerTokenProvider.getToken(MEMBER_ID))
+        );
+
+        // then
+        result.andExpect((status().isOk()))
+                .andDo(document("birthday-cafe-state-update", HOST_INFO, DOCUMENT_RESPONSE,
+                        pathParameters(
+                                parameterWithName("birthdayCafeId").description("취소할 생일 카페 ID"),
+                                parameterWithName("stateName")
+                                        .description("변경할 상태 이름 (specialGoods, congestion, visibility)")
+                        ),
+                        requestFields(
+                                fieldWithPath("state").type(JsonFieldType.STRING).description("변경할 상태 값")
                         )
                 ));
     }

--- a/src/test/java/com/birca/bircabackend/support/ErrorCodeController.java
+++ b/src/test/java/com/birca/bircabackend/support/ErrorCodeController.java
@@ -7,6 +7,7 @@ import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import java.util.Arrays;
+import java.util.Comparator;
 import java.util.Map;
 
 import static java.util.stream.Collectors.toMap;

--- a/src/test/resources/fixture/birthday-cafe-fixture.sql
+++ b/src/test/resources/fixture/birthday-cafe-fixture.sql
@@ -28,4 +28,14 @@ VALUES (2, 2, 4);
 INSERT INTO artist (id, group_id, name, image_url)
 VALUES (1, null, '아이유', 'image1.com');
 
+-- 대관 대기 중 생일 카페
+INSERT INTO birthday_cafe
+    (id, host_id, artist_id, cafe_id, cafe_owner_id, start_date, end_date, minimum_visitant, maximum_visitant, twitter_account, host_phone_number, progress_state, visibility, congestion_state, special_goods_stock_state)
+VALUES (1, 1, 1, 1, 3, '2024-02-08T00:00:00', '2024-02-10T00:00:00', 5, 10, '@ChaseM', '010-0000-0000', 'RENTAL_PENDING', 'PRIVATE', 'SMOOTH', 'ABUNDANT');
+
+-- 진행 중인 생일 카페
+INSERT INTO birthday_cafe
+(id, host_id, artist_id, cafe_id, cafe_owner_id, start_date, end_date, minimum_visitant, maximum_visitant, twitter_account, host_phone_number, progress_state, visibility, congestion_state, special_goods_stock_state)
+VALUES (2, 1, 1, 1, 3, '2024-02-08T00:00:00', '2024-02-10T00:00:00', 5, 10, '@ChaseM', '010-0000-0000', 'IN_PROGRESS', 'PRIVATE', 'SMOOTH', 'ABUNDANT');
+
 SET foreign_key_checks = 1;


### PR DESCRIPTION
## 🌍 이슈 번호
- closed #50 

## 📝 구현 내용
- 특전 재고 상태 변경
- 혼잡 상태 변경
- 공개 상태 변경

## 🍀 확인해야 할 부분
api 문서에는 `/api/v1/birthday-cafes/{birthdayCafeId}/{stateName}`라고 되어 있지만 실제 코드에선 아래처럼 분기가 가능해서 매핑 메서드를 나눠서 구현했습니다

``` java
    @PatchMapping("/v1/birthday-cafes/{birthdayCafeId}/specialGoods")
    @RequiredLogin
    public ResponseEntity<Void> changeSpecialGoodsStockState(@PathVariable Long birthdayCafeId,
                                                             LoginMember loginMember,
                                                             @RequestBody StateChangeRequest request) {
        birthdayCafeService.changeSpecialGoodsStockState(birthdayCafeId, loginMember, request);
        return ResponseEntity.ok().build();
    }

    @PatchMapping("/v1/birthday-cafes/{birthdayCafeId}/congestion")
    @RequiredLogin
    public ResponseEntity<Void> changeCongestionState(@PathVariable Long birthdayCafeId,
                                                      LoginMember loginMember,
                                                      @RequestBody StateChangeRequest request) {
        birthdayCafeService.changeCongestionState(birthdayCafeId, loginMember, request);
        return ResponseEntity.ok().build();
    }

    @PatchMapping("/v1/birthday-cafes/{birthdayCafeId}/visibility")
    @RequiredLogin
    public ResponseEntity<Void> changeVisibilityState(@PathVariable Long birthdayCafeId,
                                                      LoginMember loginMember,
                                                      @RequestBody StateChangeRequest request) {
        birthdayCafeService.changeVisibility(birthdayCafeId, loginMember, request);
        return ResponseEntity.ok().build();
    }
```