### PR TITLE
[FEAT] 생일 카페 특전 등록 기능

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,6 @@ out/
 
 ## QType
 /src/main/generated/
+
+## fixture monkey
+.jqwik-database

--- a/build.gradle
+++ b/build.gradle
@@ -52,6 +52,8 @@ dependencies {
 	testImplementation "org.testcontainers:junit-jupiter:1.19.3"
 	testImplementation "org.testcontainers:mysql:1.19.3"
 
+	testImplementation("com.navercorp.fixturemonkey:fixture-monkey-starter:1.0.0")
+
 	implementation 'io.jsonwebtoken:jjwt-api:0.11.5'
 	runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.11.5'
 	runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.11.5'

--- a/src/docs/asciidoc/api.adoc
+++ b/src/docs/asciidoc/api.adoc
@@ -64,6 +64,8 @@ operation::birthday-cafe-state-update[snippets='http-request,request-fields,path
 operation::like-birthday-cafe[snippets='http-request,path-parameters,http-response']
 === 생일 카페 찜하기 취소
 operation::like-cancel-birthday-cafe[snippets='http-request,path-parameters,http-response']
+=== 생일 카페 특전 등록
+operation::birthday-cafe-special-goods[snippets='http-request,request-fields,path-parameters,http-response']
 === 에러 코드
 include::{snippets}/birthday-cafe-error-Code/response-body.adoc[]
 

--- a/src/main/java/com/birca/bircabackend/command/birca/application/BirthdayCafeMapper.java
+++ b/src/main/java/com/birca/bircabackend/command/birca/application/BirthdayCafeMapper.java
@@ -1,0 +1,32 @@
+package com.birca.bircabackend.command.birca.application;
+
+import com.birca.bircabackend.command.birca.domain.BirthdayCafe;
+import com.birca.bircabackend.command.birca.domain.BirthdayCafeRepository;
+import com.birca.bircabackend.command.birca.domain.value.PhoneNumber;
+import com.birca.bircabackend.command.birca.domain.value.Schedule;
+import com.birca.bircabackend.command.birca.domain.value.Visitants;
+import com.birca.bircabackend.command.birca.dto.ApplyRentalRequest;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+@Component
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+public class BirthdayCafeMapper {
+
+    private final BirthdayCafeRepository birthdayCafeRepository;
+
+    public BirthdayCafe toBirthdayCafe(ApplyRentalRequest request, Long hostId) {
+        return BirthdayCafe.applyRental(
+                hostId,
+                request.artistId(),
+                request.cafeId(),
+                birthdayCafeRepository.findOwnerIdByCafeId(request.cafeId()),
+                Schedule.of(request.startDate(), request.endDate()),
+                Visitants.of(request.minimumVisitant(), request.maximumVisitant()),
+                request.twitterAccount(),
+                PhoneNumber.from(request.hostPhoneNumber())
+        );
+    }
+}

--- a/src/main/java/com/birca/bircabackend/command/birca/application/BirthdayCafeService.java
+++ b/src/main/java/com/birca/bircabackend/command/birca/application/BirthdayCafeService.java
@@ -77,6 +77,10 @@ public class BirthdayCafeService {
     public void registerSpecialGoods(Long birthdayCafeId,
                                      LoginMember loginMember,
                                      List<SpecialGoodsRequest> request) {
-
+        BirthdayCafe birthdayCafe = entityUtil.getEntity(BirthdayCafe.class, birthdayCafeId, NOT_FOUND);
+        List<SpecialGoods> specialGoods = request.stream()
+                .map(req -> new SpecialGoods(req.name(), req.details()))
+                .toList();
+        birthdayCafe.registerSpecialGoods(loginMember.id(), specialGoods);
     }
 }

--- a/src/main/java/com/birca/bircabackend/command/birca/application/BirthdayCafeService.java
+++ b/src/main/java/com/birca/bircabackend/command/birca/application/BirthdayCafeService.java
@@ -62,13 +62,13 @@ public class BirthdayCafeService {
         birthdayCafe.changeState(state, loginMember.id());
     }
 
-    public void registerSpecialGoods(Long birthdayCafeId,
-                                     LoginMember loginMember,
-                                     List<SpecialGoodsRequest> request) {
+    public void replaceSpecialGoods(Long birthdayCafeId,
+                                    LoginMember loginMember,
+                                    List<SpecialGoodsRequest> request) {
         BirthdayCafe birthdayCafe = entityUtil.getEntity(BirthdayCafe.class, birthdayCafeId, NOT_FOUND);
         List<SpecialGoods> specialGoods = request.stream()
                 .map(req -> new SpecialGoods(req.name(), req.details()))
                 .toList();
-        birthdayCafe.registerSpecialGoods(loginMember.id(), specialGoods);
+        birthdayCafe.replaceSpecialGoods(loginMember.id(), specialGoods);
     }
 }

--- a/src/main/java/com/birca/bircabackend/command/birca/application/BirthdayCafeService.java
+++ b/src/main/java/com/birca/bircabackend/command/birca/application/BirthdayCafeService.java
@@ -5,12 +5,15 @@ import com.birca.bircabackend.command.birca.domain.BirthdayCafe;
 import com.birca.bircabackend.command.birca.domain.BirthdayCafeRepository;
 import com.birca.bircabackend.command.birca.domain.value.*;
 import com.birca.bircabackend.command.birca.dto.ApplyRentalRequest;
+import com.birca.bircabackend.command.birca.dto.SpecialGoodsRequest;
 import com.birca.bircabackend.command.birca.dto.StateChangeRequest;
 import com.birca.bircabackend.common.EntityUtil;
 import com.birca.bircabackend.common.exception.BusinessException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
 
 import static com.birca.bircabackend.command.birca.exception.BirthdayCafeErrorCode.*;
 
@@ -69,5 +72,11 @@ public class BirthdayCafeService {
         BirthdayCafe birthdayCafe = entityUtil.getEntity(BirthdayCafe.class, birthdayCafeId, NOT_FOUND);
         Visibility state = Visibility.valueOf(request.state());
         birthdayCafe.changeState(state, loginMember.id());
+    }
+
+    public void registerSpecialGoods(Long birthdayCafeId,
+                                     LoginMember loginMember,
+                                     List<SpecialGoodsRequest> request) {
+
     }
 }

--- a/src/main/java/com/birca/bircabackend/command/birca/application/BirthdayCafeService.java
+++ b/src/main/java/com/birca/bircabackend/command/birca/application/BirthdayCafeService.java
@@ -24,25 +24,13 @@ public class BirthdayCafeService {
 
     private final BirthdayCafeRepository birthdayCafeRepository;
     private final EntityUtil entityUtil;
+    private final BirthdayCafeMapper birthdayCafeMapper;
 
     public void applyRental(ApplyRentalRequest request, LoginMember loginMember) {
         Long hostId = loginMember.id();
         validateRentalPendingExists(hostId);
-        BirthdayCafe birthdayCafe = mapToBirthdayCafe(request, hostId);
+        BirthdayCafe birthdayCafe = birthdayCafeMapper.toBirthdayCafe(request, hostId);
         birthdayCafeRepository.save(birthdayCafe);
-    }
-
-    private BirthdayCafe mapToBirthdayCafe(ApplyRentalRequest request, Long hostId) {
-        return BirthdayCafe.applyRental(
-                hostId,
-                request.artistId(),
-                request.cafeId(),
-                birthdayCafeRepository.findOwnerIdByCafeId(request.cafeId()),
-                Schedule.of(request.startDate(), request.endDate()),
-                Visitants.of(request.minimumVisitant(), request.maximumVisitant()),
-                request.twitterAccount(),
-                PhoneNumber.from(request.hostPhoneNumber())
-        );
     }
 
     private void validateRentalPendingExists(Long hostId) {

--- a/src/main/java/com/birca/bircabackend/command/birca/domain/BirthdayCafe.java
+++ b/src/main/java/com/birca/bircabackend/command/birca/domain/BirthdayCafe.java
@@ -57,7 +57,7 @@ public class BirthdayCafe extends BaseEntity {
     @Enumerated(EnumType.STRING)
     private SpecialGoodsStockState specialGoodsStockState;
 
-    @ElementCollection
+    @ElementCollection(fetch = FetchType.EAGER)
     @CollectionTable(name = "special_goods")
     private List<SpecialGoods> specialGoods = new ArrayList<>();
 

--- a/src/main/java/com/birca/bircabackend/command/birca/domain/BirthdayCafe.java
+++ b/src/main/java/com/birca/bircabackend/command/birca/domain/BirthdayCafe.java
@@ -116,7 +116,7 @@ public class BirthdayCafe extends BaseEntity {
         return new BirthdayCafeLike(this.getId(), visitantId);
     }
 
-    public void registerSpecialGoods(Long memberId, List<SpecialGoods> specialGoods) {
+    public void replaceSpecialGoods(Long memberId, List<SpecialGoods> specialGoods) {
         validateIsHost(memberId);
         if (!progressState.isInProgress() && !progressState.isRentalApproved()) {
             throw BusinessException.from(INVALID_UPDATE);

--- a/src/main/java/com/birca/bircabackend/command/birca/domain/BirthdayCafe.java
+++ b/src/main/java/com/birca/bircabackend/command/birca/domain/BirthdayCafe.java
@@ -14,7 +14,7 @@ import static com.birca.bircabackend.command.birca.exception.BirthdayCafeErrorCo
 @Entity
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
-@Builder(access = AccessLevel.PACKAGE)
+@Builder(access = AccessLevel.PRIVATE)
 @Getter
 public class BirthdayCafe extends BaseEntity {
 

--- a/src/main/java/com/birca/bircabackend/command/birca/domain/BirthdayCafe.java
+++ b/src/main/java/com/birca/bircabackend/command/birca/domain/BirthdayCafe.java
@@ -1,20 +1,20 @@
 package com.birca.bircabackend.command.birca.domain;
 
 import com.birca.bircabackend.command.birca.domain.value.*;
-import com.birca.bircabackend.command.birca.exception.BirthdayCafeErrorCode;
 import com.birca.bircabackend.common.domain.BaseEntity;
 import com.birca.bircabackend.common.exception.BusinessException;
 import jakarta.persistence.*;
-import lombok.AccessLevel;
-import lombok.AllArgsConstructor;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+import lombok.*;
+
+import java.util.ArrayList;
+import java.util.List;
 
 import static com.birca.bircabackend.command.birca.exception.BirthdayCafeErrorCode.*;
 
 @Entity
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-@AllArgsConstructor(access = AccessLevel.PACKAGE)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@Builder(access = AccessLevel.PACKAGE)
 @Getter
 public class BirthdayCafe extends BaseEntity {
 
@@ -57,28 +57,26 @@ public class BirthdayCafe extends BaseEntity {
     @Enumerated(EnumType.STRING)
     private SpecialGoodsStockState specialGoodsStockState;
 
-    public static BirthdayCafe applyRental(Long hostId,
-                                           Long artistId,
-                                           Long cafeId,
-                                           Long cafeOwnerId,
-                                           Schedule schedule,
-                                           Visitants visitants,
-                                           String twitterAccount,
-                                           PhoneNumber hostPhoneNumber) {
-        return new BirthdayCafe(
-                hostId,
-                artistId,
-                cafeId,
-                cafeOwnerId,
-                schedule,
-                visitants,
-                twitterAccount,
-                hostPhoneNumber,
-                ProgressState.RENTAL_PENDING,
-                Visibility.PRIVATE,
-                CongestionState.SMOOTH,
-                SpecialGoodsStockState.ABUNDANT
-        );
+    @ElementCollection
+    @CollectionTable(name = "special_goods")
+    private List<SpecialGoods> specialGoods = new ArrayList<>();
+
+    public static BirthdayCafe applyRental(Long hostId, Long artistId, Long cafeId, Long cafeOwnerId, Schedule schedule,
+                                           Visitants visitants, String twitterAccount, PhoneNumber hostPhoneNumber) {
+        return BirthdayCafe.builder()
+                .hostId(hostId)
+                .artistId(artistId)
+                .cafeId(cafeId)
+                .cafeOwnerId(cafeOwnerId)
+                .schedule(schedule)
+                .visitants(visitants)
+                .twitterAccount(twitterAccount)
+                .hostPhoneNumber(hostPhoneNumber)
+                .progressState(ProgressState.RENTAL_PENDING)
+                .visibility(Visibility.PRIVATE)
+                .congestionState(CongestionState.SMOOTH)
+                .specialGoodsStockState(SpecialGoodsStockState.ABUNDANT)
+                .build();
     }
 
     public void cancelRental(Long memberId) {
@@ -106,20 +104,35 @@ public class BirthdayCafe extends BaseEntity {
     public void changeState(Visibility visibility, Long memberId) {
         validateIsHost(memberId);
         if (progressState.isRentalPending()) {
-            throw BusinessException.from(INVALID_STATE_CHANGE);
+            throw BusinessException.from(INVALID_UPDATE);
         }
         this.visibility = visibility;
     }
 
-    private void validateIsInProgressState() {
-        if (progressState != ProgressState.IN_PROGRESS) {
-            throw BusinessException.from(INVALID_STATE_CHANGE);
+    public BirthdayCafeLike like(Long visitantId) {
+        if (progressState.isRentalPending() || progressState.isRentalCanceled()) {
+            throw BusinessException.from(INVALID_LIKE_REQUEST);
         }
+        return new BirthdayCafeLike(this.getId(), visitantId);
+    }
+
+    public void registerSpecialGoods(Long memberId, List<SpecialGoods> specialGoods) {
+        validateIsHost(memberId);
+        if (!progressState.isInProgress() && !progressState.isRentalApproved()) {
+            throw BusinessException.from(INVALID_UPDATE);
+        }
+        this.specialGoods = specialGoods;
     }
 
     private void validateIsHost(Long memberId) {
         if (!isHost(memberId)) {
-            throw BusinessException.from(UNAUTHORIZED_STATE_CHANGE);
+            throw BusinessException.from(UNAUTHORIZED_UPDATE);
+        }
+    }
+
+    private void validateIsInProgressState() {
+        if (!progressState.isInProgress()) {
+            throw BusinessException.from(INVALID_UPDATE);
         }
     }
 
@@ -129,12 +142,5 @@ public class BirthdayCafe extends BaseEntity {
 
     private boolean isHost(Long memberId) {
         return memberId.equals(hostId);
-    }
-
-    public BirthdayCafeLike like(Long visitantId) {
-        if (progressState.isRentalPending() || progressState.isRentalCanceled()) {
-            throw BusinessException.from(BirthdayCafeErrorCode.INVALID_LIKE_REQUEST);
-        }
-        return new BirthdayCafeLike(this.getId(), visitantId);
     }
 }

--- a/src/main/java/com/birca/bircabackend/command/birca/domain/value/ProgressState.java
+++ b/src/main/java/com/birca/bircabackend/command/birca/domain/value/ProgressState.java
@@ -6,9 +6,7 @@ public enum ProgressState {
     RENTAL_APPROVED,
     RENTAL_CANCELED,
     IN_PROGRESS,
-    FINISHED
-
-    ;
+    FINISHED;
 
     public boolean isRentalPending() {
         return this == RENTAL_PENDING;
@@ -16,5 +14,13 @@ public enum ProgressState {
 
     public boolean isRentalCanceled() {
         return this == RENTAL_CANCELED;
+    }
+
+    public boolean isRentalApproved() {
+        return this == RENTAL_APPROVED;
+    }
+
+    public boolean isInProgress() {
+        return this == IN_PROGRESS;
     }
 }

--- a/src/main/java/com/birca/bircabackend/command/birca/domain/value/SpecialGoods.java
+++ b/src/main/java/com/birca/bircabackend/command/birca/domain/value/SpecialGoods.java
@@ -1,0 +1,26 @@
+package com.birca.bircabackend.command.birca.domain.value;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Embeddable;
+import lombok.AccessLevel;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Embeddable
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
+@EqualsAndHashCode
+public class SpecialGoods {
+
+    @Column(nullable = false)
+    private String name;
+
+    @Column(nullable = false)
+    private String details;
+
+    public SpecialGoods(String name, String details) {
+        this.name = name;
+        this.details = details;
+    }
+}

--- a/src/main/java/com/birca/bircabackend/command/birca/dto/SpecialGoodsRequest.java
+++ b/src/main/java/com/birca/bircabackend/command/birca/dto/SpecialGoodsRequest.java
@@ -1,0 +1,7 @@
+package com.birca.bircabackend.command.birca.dto;
+
+public record SpecialGoodsRequest(
+        String name,
+        String details
+) {
+}

--- a/src/main/java/com/birca/bircabackend/command/birca/exception/BirthdayCafeErrorCode.java
+++ b/src/main/java/com/birca/bircabackend/command/birca/exception/BirthdayCafeErrorCode.java
@@ -18,8 +18,8 @@ public enum BirthdayCafeErrorCode implements ErrorCode {
     UNAUTHORIZED_CANCEL(5007, 400, "대관 취소 권한이 없는 회원입니다."),
     INVALID_LIKE_REQUEST(5008, 400, "대관 대기, 취소 상태에서는 찜하기를할 수 없습니다."),
     CANNOT_CANCEL_LIKE(5009, 400, "찜하지 않은 생일 카페는 찜을 취소할 수 없습니다."),
-    INVALID_STATE_CHANGE(5010, 400, "현재 상태로는 해당 상태를 변경할 수 없습니다."),
-    UNAUTHORIZED_STATE_CHANGE(5011, 400, "상태 변경 권한이 없는 회원입니다.")
+    INVALID_UPDATE(5010, 400, "현재 상태로는 해당 정보를 변경할 수 없습니다."),
+    UNAUTHORIZED_UPDATE(5011, 400, "생일 카페 변경 권한이 없는 회원입니다.")
 
     ;
 

--- a/src/main/java/com/birca/bircabackend/command/birca/presentation/BirthdayCafeController.java
+++ b/src/main/java/com/birca/bircabackend/command/birca/presentation/BirthdayCafeController.java
@@ -63,10 +63,10 @@ public class BirthdayCafeController {
 
     @PostMapping("/v1/birthday-cafes/{birthdayCafeId}/special-goods")
     @RequiredLogin
-    public ResponseEntity<Void> registerSpecialGoods(@PathVariable Long birthdayCafeId,
-                                                      LoginMember loginMember,
-                                                      @RequestBody List<SpecialGoodsRequest> request) {
-        birthdayCafeService.registerSpecialGoods(birthdayCafeId, loginMember, request);
+    public ResponseEntity<Void> replaceSpecialGoods(@PathVariable Long birthdayCafeId,
+                                                    LoginMember loginMember,
+                                                    @RequestBody List<SpecialGoodsRequest> request) {
+        birthdayCafeService.replaceSpecialGoods(birthdayCafeId, loginMember, request);
         return ResponseEntity.ok().build();
     }
 }

--- a/src/main/java/com/birca/bircabackend/command/birca/presentation/BirthdayCafeController.java
+++ b/src/main/java/com/birca/bircabackend/command/birca/presentation/BirthdayCafeController.java
@@ -4,10 +4,13 @@ import com.birca.bircabackend.command.auth.authorization.LoginMember;
 import com.birca.bircabackend.command.auth.authorization.RequiredLogin;
 import com.birca.bircabackend.command.birca.application.BirthdayCafeService;
 import com.birca.bircabackend.command.birca.dto.ApplyRentalRequest;
+import com.birca.bircabackend.command.birca.dto.SpecialGoodsRequest;
 import com.birca.bircabackend.command.birca.dto.StateChangeRequest;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
 
 @RestController
 @RequestMapping("/api")
@@ -55,6 +58,15 @@ public class BirthdayCafeController {
                                                       LoginMember loginMember,
                                                       @RequestBody StateChangeRequest request) {
         birthdayCafeService.changeVisibility(birthdayCafeId, loginMember, request);
+        return ResponseEntity.ok().build();
+    }
+
+    @PostMapping("/v1/birthday-cafes/{birthdayCafeId}/special-goods")
+    @RequiredLogin
+    public ResponseEntity<Void> registerSpecialGoods(@PathVariable Long birthdayCafeId,
+                                                      LoginMember loginMember,
+                                                      @RequestBody List<SpecialGoodsRequest> request) {
+        birthdayCafeService.registerSpecialGoods(birthdayCafeId, loginMember, request);
         return ResponseEntity.ok().build();
     }
 }

--- a/src/main/resources/db/migration/V1__init.sql
+++ b/src/main/resources/db/migration/V1__init.sql
@@ -155,6 +155,16 @@ ALTER TABLE birthday_cafe_like
 ALTER TABLE birthday_cafe_like
     ADD CONSTRAINT uc_birthday_cafe_like_birthday_cafe_visitant UNIQUE (birthday_cafe_id, visitant_id);
 
+CREATE TABLE special_goods
+(
+    birthday_cafe_id BIGINT       NOT NULL,
+    name             VARCHAR(255) NOT NULL,
+    details          VARCHAR(255) NOT NULL
+);
+
+ALTER TABLE special_goods
+    ADD CONSTRAINT fk_special_goods_on_birthday_cafe FOREIGN KEY (birthday_cafe_id) REFERENCES birthday_cafe (id);
+
 CREATE TABLE ocr_request_history
 (
     id           BIGINT AUTO_INCREMENT NOT NULL,

--- a/src/main/resources/static/docs/api.html
+++ b/src/main/resources/static/docs/api.html
@@ -488,6 +488,7 @@ body.book #toc,body.book #preamble,body.book h1.sect0,body.book .sect1>h2{page-b
 <li><a href="#_생일_카페_상태_변경">생일 카페 상태 변경</a></li>
 <li><a href="#_생일_카페_찜하기">생일 카페 찜하기</a></li>
 <li><a href="#_생일_카페_찜하기_취소">생일 카페 찜하기 취소</a></li>
+<li><a href="#_생일_카페_특전_등록">생일 카페 특전 등록</a></li>
 <li><a href="#_에러_코드_5">에러 코드</a></li>
 </ul>
 </li>
@@ -630,7 +631,7 @@ Content-Length: 97
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">POST /api/v1/members/role-change HTTP/1.1
 Content-Type: application/json;charset=UTF-8
-Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwiaWF0IjoxNzA5ODc5ODgxLCJleHAiOjE3MDk4ODE2ODF9.eDoOLk_IH5_3Qo505VZGH2YixWwLvp21hwIEzPmIrx0
+Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwiaWF0IjoxNzA5OTA5NzQ4LCJleHAiOjE3MDk5MTE1NDh9.WMXYn6hRLki4Zo1PDhXUfgC3n2F0beVQA6cEpcTJESY
 Content-Length: 21
 Host: www.api.birca.com
 
@@ -660,7 +661,7 @@ Vary: Access-Control-Request-Headers</code></pre>
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">GET /api/v1/join/check-nickname?nickname=does HTTP/1.1
 Content-Type: application/json;charset=UTF-8
-Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwiaWF0IjoxNzA5ODc5ODg0LCJleHAiOjE3MDk4ODE2ODR9.81_1mtKYA-EI9nSdVeV9OlTxBwDVjuh-ludyB3xr-1s
+Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwiaWF0IjoxNzA5OTA5NzQ5LCJleHAiOjE3MDk5MTE1NDl9.cAix1AUk7xxZcoBgrIok8RG1m1pJDCfFL6HFOqQL_iI
 Host: www.api.birca.com</code></pre>
 </div>
 </div>
@@ -734,7 +735,7 @@ Content-Length: 16
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">POST /api/v1/join/register-nickname HTTP/1.1
 Content-Type: application/json;charset=UTF-8
-Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwiaWF0IjoxNzA5ODc5ODgxLCJleHAiOjE3MDk4ODE2ODF9.eDoOLk_IH5_3Qo505VZGH2YixWwLvp21hwIEzPmIrx0
+Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwiaWF0IjoxNzA5OTA5NzQ4LCJleHAiOjE3MDk5MTE1NDh9.WMXYn6hRLki4Zo1PDhXUfgC3n2F0beVQA6cEpcTJESY
 Content-Length: 30
 Host: www.api.birca.com
 
@@ -822,7 +823,7 @@ Vary: Access-Control-Request-Headers</code></pre>
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">GET /api/v1/artist-groups?cursor=10&amp;size=3 HTTP/1.1
 Content-Type: application/json;charset=UTF-8
-Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwiaWF0IjoxNzA5ODc5ODgzLCJleHAiOjE3MDk4ODE2ODN9.qDmQnzSsXbyKH6AxZeDcvmcbq6FaEk0YpwWTKKaCuL0
+Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwiaWF0IjoxNzA5OTA5NzQ5LCJleHAiOjE3MDk5MTE1NDl9.cAix1AUk7xxZcoBgrIok8RG1m1pJDCfFL6HFOqQL_iI
 Host: www.api.birca.com</code></pre>
 </div>
 </div>
@@ -922,7 +923,7 @@ Content-Length: 250
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">GET /api/v1/artist-groups/1/artists HTTP/1.1
 Content-Type: application/json;charset=UTF-8
-Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwiaWF0IjoxNzA5ODc5ODgzLCJleHAiOjE3MDk4ODE2ODN9.qDmQnzSsXbyKH6AxZeDcvmcbq6FaEk0YpwWTKKaCuL0
+Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwiaWF0IjoxNzA5OTA5NzQ5LCJleHAiOjE3MDk5MTE1NDl9.cAix1AUk7xxZcoBgrIok8RG1m1pJDCfFL6HFOqQL_iI
 Host: www.api.birca.com</code></pre>
 </div>
 </div>
@@ -1035,7 +1036,7 @@ Content-Length: 565
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">GET /api/v1/artists/solo?cursor=12&amp;size=6 HTTP/1.1
 Content-Type: application/json;charset=UTF-8
-Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwiaWF0IjoxNzA5ODc5ODgzLCJleHAiOjE3MDk4ODE2ODN9.qDmQnzSsXbyKH6AxZeDcvmcbq6FaEk0YpwWTKKaCuL0
+Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwiaWF0IjoxNzA5OTA5NzQ5LCJleHAiOjE3MDk5MTE1NDl9.cAix1AUk7xxZcoBgrIok8RG1m1pJDCfFL6HFOqQL_iI
 Host: www.api.birca.com</code></pre>
 </div>
 </div>
@@ -1147,7 +1148,7 @@ Content-Length: 518
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">POST /api/v1/artists/favorite HTTP/1.1
 Content-Type: application/json;charset=UTF-8
-Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwiaWF0IjoxNzA5ODc5ODczLCJleHAiOjE3MDk4ODE2NzN9.PaDmgcYFZcGlbVAZtpz8RsUmJ3ay8MJbnYMarOuOiUg
+Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwiaWF0IjoxNzA5OTA5NzQ1LCJleHAiOjE3MDk5MTE1NDV9.QBj3VepzfpRmO8pP6R3y-mgHb9k4MRrZ93pLHGzz4EQ
 Content-Length: 20
 Host: www.api.birca.com
 
@@ -1201,7 +1202,7 @@ Vary: Access-Control-Request-Headers</code></pre>
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">POST /api/v1/artists/interest HTTP/1.1
 Content-Type: application/json;charset=UTF-8
-Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwiaWF0IjoxNzA5ODc5ODczLCJleHAiOjE3MDk4ODE2NzN9.PaDmgcYFZcGlbVAZtpz8RsUmJ3ay8MJbnYMarOuOiUg
+Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwiaWF0IjoxNzA5OTA5NzQ1LCJleHAiOjE3MDk5MTE1NDV9.QBj3VepzfpRmO8pP6R3y-mgHb9k4MRrZ93pLHGzz4EQ
 Content-Length: 68
 Host: www.api.birca.com
 
@@ -1259,7 +1260,7 @@ Vary: Access-Control-Request-Headers</code></pre>
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">GET /api/v1/artists/favorite HTTP/1.1
 Content-Type: application/json;charset=UTF-8
-Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwiaWF0IjoxNzA5ODc5ODg0LCJleHAiOjE3MDk4ODE2ODR9.81_1mtKYA-EI9nSdVeV9OlTxBwDVjuh-ludyB3xr-1s
+Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwiaWF0IjoxNzA5OTA5NzQ5LCJleHAiOjE3MDk5MTE1NDl9.cAix1AUk7xxZcoBgrIok8RG1m1pJDCfFL6HFOqQL_iI
 Host: www.api.birca.com</code></pre>
 </div>
 </div>
@@ -1326,7 +1327,7 @@ Content-Length: 81
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">GET /api/v1/artists/interest HTTP/1.1
 Content-Type: application/json;charset=UTF-8
-Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwiaWF0IjoxNzA5ODc5ODg0LCJleHAiOjE3MDk4ODE2ODR9.81_1mtKYA-EI9nSdVeV9OlTxBwDVjuh-ludyB3xr-1s
+Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwiaWF0IjoxNzA5OTA5NzQ5LCJleHAiOjE3MDk5MTE1NDl9.cAix1AUk7xxZcoBgrIok8RG1m1pJDCfFL6HFOqQL_iI
 Host: www.api.birca.com</code></pre>
 </div>
 </div>
@@ -1409,7 +1410,7 @@ Content-Length: 416
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">GET /api/v1/artists/search?name=%EB%A7%88%ED%81%AC HTTP/1.1
 Content-Type: application/json;charset=UTF-8
-Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwiaWF0IjoxNzA5ODc5ODgzLCJleHAiOjE3MDk4ODE2ODN9.qDmQnzSsXbyKH6AxZeDcvmcbq6FaEk0YpwWTKKaCuL0
+Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwiaWF0IjoxNzA5OTA5NzQ5LCJleHAiOjE3MDk5MTE1NDl9.cAix1AUk7xxZcoBgrIok8RG1m1pJDCfFL6HFOqQL_iI
 Host: www.api.birca.com</code></pre>
 </div>
 </div>
@@ -1474,7 +1475,7 @@ Content-Length: 225
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">POST /api/v1/cafes/license-read HTTP/1.1
 Content-Type: multipart/form-data;charset=UTF-8; boundary=6o2knFse3p53ty9dmcQvWAIx1zInP11uCfbm
-Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwiaWF0IjoxNzA5ODc5ODgwLCJleHAiOjE3MDk4ODE2ODB9.eZ-uX0Ctc0nKepokTZ2Shke3heUBMfBbKbaXqQRtH5U
+Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwiaWF0IjoxNzA5OTA5NzQ4LCJleHAiOjE3MDk5MTE1NDh9.WMXYn6hRLki4Zo1PDhXUfgC3n2F0beVQA6cEpcTJESY
 Host: www.api.birca.com
 
 --6o2knFse3p53ty9dmcQvWAIx1zInP11uCfbm
@@ -1560,7 +1561,7 @@ Content-Length: 141
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">POST /api/v1/cafes/apply HTTP/1.1
 Content-Type: multipart/form-data;charset=UTF-8; boundary=6o2knFse3p53ty9dmcQvWAIx1zInP11uCfbm
-Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwiaWF0IjoxNzA5ODc5ODgwLCJleHAiOjE3MDk4ODE2ODB9.eZ-uX0Ctc0nKepokTZ2Shke3heUBMfBbKbaXqQRtH5U
+Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwiaWF0IjoxNzA5OTA5NzQ4LCJleHAiOjE3MDk5MTE1NDh9.WMXYn6hRLki4Zo1PDhXUfgC3n2F0beVQA6cEpcTJESY
 Host: www.api.birca.com
 
 --6o2knFse3p53ty9dmcQvWAIx1zInP11uCfbm
@@ -1634,7 +1635,7 @@ Vary: Access-Control-Request-Headers</code></pre>
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">POST /api/v1/birthday-cafes HTTP/1.1
 Content-Type: application/json;charset=UTF-8
-Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwiaWF0IjoxNzA5ODc5ODc2LCJleHAiOjE3MDk4ODE2NzZ9.tXNVFERja1hDaGX-JEIN450Ehn2fxERSo7qor2-w_Ak
+Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwiaWF0IjoxNzA5OTA5NzQ2LCJleHAiOjE3MDk5MTE1NDZ9.9txOSm5sYVKB_GwMK3iYw-sPzT9UO8uUg0Cpk57gdMA
 Content-Length: 234
 Host: www.api.birca.com
 
@@ -1730,7 +1731,7 @@ Vary: Access-Control-Request-Headers</code></pre>
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">POST /api/v1/birthday-cafes/1/cancel HTTP/1.1
 Content-Type: application/json;charset=UTF-8
-Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwiaWF0IjoxNzA5ODc5ODc2LCJleHAiOjE3MDk4ODE2NzZ9.tXNVFERja1hDaGX-JEIN450Ehn2fxERSo7qor2-w_Ak
+Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwiaWF0IjoxNzA5OTA5NzQ2LCJleHAiOjE3MDk5MTE1NDZ9.9txOSm5sYVKB_GwMK3iYw-sPzT9UO8uUg0Cpk57gdMA
 Host: www.api.birca.com</code></pre>
 </div>
 </div>
@@ -1777,7 +1778,7 @@ Vary: Access-Control-Request-Headers</code></pre>
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">PATCH /api/v1/birthday-cafes/1/congestion HTTP/1.1
 Content-Type: application/json;charset=UTF-8
-Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwiaWF0IjoxNzA5ODc5ODc2LCJleHAiOjE3MDk4ODE2NzZ9.tXNVFERja1hDaGX-JEIN450Ehn2fxERSo7qor2-w_Ak
+Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwiaWF0IjoxNzA5OTA5NzQ2LCJleHAiOjE3MDk5MTE1NDZ9.9txOSm5sYVKB_GwMK3iYw-sPzT9UO8uUg0Cpk57gdMA
 Content-Length: 26
 Host: www.api.birca.com
 
@@ -1857,7 +1858,7 @@ Vary: Access-Control-Request-Headers</code></pre>
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">POST /api/v1/birthday-cafes/1/like HTTP/1.1
 Content-Type: application/json;charset=UTF-8
-Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwiaWF0IjoxNzA5ODc5ODc2LCJleHAiOjE3MDk4ODE2NzZ9.tXNVFERja1hDaGX-JEIN450Ehn2fxERSo7qor2-w_Ak
+Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwiaWF0IjoxNzA5OTA5NzQ2LCJleHAiOjE3MDk5MTE1NDZ9.9txOSm5sYVKB_GwMK3iYw-sPzT9UO8uUg0Cpk57gdMA
 Host: www.api.birca.com</code></pre>
 </div>
 </div>
@@ -1904,7 +1905,7 @@ Vary: Access-Control-Request-Headers</code></pre>
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">DELETE /api/v1/birthday-cafes/1/like HTTP/1.1
 Content-Type: application/json;charset=UTF-8
-Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwiaWF0IjoxNzA5ODc5ODc2LCJleHAiOjE3MDk4ODE2NzZ9.tXNVFERja1hDaGX-JEIN450Ehn2fxERSo7qor2-w_Ak
+Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwiaWF0IjoxNzA5OTA5NzQ2LCJleHAiOjE3MDk5MTE1NDZ9.9txOSm5sYVKB_GwMK3iYw-sPzT9UO8uUg0Cpk57gdMA
 Host: www.api.birca.com</code></pre>
 </div>
 </div>
@@ -1933,6 +1934,91 @@ Host: www.api.birca.com</code></pre>
 </div>
 <div class="sect3">
 <h4 id="_생일_카페_찜하기_취소_http_response"><a class="link" href="#_생일_카페_찜하기_취소_http_response">HTTP response</a></h4>
+<div class="listingblock">
+<div class="content">
+<pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">HTTP/1.1 200 OK
+Vary: Origin
+Vary: Access-Control-Request-Method
+Vary: Access-Control-Request-Headers</code></pre>
+</div>
+</div>
+</div>
+</div>
+<div class="sect2">
+<h3 id="_생일_카페_특전_등록"><a class="link" href="#_생일_카페_특전_등록">생일 카페 특전 등록</a></h3>
+<div class="sect3">
+<h4 id="_생일_카페_특전_등록_http_request"><a class="link" href="#_생일_카페_특전_등록_http_request">HTTP request</a></h4>
+<div class="listingblock">
+<div class="content">
+<pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">POST /api/v1/birthday-cafes/1/special-goods HTTP/1.1
+Content-Type: application/json;charset=UTF-8
+Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwiaWF0IjoxNzA5OTA5NzQ2LCJleHAiOjE3MDk5MTE1NDZ9.9txOSm5sYVKB_GwMK3iYw-sPzT9UO8uUg0Cpk57gdMA
+Content-Length: 147
+Host: www.api.birca.com
+
+[ {
+  "name" : "기본",
+  "details" : "종이컵, 포토카드"
+}, {
+  "name" : "디저트",
+  "details" : "종이컵, 포토카드, ID카드"
+} ]</code></pre>
+</div>
+</div>
+</div>
+<div class="sect3">
+<h4 id="_생일_카페_특전_등록_request_fields"><a class="link" href="#_생일_카페_특전_등록_request_fields">Request fields</a></h4>
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 33.3333%;">
+<col style="width: 33.3333%;">
+<col style="width: 33.3334%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">Path</th>
+<th class="tableblock halign-left valign-top">Type</th>
+<th class="tableblock halign-left valign-top">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>[].name</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">특전의 이름</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>[].details</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">특전의 세부 내용</p></td>
+</tr>
+</tbody>
+</table>
+</div>
+<div class="sect3">
+<h4 id="_생일_카페_특전_등록_path_parameters"><a class="link" href="#_생일_카페_특전_등록_path_parameters">Path parameters</a></h4>
+<table class="tableblock frame-all grid-all stretch">
+<caption class="title">Table 1. /api/v1/birthday-cafes/{birthdayCafeId}/special-goods</caption>
+<colgroup>
+<col style="width: 50%;">
+<col style="width: 50%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">Parameter</th>
+<th class="tableblock halign-left valign-top">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>birthdayCafeId</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">특전을 추가할 생일 카페 ID</p></td>
+</tr>
+</tbody>
+</table>
+</div>
+<div class="sect3">
+<h4 id="_생일_카페_특전_등록_http_response"><a class="link" href="#_생일_카페_특전_등록_http_response">HTTP response</a></h4>
 <div class="listingblock">
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">HTTP/1.1 200 OK
@@ -2009,7 +2095,7 @@ Vary: Access-Control-Request-Headers</code></pre>
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">GET /api/v1/cafes/search?name=%EC%BB%A4%ED%94%BC HTTP/1.1
 Content-Type: application/json;charset=UTF-8
-Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwiaWF0IjoxNzA5ODc5ODg0LCJleHAiOjE3MDk4ODE2ODR9.81_1mtKYA-EI9nSdVeV9OlTxBwDVjuh-ludyB3xr-1s
+Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwiaWF0IjoxNzA5OTA5NzQ5LCJleHAiOjE3MDk5MTE1NDl9.cAix1AUk7xxZcoBgrIok8RG1m1pJDCfFL6HFOqQL_iI
 Host: www.api.birca.com</code></pre>
 </div>
 </div>
@@ -2042,7 +2128,7 @@ Content-Length: 106
 <div id="footer">
 <div id="footer-text">
 Version 0.0.1-SNAPSHOT<br>
-Last updated 2024-03-08 15:33:18 +0900
+Last updated 2024-03-08 23:50:58 +0900
 </div>
 </div>
 <script src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/9.18.3/highlight.min.js"></script>

--- a/src/test/java/com/birca/bircabackend/command/birca/acceptance/BirthdayCafeAcceptanceTest.java
+++ b/src/test/java/com/birca/bircabackend/command/birca/acceptance/BirthdayCafeAcceptanceTest.java
@@ -65,15 +65,6 @@ public class BirthdayCafeAcceptanceTest extends AcceptanceTest {
 
     @Test
     void 생일_카페_특전_상태를_변경한다() {
-        // given
-        RestAssured.given().log().all()
-                .contentType(MediaType.APPLICATION_JSON_VALUE)
-                .header(HttpHeaders.AUTHORIZATION, bearerTokenProvider.getToken(HOST_1_ID))
-                .body(APPLY_RENTAL_REQUEST)
-                .post("/api/v1/birthday-cafes")
-                .then().log().all()
-                .extract();
-
         StateChangeRequest request = new StateChangeRequest("SCARCE");
 
         // when
@@ -92,14 +83,6 @@ public class BirthdayCafeAcceptanceTest extends AcceptanceTest {
     @Test
     void 생일_카페_혼잡도_상태를_변경한다() {
         // given
-        RestAssured.given().log().all()
-                .contentType(MediaType.APPLICATION_JSON_VALUE)
-                .header(HttpHeaders.AUTHORIZATION, bearerTokenProvider.getToken(HOST_1_ID))
-                .body(APPLY_RENTAL_REQUEST)
-                .post("/api/v1/birthday-cafes")
-                .then().log().all()
-                .extract();
-
         StateChangeRequest request = new StateChangeRequest("MODERATE");
 
         // when
@@ -118,14 +101,6 @@ public class BirthdayCafeAcceptanceTest extends AcceptanceTest {
     @Test
     void 생일_카페_공개_상태를_변경한다() {
         // given
-        RestAssured.given().log().all()
-                .contentType(MediaType.APPLICATION_JSON_VALUE)
-                .header(HttpHeaders.AUTHORIZATION, bearerTokenProvider.getToken(HOST_1_ID))
-                .body(APPLY_RENTAL_REQUEST)
-                .post("/api/v1/birthday-cafes")
-                .then().log().all()
-                .extract();
-
         StateChangeRequest request = new StateChangeRequest("PUBLIC");
 
         // when
@@ -139,5 +114,14 @@ public class BirthdayCafeAcceptanceTest extends AcceptanceTest {
 
         // then
         assertThat(response.statusCode()).isEqualTo(HttpStatus.OK.value());
+    }
+
+    @Test
+    void 생일_카페_특전을_추가한다() {
+        // given
+
+        // when
+
+        // then
     }
 }

--- a/src/test/java/com/birca/bircabackend/command/birca/acceptance/BirthdayCafeAcceptanceTest.java
+++ b/src/test/java/com/birca/bircabackend/command/birca/acceptance/BirthdayCafeAcceptanceTest.java
@@ -14,6 +14,7 @@ import org.springframework.http.MediaType;
 import org.springframework.test.context.jdbc.Sql;
 
 import java.time.LocalDateTime;
+import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -120,7 +121,10 @@ public class BirthdayCafeAcceptanceTest extends AcceptanceTest {
     @Test
     void 생일_카페_특전을_추가한다() {
         // given
-        SpecialGoodsRequest request = new SpecialGoodsRequest("기본", "종이컵, 포토카드");
+        List<SpecialGoodsRequest> request = List.of(
+                new SpecialGoodsRequest("기본", "종이컵, 포토카드"),
+                new SpecialGoodsRequest("디저트", "종이컵, 포토카드, ID카드")
+        );
 
         // when
         ExtractableResponse<Response> response = RestAssured.given().log().all()

--- a/src/test/java/com/birca/bircabackend/command/birca/acceptance/BirthdayCafeAcceptanceTest.java
+++ b/src/test/java/com/birca/bircabackend/command/birca/acceptance/BirthdayCafeAcceptanceTest.java
@@ -1,6 +1,7 @@
 package com.birca.bircabackend.command.birca.acceptance;
 
 import com.birca.bircabackend.command.birca.dto.ApplyRentalRequest;
+import com.birca.bircabackend.command.birca.dto.SpecialGoodsRequest;
 import com.birca.bircabackend.command.birca.dto.StateChangeRequest;
 import com.birca.bircabackend.support.enviroment.AcceptanceTest;
 import io.restassured.RestAssured;
@@ -119,9 +120,18 @@ public class BirthdayCafeAcceptanceTest extends AcceptanceTest {
     @Test
     void 생일_카페_특전을_추가한다() {
         // given
+        SpecialGoodsRequest request = new SpecialGoodsRequest("기본", "종이컵, 포토카드");
 
         // when
+        ExtractableResponse<Response> response = RestAssured.given().log().all()
+                .contentType(MediaType.APPLICATION_JSON_VALUE)
+                .header(HttpHeaders.AUTHORIZATION, bearerTokenProvider.getToken(HOST_1_ID))
+                .body(request)
+                .post("/api/v1/birthday-cafes/{birthdayCafeId}/special-goods", IN_PROGRESS_CAFE)
+                .then().log().all()
+                .extract();
 
         // then
+        assertThat(response.statusCode()).isEqualTo(HttpStatus.OK.value());
     }
 }

--- a/src/test/java/com/birca/bircabackend/command/birca/application/BirthdayCafeServiceTest.java
+++ b/src/test/java/com/birca/bircabackend/command/birca/application/BirthdayCafeServiceTest.java
@@ -288,7 +288,7 @@ class BirthdayCafeServiceTest extends ServiceTest {
         @Test
         void 진행_중인_카페에서_가능하다() {
             // when
-            birthdayCafeService.registerSpecialGoods(inProgressCafeId, HOST1, request);
+            birthdayCafeService.replaceSpecialGoods(inProgressCafeId, HOST1, request);
 
             // then
             BirthdayCafe actual = entityManager.find(BirthdayCafe.class, inProgressCafeId);
@@ -303,10 +303,10 @@ class BirthdayCafeServiceTest extends ServiceTest {
         @Test
         void 기존_특전을_완전히_대체한다() {
             // given
-            birthdayCafeService.registerSpecialGoods(inProgressCafeId, HOST1, request);
+            birthdayCafeService.replaceSpecialGoods(inProgressCafeId, HOST1, request);
 
             // when
-            birthdayCafeService.registerSpecialGoods(inProgressCafeId, HOST1, List.of(
+            birthdayCafeService.replaceSpecialGoods(inProgressCafeId, HOST1, List.of(
                     new SpecialGoodsRequest("바뀐 특전", "새로운 포토카드"),
                     new SpecialGoodsRequest("바뀐 디저트", "새로운 포토카드, 새로운 ID 카드"),
                     new SpecialGoodsRequest("스페셜", "특별 선물")
@@ -326,7 +326,7 @@ class BirthdayCafeServiceTest extends ServiceTest {
         @Test
         void 대관_대기_상태에선_못한다() {
             // when then
-            assertThatThrownBy(() -> birthdayCafeService.registerSpecialGoods(rentalPendingCafeId, HOST1, request))
+            assertThatThrownBy(() -> birthdayCafeService.replaceSpecialGoods(rentalPendingCafeId, HOST1, request))
                     .isInstanceOf(BusinessException.class)
                     .extracting("errorCode")
                     .isEqualTo(BirthdayCafeErrorCode.INVALID_UPDATE);
@@ -335,7 +335,7 @@ class BirthdayCafeServiceTest extends ServiceTest {
         @Test
         void 주최자가_아니면_못한다() {
             // when then
-            assertThatThrownBy(() -> birthdayCafeService.registerSpecialGoods(inProgressCafeId, ANOTHER_MEMBER, request))
+            assertThatThrownBy(() -> birthdayCafeService.replaceSpecialGoods(inProgressCafeId, ANOTHER_MEMBER, request))
                     .isInstanceOf(BusinessException.class)
                     .extracting("errorCode")
                     .isEqualTo(BirthdayCafeErrorCode.UNAUTHORIZED_UPDATE);

--- a/src/test/java/com/birca/bircabackend/command/birca/application/BirthdayCafeServiceTest.java
+++ b/src/test/java/com/birca/bircabackend/command/birca/application/BirthdayCafeServiceTest.java
@@ -4,6 +4,7 @@ import com.birca.bircabackend.command.auth.authorization.LoginMember;
 import com.birca.bircabackend.command.birca.domain.BirthdayCafe;
 import com.birca.bircabackend.command.birca.domain.value.*;
 import com.birca.bircabackend.command.birca.dto.ApplyRentalRequest;
+import com.birca.bircabackend.command.birca.dto.SpecialGoodsRequest;
 import com.birca.bircabackend.command.birca.dto.StateChangeRequest;
 import com.birca.bircabackend.command.birca.exception.BirthdayCafeErrorCode;
 import com.birca.bircabackend.common.exception.BusinessException;
@@ -17,6 +18,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.test.context.jdbc.Sql;
 
 import java.time.LocalDateTime;
+import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -268,6 +270,75 @@ class BirthdayCafeServiceTest extends ServiceTest {
             // then
             BirthdayCafe actual = entityManager.find(BirthdayCafe.class, inProgressCafeId);
             assertThat(actual.getVisibility()).isEqualTo(Visibility.PUBLIC);
+        }
+    }
+
+    @Nested
+    @DisplayName("생일 카페 특전 등록은")
+    class SpecialGoodsTest {
+
+        private final Long rentalPendingCafeId = 1L;
+        private final Long inProgressCafeId = 2L;
+
+        private final List<SpecialGoodsRequest> request = List.of(
+                new SpecialGoodsRequest("특전", "포토카드"),
+                new SpecialGoodsRequest("디저트", "포토카드, ID 카드")
+        );
+
+        @Test
+        void 진행_중인_카페에서_가능하다() {
+            // when
+            birthdayCafeService.registerSpecialGoods(inProgressCafeId, HOST1, request);
+
+            // then
+            BirthdayCafe actual = entityManager.find(BirthdayCafe.class, inProgressCafeId);
+            assertThat(actual.getSpecialGoods())
+                    .usingRecursiveComparison()
+                    .isEqualTo(List.of(
+                            new SpecialGoods("특전", "포토카드"),
+                            new SpecialGoods("디저트", "포토카드, ID 카드")
+                    ));
+        }
+
+        @Test
+        void 기존_특전을_완전히_대체한다() {
+            // given
+            birthdayCafeService.registerSpecialGoods(inProgressCafeId, HOST1, request);
+
+            // when
+            birthdayCafeService.registerSpecialGoods(inProgressCafeId, HOST1, List.of(
+                    new SpecialGoodsRequest("바뀐 특전", "새로운 포토카드"),
+                    new SpecialGoodsRequest("바뀐 디저트", "새로운 포토카드, 새로운 ID 카드"),
+                    new SpecialGoodsRequest("스페셜", "특별 선물")
+            ));
+
+            // then
+            BirthdayCafe actual = entityManager.find(BirthdayCafe.class, inProgressCafeId);
+            assertThat(actual.getSpecialGoods())
+                    .usingRecursiveComparison()
+                    .isEqualTo(List.of(
+                            new SpecialGoods("바뀐 특전", "새로운 포토카드"),
+                            new SpecialGoods("바뀐 디저트", "새로운 포토카드, 새로운 ID 카드"),
+                            new SpecialGoods("스페셜", "특별 선물")
+                    ));
+        }
+
+        @Test
+        void 대관_대기_상태에선_못한다() {
+            // when then
+            assertThatThrownBy(() -> birthdayCafeService.registerSpecialGoods(rentalPendingCafeId, HOST1, request))
+                    .isInstanceOf(BusinessException.class)
+                    .extracting("errorCode")
+                    .isEqualTo(BirthdayCafeErrorCode.INVALID_UPDATE);
+        }
+
+        @Test
+        void 주최자가_아니면_못한다() {
+            // when then
+            assertThatThrownBy(() -> birthdayCafeService.registerSpecialGoods(inProgressCafeId, ANOTHER_MEMBER, request))
+                    .isInstanceOf(BusinessException.class)
+                    .extracting("errorCode")
+                    .isEqualTo(BirthdayCafeErrorCode.UNAUTHORIZED_UPDATE);
         }
     }
 }

--- a/src/test/java/com/birca/bircabackend/command/birca/domain/BirthdayCafeTest.java
+++ b/src/test/java/com/birca/bircabackend/command/birca/domain/BirthdayCafeTest.java
@@ -356,7 +356,7 @@ class BirthdayCafeTest {
                     .sample();
 
             // when
-            birthdayCafe.registerSpecialGoods(HOST_ID, specialGoods);
+            birthdayCafe.replaceSpecialGoods(HOST_ID, specialGoods);
 
             // then
             assertThat(birthdayCafe.getSpecialGoods()).isEqualTo(specialGoods);
@@ -372,7 +372,7 @@ class BirthdayCafeTest {
                     .sample();
 
             // when
-            birthdayCafe.registerSpecialGoods(HOST_ID, specialGoods);
+            birthdayCafe.replaceSpecialGoods(HOST_ID, specialGoods);
 
             // then
             assertThat(birthdayCafe.getSpecialGoods()).isEqualTo(specialGoods);
@@ -388,7 +388,7 @@ class BirthdayCafeTest {
                     .sample();
 
             // when then
-            assertThatThrownBy(() -> birthdayCafe.registerSpecialGoods(HOST_ID, specialGoods))
+            assertThatThrownBy(() -> birthdayCafe.replaceSpecialGoods(HOST_ID, specialGoods))
                     .isInstanceOf(BusinessException.class)
                     .extracting("errorCode")
                     .isEqualTo(BirthdayCafeErrorCode.INVALID_UPDATE);
@@ -403,7 +403,7 @@ class BirthdayCafeTest {
                     .sample();
 
             // when then
-            assertThatThrownBy(() -> birthdayCafe.registerSpecialGoods(100L, specialGoods))
+            assertThatThrownBy(() -> birthdayCafe.replaceSpecialGoods(100L, specialGoods))
                     .isInstanceOf(BusinessException.class)
                     .extracting("errorCode")
                     .isEqualTo(BirthdayCafeErrorCode.UNAUTHORIZED_UPDATE);

--- a/src/test/java/com/birca/bircabackend/command/birca/domain/BirthdayCafeTest.java
+++ b/src/test/java/com/birca/bircabackend/command/birca/domain/BirthdayCafeTest.java
@@ -3,6 +3,8 @@ package com.birca.bircabackend.command.birca.domain;
 import com.birca.bircabackend.command.birca.domain.value.*;
 import com.birca.bircabackend.command.birca.exception.BirthdayCafeErrorCode;
 import com.birca.bircabackend.common.exception.BusinessException;
+import com.navercorp.fixturemonkey.FixtureMonkey;
+import com.navercorp.fixturemonkey.api.introspector.FieldReflectionArbitraryIntrospector;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -28,10 +30,13 @@ class BirthdayCafeTest {
     private static final String TWITTER_ACCOUNT = "ChaseM";
     private static final PhoneNumber HOST_PHONE_NUMBER = PhoneNumber.from("010-0000-0000");
 
+    private static final FixtureMonkey fixtureMonkey = FixtureMonkey.builder()
+            .objectIntrospector(FieldReflectionArbitraryIntrospector.INSTANCE)
+            .build();
+
     @Nested
     @DisplayName("생일 카페는 카페 대관 신청 시")
     class ApplyRentalTest {
-
 
         @Test
         void 대관_대기_상태로_생성된다() {
@@ -78,41 +83,37 @@ class BirthdayCafeTest {
     @DisplayName("생일 카페 대관을 취소 시")
     class CancelTest {
 
+        private final BirthdayCafe rentalPendingCafe = fixtureMonkey.giveMeBuilder(BirthdayCafe.class)
+                .set("hostId", HOST_ID)
+                .set("cafeOwnerId", CAFE_OWNER_ID)
+                .set("progressState", ProgressState.RENTAL_PENDING)
+                .sample();
+
         @Test
         void 주최자_취소한다() {
-            // given
-            BirthdayCafe birthdayCafe = BirthdayCafe.applyRental(
-                    HOST_ID, ARTIST_ID, CAFE_ID, CAFE_OWNER_ID, SCHEDULE, VISITANTS, TWITTER_ACCOUNT, HOST_PHONE_NUMBER);
-
             // when
-            birthdayCafe.cancelRental(HOST_ID);
+            rentalPendingCafe.cancelRental(HOST_ID);
 
             // then
-            assertThat(birthdayCafe.getProgressState()).isEqualTo(ProgressState.RENTAL_CANCELED);
+            assertThat(rentalPendingCafe.getProgressState()).isEqualTo(ProgressState.RENTAL_CANCELED);
         }
 
         @Test
         void 사장님이_취소한다() {
-            // given
-            BirthdayCafe birthdayCafe = BirthdayCafe.applyRental(
-                    HOST_ID, ARTIST_ID, CAFE_ID, CAFE_OWNER_ID, SCHEDULE, VISITANTS, TWITTER_ACCOUNT, HOST_PHONE_NUMBER);
-
             // when
-            birthdayCafe.cancelRental(CAFE_OWNER_ID);
+            rentalPendingCafe.cancelRental(CAFE_OWNER_ID);
 
             // then
-            assertThat(birthdayCafe.getProgressState()).isEqualTo(ProgressState.RENTAL_CANCELED);
+            assertThat(rentalPendingCafe.getProgressState()).isEqualTo(ProgressState.RENTAL_CANCELED);
         }
 
         @Test
         void 주최자도_사장님도_아니면_취소하지_못한다() {
             // given
-            BirthdayCafe birthdayCafe = BirthdayCafe.applyRental(
-                    HOST_ID, ARTIST_ID, CAFE_ID, CAFE_OWNER_ID, SCHEDULE, VISITANTS, TWITTER_ACCOUNT, HOST_PHONE_NUMBER);
             Long anotherMember = 100L;
 
             // when then
-            assertThatThrownBy(() -> birthdayCafe.cancelRental(anotherMember))
+            assertThatThrownBy(() -> rentalPendingCafe.cancelRental(anotherMember))
                     .isInstanceOf(BusinessException.class)
                     .extracting("errorCode")
                     .isEqualTo(BirthdayCafeErrorCode.UNAUTHORIZED_CANCEL);
@@ -122,10 +123,11 @@ class BirthdayCafeTest {
         @EnumSource(mode = EXCLUDE, names = "RENTAL_PENDING")
         void 대관_대기_상태가_아니면_취소하지_못한다(ProgressState progressState) {
             // given
-            BirthdayCafe birthdayCafe = BirthdayCafe.builder()
-                    .hostId(HOST_ID)
-                    .progressState(progressState)
-                    .build();
+            BirthdayCafe birthdayCafe = fixtureMonkey.giveMeBuilder(BirthdayCafe.class)
+                    .set("hostId", HOST_ID)
+                    .set("cafeOwnerId", CAFE_OWNER_ID)
+                    .set("progressState", progressState)
+                    .sample();
 
             // when then
             assertThatThrownBy(() -> birthdayCafe.cancelRental(HOST_ID))
@@ -144,10 +146,10 @@ class BirthdayCafeTest {
         void 누른다(ProgressState progressState) {
             // given
             Long visitantId = 1L;
-            BirthdayCafe birthdayCafe = BirthdayCafe.builder()
-                    .hostId(HOST_ID)
-                    .progressState(progressState)
-                    .build();
+            BirthdayCafe birthdayCafe = fixtureMonkey.giveMeBuilder(BirthdayCafe.class)
+                    .set("hostId", HOST_ID)
+                    .set("progressState", progressState)
+                    .sample();
 
             // when
             BirthdayCafeLike birthdayCafeLike = birthdayCafe.like(visitantId);
@@ -162,11 +164,10 @@ class BirthdayCafeTest {
         void 대관_대기_상태나_취소_상태의_생일_카페는_누를_수_없다(ProgressState progressState) {
             // given
             Long visitantId = 1L;
-
-            BirthdayCafe birthdayCafe = BirthdayCafe.builder()
-                    .hostId(HOST_ID)
-                    .progressState(progressState)
-                    .build();
+            BirthdayCafe birthdayCafe = fixtureMonkey.giveMeBuilder(BirthdayCafe.class)
+                    .set("hostId", HOST_ID)
+                    .set("progressState", progressState)
+                    .sample();
 
             // when then
             assertThatThrownBy(() -> birthdayCafe.like(visitantId))
@@ -183,11 +184,11 @@ class BirthdayCafeTest {
         @Test
         void 진행_중인_생일_카페면_가능하다() {
             // given
-            BirthdayCafe birthdayCafe = BirthdayCafe.builder()
-                    .hostId(HOST_ID)
-                    .progressState(ProgressState.IN_PROGRESS)
-                    .specialGoodsStockState(SpecialGoodsStockState.ABUNDANT)
-                    .build();
+            BirthdayCafe birthdayCafe = fixtureMonkey.giveMeBuilder(BirthdayCafe.class)
+                    .set("hostId", HOST_ID)
+                    .set("progressState", ProgressState.IN_PROGRESS)
+                    .set("specialGoodsStockState", SpecialGoodsStockState.ABUNDANT)
+                    .sample();
 
             // when
             birthdayCafe.changeState(SpecialGoodsStockState.SCARCE, HOST_ID);
@@ -200,11 +201,11 @@ class BirthdayCafeTest {
         @EnumSource(mode = EXCLUDE, names = "IN_PROGRESS")
         void 진행_중이_아닌_생일_카페면_불가능하다(ProgressState progressState) {
             // given
-            BirthdayCafe birthdayCafe = BirthdayCafe.builder()
-                    .hostId(HOST_ID)
-                    .progressState(progressState)
-                    .specialGoodsStockState(SpecialGoodsStockState.ABUNDANT)
-                    .build();
+            BirthdayCafe birthdayCafe = fixtureMonkey.giveMeBuilder(BirthdayCafe.class)
+                    .set("hostId", HOST_ID)
+                    .set("progressState", progressState)
+                    .set("specialGoodsStockState", SpecialGoodsStockState.ABUNDANT)
+                    .sample();
 
             // when then
             assertThatThrownBy(() -> birthdayCafe.changeState(SpecialGoodsStockState.SCARCE, HOST_ID))
@@ -216,11 +217,11 @@ class BirthdayCafeTest {
         @Test
         void 주최자만_가능하다() {
             // given
-            BirthdayCafe birthdayCafe = BirthdayCafe.builder()
-                    .hostId(HOST_ID)
-                    .progressState(ProgressState.IN_PROGRESS)
-                    .specialGoodsStockState(SpecialGoodsStockState.ABUNDANT)
-                    .build();
+            BirthdayCafe birthdayCafe = fixtureMonkey.giveMeBuilder(BirthdayCafe.class)
+                    .set("hostId", HOST_ID)
+                    .set("progressState", ProgressState.IN_PROGRESS)
+                    .set("specialGoodsStockState", SpecialGoodsStockState.ABUNDANT)
+                    .sample();
 
             assertThatThrownBy(() -> birthdayCafe.changeState(SpecialGoodsStockState.SCARCE, 100L))
                     .isInstanceOf(BusinessException.class)
@@ -235,11 +236,11 @@ class BirthdayCafeTest {
         @Test
         void 진행_중인_생일_카페면_가능하다() {
             // given
-            BirthdayCafe birthdayCafe = BirthdayCafe.builder()
-                    .hostId(HOST_ID)
-                    .progressState(ProgressState.IN_PROGRESS)
-                    .congestionState(CongestionState.SMOOTH)
-                    .build();
+            BirthdayCafe birthdayCafe = fixtureMonkey.giveMeBuilder(BirthdayCafe.class)
+                    .set("hostId", HOST_ID)
+                    .set("progressState", ProgressState.IN_PROGRESS)
+                    .set("congestionState", CongestionState.SMOOTH)
+                    .sample();
 
             // when
             birthdayCafe.changeState(CongestionState.MODERATE, HOST_ID);
@@ -252,11 +253,11 @@ class BirthdayCafeTest {
         @EnumSource(mode = EXCLUDE, names = "IN_PROGRESS")
         void 진행_중이_아닌_생일_카페면_불가능하다(ProgressState progressState) {
             // given
-            BirthdayCafe birthdayCafe = BirthdayCafe.builder()
-                    .hostId(HOST_ID)
-                    .progressState(progressState)
-                    .congestionState(CongestionState.SMOOTH)
-                    .build();
+            BirthdayCafe birthdayCafe = fixtureMonkey.giveMeBuilder(BirthdayCafe.class)
+                    .set("hostId", HOST_ID)
+                    .set("progressState", progressState)
+                    .set("congestionState", CongestionState.SMOOTH)
+                    .sample();
 
             // when then
             assertThatThrownBy(() -> birthdayCafe.changeState(CongestionState.MODERATE, HOST_ID))
@@ -268,11 +269,11 @@ class BirthdayCafeTest {
         @Test
         void 주최자만_가능하다() {
             // given
-            BirthdayCafe birthdayCafe = BirthdayCafe.builder()
-                    .hostId(HOST_ID)
-                    .progressState(ProgressState.IN_PROGRESS)
-                    .congestionState(CongestionState.SMOOTH)
-                    .build();
+            BirthdayCafe birthdayCafe = fixtureMonkey.giveMeBuilder(BirthdayCafe.class)
+                    .set("hostId", HOST_ID)
+                    .set("progressState", ProgressState.IN_PROGRESS)
+                    .set("congestionState", CongestionState.SMOOTH)
+                    .sample();
 
             // when then
             assertThatThrownBy(() -> birthdayCafe.changeState(CongestionState.MODERATE, 100L))
@@ -290,11 +291,11 @@ class BirthdayCafeTest {
         @EnumSource(mode = EXCLUDE, names = "RENTAL_PENDING")
         void 대관_대기가_아닌_생일_카페면_가능하다(ProgressState progressState) {
             // given
-            BirthdayCafe birthdayCafe = BirthdayCafe.builder()
-                    .hostId(HOST_ID)
-                    .progressState(progressState)
-                    .visibility(Visibility.PRIVATE)
-                    .build();
+            BirthdayCafe birthdayCafe = fixtureMonkey.giveMeBuilder(BirthdayCafe.class)
+                    .set("hostId", HOST_ID)
+                    .set("progressState", progressState)
+                    .set("visibility", Visibility.PRIVATE)
+                    .sample();
 
             // when
             birthdayCafe.changeState(Visibility.PUBLIC, HOST_ID);
@@ -306,11 +307,11 @@ class BirthdayCafeTest {
         @Test
         void 대관_대기인_생일_카페면_불가능하다() {
             // given
-            BirthdayCafe birthdayCafe = BirthdayCafe.builder()
-                    .hostId(HOST_ID)
-                    .progressState(ProgressState.RENTAL_PENDING)
-                    .visibility(Visibility.PRIVATE)
-                    .build();
+            BirthdayCafe birthdayCafe = fixtureMonkey.giveMeBuilder(BirthdayCafe.class)
+                    .set("hostId", HOST_ID)
+                    .set("progressState", ProgressState.RENTAL_PENDING)
+                    .set("visibility", Visibility.PRIVATE)
+                    .sample();
 
             // when then
             assertThatThrownBy(() -> birthdayCafe.changeState(Visibility.PUBLIC, HOST_ID))
@@ -322,11 +323,11 @@ class BirthdayCafeTest {
         @Test
         void 주최자만_가능하다() {
             // given
-            BirthdayCafe birthdayCafe = BirthdayCafe.builder()
-                    .hostId(HOST_ID)
-                    .progressState(ProgressState.IN_PROGRESS)
-                    .visibility(Visibility.PRIVATE)
-                    .build();
+            BirthdayCafe birthdayCafe = fixtureMonkey.giveMeBuilder(BirthdayCafe.class)
+                    .set("hostId", HOST_ID)
+                    .set("progressState", ProgressState.IN_PROGRESS)
+                    .set("visibility", Visibility.PRIVATE)
+                    .sample();
 
             // when then
             assertThatThrownBy(() -> birthdayCafe.changeState(Visibility.PUBLIC, 100L))
@@ -349,10 +350,10 @@ class BirthdayCafeTest {
         @EnumSource(mode = INCLUDE, names = {"RENTAL_APPROVED", "IN_PROGRESS"})
         void 대관_승인됨과_진행_중일_때만_가능하다(ProgressState progressState) {
             // given
-            BirthdayCafe birthdayCafe = BirthdayCafe.builder()
-                    .hostId(HOST_ID)
-                    .progressState(progressState)
-                    .build();
+            BirthdayCafe birthdayCafe = fixtureMonkey.giveMeBuilder(BirthdayCafe.class)
+                    .set("hostId", HOST_ID)
+                    .set("progressState", progressState)
+                    .sample();
 
             // when
             birthdayCafe.registerSpecialGoods(HOST_ID, specialGoods);
@@ -364,11 +365,11 @@ class BirthdayCafeTest {
         @Test
         void 기존의_특전을_완전히_대체한다() {
             // given
-            BirthdayCafe birthdayCafe = BirthdayCafe.builder()
-                    .hostId(HOST_ID)
-                    .progressState(ProgressState.RENTAL_APPROVED)
-                    .specialGoods(List.of(new SpecialGoods("기존 특전", "포토카드")))
-                    .build();
+            BirthdayCafe birthdayCafe = fixtureMonkey.giveMeBuilder(BirthdayCafe.class)
+                    .set("hostId", HOST_ID)
+                    .set("progressState", ProgressState.RENTAL_APPROVED)
+                    .set("specialGoods", List.of(new SpecialGoods("기존 특전", "포토카드")))
+                    .sample();
 
             // when
             birthdayCafe.registerSpecialGoods(HOST_ID, specialGoods);
@@ -381,10 +382,10 @@ class BirthdayCafeTest {
         @EnumSource(mode = EXCLUDE, names = {"RENTAL_APPROVED", "IN_PROGRESS"})
         void 대관_승인됨과_진행_중이_아니면_불가능하다(ProgressState progressState) {
             // given
-            BirthdayCafe birthdayCafe = BirthdayCafe.builder()
-                    .hostId(HOST_ID)
-                    .progressState(progressState)
-                    .build();
+            BirthdayCafe birthdayCafe = fixtureMonkey.giveMeBuilder(BirthdayCafe.class)
+                    .set("hostId", HOST_ID)
+                    .set("progressState", progressState)
+                    .sample();
 
             // when then
             assertThatThrownBy(() -> birthdayCafe.registerSpecialGoods(HOST_ID, specialGoods))
@@ -395,12 +396,13 @@ class BirthdayCafeTest {
 
         @Test
         void 주최자만_가능하다() {
-            BirthdayCafe birthdayCafe = BirthdayCafe.builder()
-                    .hostId(HOST_ID)
-                    .progressState(ProgressState.IN_PROGRESS)
-                    .build();
+            // given
+            BirthdayCafe birthdayCafe = fixtureMonkey.giveMeBuilder(BirthdayCafe.class)
+                    .set("hostId", HOST_ID)
+                    .set("progressState", ProgressState.IN_PROGRESS)
+                    .sample();
 
-            // then
+            // when then
             assertThatThrownBy(() -> birthdayCafe.registerSpecialGoods(100L, specialGoods))
                     .isInstanceOf(BusinessException.class)
                     .extracting("errorCode")

--- a/src/test/java/com/birca/bircabackend/command/birca/domain/BirthdayCafeTest.java
+++ b/src/test/java/com/birca/bircabackend/command/birca/domain/BirthdayCafeTest.java
@@ -121,9 +121,10 @@ class BirthdayCafeTest {
         @EnumSource(mode = EXCLUDE, names = "RENTAL_PENDING")
         void 대관_대기_상태가_아니면_취소하지_못한다(ProgressState progressState) {
             // given
-            BirthdayCafe birthdayCafe = new BirthdayCafe(
-                    HOST_ID, ARTIST_ID, CAFE_ID, CAFE_OWNER_ID, SCHEDULE, VISITANTS, TWITTER_ACCOUNT, HOST_PHONE_NUMBER,
-                    progressState, Visibility.PRIVATE, CongestionState.SMOOTH, SpecialGoodsStockState.ABUNDANT);
+            BirthdayCafe birthdayCafe = BirthdayCafe.builder()
+                    .hostId(HOST_ID)
+                    .progressState(progressState)
+                    .build();
 
             // when then
             assertThatThrownBy(() -> birthdayCafe.cancelRental(HOST_ID))
@@ -142,10 +143,10 @@ class BirthdayCafeTest {
         void 누른다(ProgressState progressState) {
             // given
             Long visitantId = 1L;
-
-            BirthdayCafe birthdayCafe = new BirthdayCafe(
-                    HOST_ID, ARTIST_ID, CAFE_ID, CAFE_OWNER_ID, SCHEDULE, VISITANTS, TWITTER_ACCOUNT, HOST_PHONE_NUMBER,
-                    progressState, Visibility.PRIVATE, CongestionState.SMOOTH, SpecialGoodsStockState.ABUNDANT);
+            BirthdayCafe birthdayCafe = BirthdayCafe.builder()
+                    .hostId(HOST_ID)
+                    .progressState(progressState)
+                    .build();
 
             // when
             BirthdayCafeLike birthdayCafeLike = birthdayCafe.like(visitantId);
@@ -161,9 +162,10 @@ class BirthdayCafeTest {
             // given
             Long visitantId = 1L;
 
-            BirthdayCafe birthdayCafe = new BirthdayCafe(
-                    HOST_ID, ARTIST_ID, CAFE_ID, CAFE_OWNER_ID, SCHEDULE, VISITANTS, TWITTER_ACCOUNT, HOST_PHONE_NUMBER,
-                    progressState, Visibility.PRIVATE, CongestionState.SMOOTH, SpecialGoodsStockState.ABUNDANT);
+            BirthdayCafe birthdayCafe = BirthdayCafe.builder()
+                    .hostId(HOST_ID)
+                    .progressState(progressState)
+                    .build();
 
             // when then
             assertThatThrownBy(() -> birthdayCafe.like(visitantId))
@@ -180,9 +182,11 @@ class BirthdayCafeTest {
         @Test
         void 진행_중인_생일_카페면_가능하다() {
             // given
-            BirthdayCafe birthdayCafe = new BirthdayCafe(
-                    HOST_ID, ARTIST_ID, CAFE_ID, CAFE_OWNER_ID, SCHEDULE, VISITANTS, TWITTER_ACCOUNT, HOST_PHONE_NUMBER,
-                    ProgressState.IN_PROGRESS, Visibility.PRIVATE, CongestionState.SMOOTH, SpecialGoodsStockState.ABUNDANT);
+            BirthdayCafe birthdayCafe = BirthdayCafe.builder()
+                    .hostId(HOST_ID)
+                    .progressState(ProgressState.IN_PROGRESS)
+                    .specialGoodsStockState(SpecialGoodsStockState.ABUNDANT)
+                    .build();
 
             // when
             birthdayCafe.changeState(SpecialGoodsStockState.SCARCE, HOST_ID);
@@ -195,28 +199,32 @@ class BirthdayCafeTest {
         @EnumSource(mode = EXCLUDE, names = "IN_PROGRESS")
         void 진행_중이_아닌_생일_카페면_불가능하다(ProgressState progressState) {
             // given
-            BirthdayCafe birthdayCafe = new BirthdayCafe(
-                    HOST_ID, ARTIST_ID, CAFE_ID, CAFE_OWNER_ID, SCHEDULE, VISITANTS, TWITTER_ACCOUNT, HOST_PHONE_NUMBER,
-                    progressState, Visibility.PRIVATE, CongestionState.SMOOTH, SpecialGoodsStockState.ABUNDANT);
+            BirthdayCafe birthdayCafe = BirthdayCafe.builder()
+                    .hostId(HOST_ID)
+                    .progressState(progressState)
+                    .specialGoodsStockState(SpecialGoodsStockState.ABUNDANT)
+                    .build();
 
             // when then
             assertThatThrownBy(() -> birthdayCafe.changeState(SpecialGoodsStockState.SCARCE, HOST_ID))
                     .isInstanceOf(BusinessException.class)
                     .extracting("errorCode")
-                    .isEqualTo(BirthdayCafeErrorCode.INVALID_STATE_CHANGE);
+                    .isEqualTo(BirthdayCafeErrorCode.INVALID_UPDATE);
         }
 
         @Test
         void 주최자만_가능하다() {
             // given
-            BirthdayCafe birthdayCafe = new BirthdayCafe(
-                    HOST_ID, ARTIST_ID, CAFE_ID, CAFE_OWNER_ID, SCHEDULE, VISITANTS, TWITTER_ACCOUNT, HOST_PHONE_NUMBER,
-                    ProgressState.IN_PROGRESS, Visibility.PRIVATE, CongestionState.SMOOTH, SpecialGoodsStockState.ABUNDANT);
+            BirthdayCafe birthdayCafe = BirthdayCafe.builder()
+                    .hostId(HOST_ID)
+                    .progressState(ProgressState.IN_PROGRESS)
+                    .specialGoodsStockState(SpecialGoodsStockState.ABUNDANT)
+                    .build();
 
             assertThatThrownBy(() -> birthdayCafe.changeState(SpecialGoodsStockState.SCARCE, 100L))
                     .isInstanceOf(BusinessException.class)
                     .extracting("errorCode")
-                    .isEqualTo(BirthdayCafeErrorCode.UNAUTHORIZED_STATE_CHANGE);
+                    .isEqualTo(BirthdayCafeErrorCode.UNAUTHORIZED_UPDATE);
         }
     }
 
@@ -226,9 +234,11 @@ class BirthdayCafeTest {
         @Test
         void 진행_중인_생일_카페면_가능하다() {
             // given
-            BirthdayCafe birthdayCafe = new BirthdayCafe(
-                    HOST_ID, ARTIST_ID, CAFE_ID, CAFE_OWNER_ID, SCHEDULE, VISITANTS, TWITTER_ACCOUNT, HOST_PHONE_NUMBER,
-                    ProgressState.IN_PROGRESS, Visibility.PRIVATE, CongestionState.SMOOTH, SpecialGoodsStockState.ABUNDANT);
+            BirthdayCafe birthdayCafe = BirthdayCafe.builder()
+                    .hostId(HOST_ID)
+                    .progressState(ProgressState.IN_PROGRESS)
+                    .congestionState(CongestionState.SMOOTH)
+                    .build();
 
             // when
             birthdayCafe.changeState(CongestionState.MODERATE, HOST_ID);
@@ -241,29 +251,33 @@ class BirthdayCafeTest {
         @EnumSource(mode = EXCLUDE, names = "IN_PROGRESS")
         void 진행_중이_아닌_생일_카페면_불가능하다(ProgressState progressState) {
             // given
-            BirthdayCafe birthdayCafe = new BirthdayCafe(
-                    HOST_ID, ARTIST_ID, CAFE_ID, CAFE_OWNER_ID, SCHEDULE, VISITANTS, TWITTER_ACCOUNT, HOST_PHONE_NUMBER,
-                    progressState, Visibility.PRIVATE, CongestionState.SMOOTH, SpecialGoodsStockState.ABUNDANT);
+            BirthdayCafe birthdayCafe = BirthdayCafe.builder()
+                    .hostId(HOST_ID)
+                    .progressState(progressState)
+                    .congestionState(CongestionState.SMOOTH)
+                    .build();
 
             // when then
             assertThatThrownBy(() -> birthdayCafe.changeState(CongestionState.MODERATE, HOST_ID))
                     .isInstanceOf(BusinessException.class)
                     .extracting("errorCode")
-                    .isEqualTo(BirthdayCafeErrorCode.INVALID_STATE_CHANGE);
+                    .isEqualTo(BirthdayCafeErrorCode.INVALID_UPDATE);
         }
 
         @Test
         void 주최자만_가능하다() {
             // given
-            BirthdayCafe birthdayCafe = new BirthdayCafe(
-                    HOST_ID, ARTIST_ID, CAFE_ID, CAFE_OWNER_ID, SCHEDULE, VISITANTS, TWITTER_ACCOUNT, HOST_PHONE_NUMBER,
-                    ProgressState.IN_PROGRESS, Visibility.PRIVATE, CongestionState.SMOOTH, SpecialGoodsStockState.ABUNDANT);
+            BirthdayCafe birthdayCafe = BirthdayCafe.builder()
+                    .hostId(HOST_ID)
+                    .progressState(ProgressState.IN_PROGRESS)
+                    .congestionState(CongestionState.SMOOTH)
+                    .build();
 
             // when then
             assertThatThrownBy(() -> birthdayCafe.changeState(CongestionState.MODERATE, 100L))
                     .isInstanceOf(BusinessException.class)
                     .extracting("errorCode")
-                    .isEqualTo(BirthdayCafeErrorCode.UNAUTHORIZED_STATE_CHANGE);
+                    .isEqualTo(BirthdayCafeErrorCode.UNAUTHORIZED_UPDATE);
         }
     }
 
@@ -275,9 +289,11 @@ class BirthdayCafeTest {
         @EnumSource(mode = EXCLUDE, names = "RENTAL_PENDING")
         void 대관_대기가_아닌_생일_카페면_가능하다(ProgressState progressState) {
             // given
-            BirthdayCafe birthdayCafe = new BirthdayCafe(
-                    HOST_ID, ARTIST_ID, CAFE_ID, CAFE_OWNER_ID, SCHEDULE, VISITANTS, TWITTER_ACCOUNT, HOST_PHONE_NUMBER,
-                    progressState, Visibility.PRIVATE, CongestionState.SMOOTH, SpecialGoodsStockState.ABUNDANT);
+            BirthdayCafe birthdayCafe = BirthdayCafe.builder()
+                    .hostId(HOST_ID)
+                    .progressState(progressState)
+                    .visibility((Visibility.PRIVATE))
+                    .build();
 
             // when
             birthdayCafe.changeState(Visibility.PUBLIC, HOST_ID);
@@ -289,29 +305,33 @@ class BirthdayCafeTest {
         @Test
         void 대관_대기인_생일_카페면_불가능하다() {
             // given
-            BirthdayCafe birthdayCafe = new BirthdayCafe(
-                    HOST_ID, ARTIST_ID, CAFE_ID, CAFE_OWNER_ID, SCHEDULE, VISITANTS, TWITTER_ACCOUNT, HOST_PHONE_NUMBER,
-                    ProgressState.RENTAL_PENDING, Visibility.PRIVATE, CongestionState.SMOOTH, SpecialGoodsStockState.ABUNDANT);
+            BirthdayCafe birthdayCafe = BirthdayCafe.builder()
+                    .hostId(HOST_ID)
+                    .progressState(ProgressState.RENTAL_PENDING)
+                    .visibility((Visibility.PRIVATE))
+                    .build();
 
             // when then
             assertThatThrownBy(() -> birthdayCafe.changeState(Visibility.PUBLIC, HOST_ID))
                     .isInstanceOf(BusinessException.class)
                     .extracting("errorCode")
-                    .isEqualTo(BirthdayCafeErrorCode.INVALID_STATE_CHANGE);
+                    .isEqualTo(BirthdayCafeErrorCode.INVALID_UPDATE);
         }
 
         @Test
         void 주최자만_가능하다() {
             // given
-            BirthdayCafe birthdayCafe = new BirthdayCafe(
-                    HOST_ID, ARTIST_ID, CAFE_ID, CAFE_OWNER_ID, SCHEDULE, VISITANTS, TWITTER_ACCOUNT, HOST_PHONE_NUMBER,
-                    ProgressState.IN_PROGRESS, Visibility.PRIVATE, CongestionState.SMOOTH, SpecialGoodsStockState.ABUNDANT);
+            BirthdayCafe birthdayCafe = BirthdayCafe.builder()
+                    .hostId(HOST_ID)
+                    .progressState(ProgressState.IN_PROGRESS)
+                    .visibility((Visibility.PRIVATE))
+                    .build();
 
             // when then
             assertThatThrownBy(() -> birthdayCafe.changeState(Visibility.PUBLIC, 100L))
                     .isInstanceOf(BusinessException.class)
                     .extracting("errorCode")
-                    .isEqualTo(BirthdayCafeErrorCode.UNAUTHORIZED_STATE_CHANGE);
+                    .isEqualTo(BirthdayCafeErrorCode.UNAUTHORIZED_UPDATE);
         }
     }
 }

--- a/src/test/java/com/birca/bircabackend/command/birca/presentation/BirthdayCafeControllerTest.java
+++ b/src/test/java/com/birca/bircabackend/command/birca/presentation/BirthdayCafeControllerTest.java
@@ -1,6 +1,7 @@
 package com.birca.bircabackend.command.birca.presentation;
 
 import com.birca.bircabackend.command.birca.dto.ApplyRentalRequest;
+import com.birca.bircabackend.command.birca.dto.SpecialGoodsRequest;
 import com.birca.bircabackend.command.birca.dto.StateChangeRequest;
 import com.birca.bircabackend.command.birca.exception.BirthdayCafeErrorCode;
 import com.birca.bircabackend.support.enviroment.DocumentationTest;
@@ -107,6 +108,33 @@ public class BirthdayCafeControllerTest extends DocumentationTest {
                         ),
                         requestFields(
                                 fieldWithPath("state").type(JsonFieldType.STRING).description("변경할 상태 값")
+                        )
+                ));
+    }
+
+    @Test
+    void 생일_카페_특전을_추가한다() throws Exception {
+        // given
+        Long birthdayCafeId = 1L;
+        SpecialGoodsRequest request = new SpecialGoodsRequest("기본", "종이컵, 포토카드");
+
+        // when
+        ResultActions result = mockMvc.perform(
+                post("/api/v1/birthday-cafes/{birthdayCafeId}/special-goods", birthdayCafeId)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request))
+                        .header(HttpHeaders.AUTHORIZATION, bearerTokenProvider.getToken(MEMBER_ID))
+        );
+
+        // then
+        result.andExpect((status().isOk()))
+                .andDo(document("birthday-cafe-special-goods", HOST_INFO, DOCUMENT_RESPONSE,
+                        pathParameters(
+                                parameterWithName("birthdayCafeId").description("특전을 추가할 생일 카페 ID")
+                        ),
+                        requestFields(
+                                fieldWithPath("name").type(JsonFieldType.STRING).description("특전의 이름"),
+                                fieldWithPath("details").type(JsonFieldType.STRING).description("특전의 세부 내용")
                         )
                 ));
     }

--- a/src/test/java/com/birca/bircabackend/command/birca/presentation/BirthdayCafeControllerTest.java
+++ b/src/test/java/com/birca/bircabackend/command/birca/presentation/BirthdayCafeControllerTest.java
@@ -12,6 +12,7 @@ import org.springframework.restdocs.payload.JsonFieldType;
 import org.springframework.test.web.servlet.ResultActions;
 
 import java.time.LocalDateTime;
+import java.util.List;
 
 import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
 import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.post;
@@ -116,7 +117,10 @@ public class BirthdayCafeControllerTest extends DocumentationTest {
     void 생일_카페_특전을_추가한다() throws Exception {
         // given
         Long birthdayCafeId = 1L;
-        SpecialGoodsRequest request = new SpecialGoodsRequest("기본", "종이컵, 포토카드");
+        List<SpecialGoodsRequest> request = List.of(
+                new SpecialGoodsRequest("기본", "종이컵, 포토카드"),
+                new SpecialGoodsRequest("디저트", "종이컵, 포토카드, ID카드")
+        );
 
         // when
         ResultActions result = mockMvc.perform(
@@ -133,8 +137,8 @@ public class BirthdayCafeControllerTest extends DocumentationTest {
                                 parameterWithName("birthdayCafeId").description("특전을 추가할 생일 카페 ID")
                         ),
                         requestFields(
-                                fieldWithPath("name").type(JsonFieldType.STRING).description("특전의 이름"),
-                                fieldWithPath("details").type(JsonFieldType.STRING).description("특전의 세부 내용")
+                                fieldWithPath("[].name").type(JsonFieldType.STRING).description("특전의 이름"),
+                                fieldWithPath("[].details").type(JsonFieldType.STRING).description("특전의 세부 내용")
                         )
                 ));
     }


### PR DESCRIPTION
## 🌍 이슈 번호
- closed #55 

## 📝 구현 내용
- 생일 카페에 특전 등록 (추가/수정/삭제)
  - 요청 내용으로 완전히 대체됨

## 🍀 확인해야 할 부분
- 빠뜨린 검증 사항이 있는지 확인해주세요!

### 테스트 시에 빌더를 사용
현재 `BirthdayCafe`에 필드가 엄청 많습니다. 별도 클래스로 분리하기엔 모두 `BirthdayCafe`에 중요한 항목들입니다.

때문에 `BirthdayCafeTest`에서 `BirthdayCafe`를 생성할 때 너무 많은 필드를 생성자에 추가해야 합니다. 때문에 테스트에서만 빌더를 사용하는 관행(?)을 추가하면 어떨까 합니다.

현재 `BirthdayCafe` 엔티티에 롬복 어노테이션은 아래와 같습니다.
``` java
@Entity
@NoArgsConstructor(access = AccessLevel.PROTECTED) // jpa 초기화를 위한 protected 기본 생성자
@AllArgsConstructor(access = AccessLevel.PRIVATE) // 빌더 사용을 위한 모든 필드를 받는 생성자
@Builder(access = AccessLevel.PACKAGE) // 같은 패키지 내에서만 사용 가능한 빌더
@Getter
public class BirthdayCafe extends BaseEntity {
```
중요하게 볼 것은 `AllArgsConstructor`와 `Builder`입니다. 
`AllArgsConstructor`은 `Builder` 어노테이션 사용을 위해 필수라 추가했지만 빌더만 사용할 것이기에 접근 제어자는 `private`입니다.
`Builder`는 테스트에서만 사용하기 위해 접근 제어자를 `pacakge-private`으로 했습니다. 이렇게 되면 BirthdayCafe와 같은 패키지에 존재하는 클래스들에서만 사용 가능하고 `BirthdayCafeTest`에서도 사용 가능합니다.

빌더를 사용함으로써 각 테스트에 필요한 값만 넣어서 생성할 수 있습니다.

``` java
        @ParameterizedTest
        @EnumSource(mode = INCLUDE, names = {"RENTAL_APPROVED", "IN_PROGRESS"})
        void 대관_승인됨과_진행_중일_때만_가능하다(ProgressState progressState) {
            // given
            BirthdayCafe birthdayCafe = BirthdayCafe.builder()
                    .hostId(HOST_ID)
                    .progressState(progressState)
                    .build();

            // when
            birthdayCafe.registerSpecialGoods(HOST_ID, specialGoods);

            // then
            assertThat(birthdayCafe.getSpecialGoods()).isEqualTo(specialGoods);
        }
```

개인적으로 builder는 정합성에 맞지 않는 도메인 객체를 생성할 위험이 있어 즐겨 사용하진 않지만 테스트 시에는 좋은 방법 같긴 합니다. 다른 엔티티에서도 너무 생성자에 필드가 많아진다면 package-private 접근 제어자의 빌더를 통해 테스트에서만 사용하는 방법을 사용할 수도 있을 것 같습니다.