### PR TITLE
[FEAT] 럭키 드로우 등록/수정/삭제 구현

### DIFF
--- a/src/docs/asciidoc/api.adoc
+++ b/src/docs/asciidoc/api.adoc
@@ -68,6 +68,8 @@ operation::like-cancel-birthday-cafe[snippets='http-request,path-parameters,http
 operation::birthday-cafe-special-goods[snippets='http-request,request-fields,path-parameters,http-response']
 === 생일 카페 메뉴 등록
 operation::birthday-cafe-menus[snippets='http-request,request-fields,path-parameters,http-response']
+=== 생일 카페 럭키 드로우 등록
+operation::birthday-cafe-lucky-draw[snippets='http-request,request-fields,path-parameters,http-response']
 === 에러 코드
 include::{snippets}/birthday-cafe-error-Code/response-body.adoc[]
 

--- a/src/main/java/com/birca/bircabackend/command/birca/application/BirthdayCafeService.java
+++ b/src/main/java/com/birca/bircabackend/command/birca/application/BirthdayCafeService.java
@@ -4,10 +4,7 @@ import com.birca.bircabackend.command.auth.authorization.LoginMember;
 import com.birca.bircabackend.command.birca.domain.BirthdayCafe;
 import com.birca.bircabackend.command.birca.domain.BirthdayCafeRepository;
 import com.birca.bircabackend.command.birca.domain.value.*;
-import com.birca.bircabackend.command.birca.dto.ApplyRentalRequest;
-import com.birca.bircabackend.command.birca.dto.MenuRequest;
-import com.birca.bircabackend.command.birca.dto.SpecialGoodsRequest;
-import com.birca.bircabackend.command.birca.dto.StateChangeRequest;
+import com.birca.bircabackend.command.birca.dto.*;
 import com.birca.bircabackend.common.EntityUtil;
 import com.birca.bircabackend.common.exception.BusinessException;
 import lombok.RequiredArgsConstructor;
@@ -81,5 +78,11 @@ public class BirthdayCafeService {
                 .map(req -> Menu.of(req.name(), req.details(), req.price()))
                 .toList();
         birthdayCafe.replaceMenus(loginMember.id(), menus);
+    }
+
+    public void replaceLuckyDraws(Long birthdayCafeId,
+                                  LoginMember loginMember,
+                                  List<LuckyDrawRequest> request) {
+
     }
 }

--- a/src/main/java/com/birca/bircabackend/command/birca/application/BirthdayCafeService.java
+++ b/src/main/java/com/birca/bircabackend/command/birca/application/BirthdayCafeService.java
@@ -83,6 +83,10 @@ public class BirthdayCafeService {
     public void replaceLuckyDraws(Long birthdayCafeId,
                                   LoginMember loginMember,
                                   List<LuckyDrawRequest> request) {
-
+        BirthdayCafe birthdayCafe = entityUtil.getEntity(BirthdayCafe.class, birthdayCafeId, NOT_FOUND);
+        List<LuckyDraw> luckyDraws = request.stream()
+                .map(req -> new LuckyDraw(req.rank(), req.prize()))
+                .toList();
+        birthdayCafe.replaceLuckyDraws(loginMember.id(), luckyDraws);
     }
 }

--- a/src/main/java/com/birca/bircabackend/command/birca/domain/BirthdayCafe.java
+++ b/src/main/java/com/birca/bircabackend/command/birca/domain/BirthdayCafe.java
@@ -65,6 +65,10 @@ public class BirthdayCafe extends BaseEntity {
     @CollectionTable(name = "menu")
     private List<Menu> menus = new ArrayList<>();
 
+    @ElementCollection(fetch = FetchType.EAGER)
+    @CollectionTable(name = "lucky_draw")
+    private List<LuckyDraw> luckyDraws = new ArrayList<>();
+
     public static BirthdayCafe applyRental(Long hostId, Long artistId, Long cafeId, Long cafeOwnerId, Schedule schedule,
                                            Visitants visitants, String twitterAccount, PhoneNumber hostPhoneNumber) {
         return BirthdayCafe.builder()
@@ -134,6 +138,14 @@ public class BirthdayCafe extends BaseEntity {
             throw BusinessException.from(INVALID_UPDATE);
         }
         this.menus = menus;
+    }
+
+    public void replaceLuckyDraws(Long memberId, List<LuckyDraw> luckyDraws) {
+        validateIsHost(memberId);
+        if (!progressState.isInProgress() && !progressState.isRentalApproved()) {
+            throw BusinessException.from(INVALID_UPDATE);
+        }
+        this.luckyDraws = luckyDraws;
     }
 
     private void validateIsHost(Long memberId) {

--- a/src/main/java/com/birca/bircabackend/command/birca/domain/BirthdayCafe.java
+++ b/src/main/java/com/birca/bircabackend/command/birca/domain/BirthdayCafe.java
@@ -57,15 +57,15 @@ public class BirthdayCafe extends BaseEntity {
     @Enumerated(EnumType.STRING)
     private SpecialGoodsStockState specialGoodsStockState;
 
-    @ElementCollection(fetch = FetchType.EAGER)
+    @ElementCollection
     @CollectionTable(name = "special_goods")
     private List<SpecialGoods> specialGoods = new ArrayList<>();
 
-    @ElementCollection(fetch = FetchType.EAGER)
+    @ElementCollection
     @CollectionTable(name = "menu")
     private List<Menu> menus = new ArrayList<>();
 
-    @ElementCollection(fetch = FetchType.EAGER)
+    @ElementCollection
     @CollectionTable(name = "lucky_draw")
     private List<LuckyDraw> luckyDraws = new ArrayList<>();
 

--- a/src/main/java/com/birca/bircabackend/command/birca/domain/value/LuckyDraw.java
+++ b/src/main/java/com/birca/bircabackend/command/birca/domain/value/LuckyDraw.java
@@ -1,0 +1,26 @@
+package com.birca.bircabackend.command.birca.domain.value;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Embeddable;
+import lombok.AccessLevel;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Embeddable
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
+@EqualsAndHashCode
+public class LuckyDraw {
+
+    @Column(nullable = false)
+    private Integer rank;
+
+    @Column(nullable = false)
+    private String prize;
+
+    public LuckyDraw(Integer rank, String prize) {
+        this.rank = rank;
+        this.prize = prize;
+    }
+}

--- a/src/main/java/com/birca/bircabackend/command/birca/domain/value/LuckyDraw.java
+++ b/src/main/java/com/birca/bircabackend/command/birca/domain/value/LuckyDraw.java
@@ -13,7 +13,7 @@ import lombok.NoArgsConstructor;
 @EqualsAndHashCode
 public class LuckyDraw {
 
-    @Column(nullable = false)
+    @Column(name = "ranks", nullable = false)
     private Integer rank;
 
     @Column(nullable = false)

--- a/src/main/java/com/birca/bircabackend/command/birca/dto/LuckyDrawRequest.java
+++ b/src/main/java/com/birca/bircabackend/command/birca/dto/LuckyDrawRequest.java
@@ -1,0 +1,4 @@
+package com.birca.bircabackend.command.birca.dto;
+
+public record LuckyDrawRequest(Integer rank, String prize) {
+}

--- a/src/main/java/com/birca/bircabackend/command/birca/presentation/BirthdayCafeController.java
+++ b/src/main/java/com/birca/bircabackend/command/birca/presentation/BirthdayCafeController.java
@@ -3,10 +3,7 @@ package com.birca.bircabackend.command.birca.presentation;
 import com.birca.bircabackend.command.auth.authorization.LoginMember;
 import com.birca.bircabackend.command.auth.authorization.RequiredLogin;
 import com.birca.bircabackend.command.birca.application.BirthdayCafeService;
-import com.birca.bircabackend.command.birca.dto.ApplyRentalRequest;
-import com.birca.bircabackend.command.birca.dto.MenuRequest;
-import com.birca.bircabackend.command.birca.dto.SpecialGoodsRequest;
-import com.birca.bircabackend.command.birca.dto.StateChangeRequest;
+import com.birca.bircabackend.command.birca.dto.*;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
@@ -77,6 +74,15 @@ public class BirthdayCafeController {
                                              LoginMember loginMember,
                                              @RequestBody List<MenuRequest> request) {
         birthdayCafeService.replaceMenus(birthdayCafeId, loginMember, request);
+        return ResponseEntity.ok().build();
+    }
+
+    @PostMapping("/v1/birthday-cafes/{birthdayCafeId}/lucky-draws")
+    @RequiredLogin
+    public ResponseEntity<Void> replaceLuckyDraws(@PathVariable Long birthdayCafeId,
+                                             LoginMember loginMember,
+                                             @RequestBody List<LuckyDrawRequest> request) {
+        birthdayCafeService.replaceLuckyDraws(birthdayCafeId, loginMember, request);
         return ResponseEntity.ok().build();
     }
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,6 +1,6 @@
 spring:
   profiles:
-    active: local
+    active: ci
   jpa:
     open-in-view: false
     hibernate:

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,6 +1,6 @@
 spring:
   profiles:
-    active: ci
+    active: local
   jpa:
     open-in-view: false
     hibernate:

--- a/src/main/resources/db/migration/V1__init.sql
+++ b/src/main/resources/db/migration/V1__init.sql
@@ -179,7 +179,7 @@ ALTER TABLE menu
 CREATE TABLE lucky_draw
 (
     birthday_cafe_id BIGINT       NOT NULL,
-    `rank`           INT          NOT NULL,
+    ranks           INT          NOT NULL,
     prize            VARCHAR(255) NOT NULL
 );
 

--- a/src/main/resources/db/migration/V1__init.sql
+++ b/src/main/resources/db/migration/V1__init.sql
@@ -176,6 +176,16 @@ CREATE TABLE menu
 ALTER TABLE menu
     ADD CONSTRAINT fk_menu_on_birthday_cafe FOREIGN KEY (birthday_cafe_id) REFERENCES birthday_cafe (id);
 
+CREATE TABLE lucky_draw
+(
+    birthday_cafe_id BIGINT       NOT NULL,
+    `rank`           INT          NOT NULL,
+    prize            VARCHAR(255) NOT NULL
+);
+
+ALTER TABLE lucky_draw
+    ADD CONSTRAINT fk_lucky_draw_on_birthday_cafe FOREIGN KEY (birthday_cafe_id) REFERENCES birthday_cafe (id);
+
 CREATE TABLE ocr_request_history
 (
     id           BIGINT AUTO_INCREMENT NOT NULL,

--- a/src/main/resources/static/docs/api.html
+++ b/src/main/resources/static/docs/api.html
@@ -490,6 +490,7 @@ body.book #toc,body.book #preamble,body.book h1.sect0,body.book .sect1>h2{page-b
 <li><a href="#_생일_카페_찜하기_취소">생일 카페 찜하기 취소</a></li>
 <li><a href="#_생일_카페_특전_등록">생일 카페 특전 등록</a></li>
 <li><a href="#_생일_카페_메뉴_등록">생일 카페 메뉴 등록</a></li>
+<li><a href="#_생일_카페_럭키_드로우_등록">생일 카페 럭키 드로우 등록</a></li>
 <li><a href="#_에러_코드_5">에러 코드</a></li>
 </ul>
 </li>
@@ -632,7 +633,7 @@ Content-Length: 97
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">POST /api/v1/members/role-change HTTP/1.1
 Content-Type: application/json;charset=UTF-8
-Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwiaWF0IjoxNzEwMjE4MTUyLCJleHAiOjE3MTAyMTk5NTJ9.xzumzL0e5q3tzCe-TWkLLT2DJs5a-JvgCr_F1TlPV2g
+Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwiaWF0IjoxNzEwMjQ2NTUxLCJleHAiOjE3MTAyNDgzNTF9.fTQR6XbXdZPelNzEQwa0TwLw5SLhkqQx9_ZPWLVWO3A
 Content-Length: 21
 Host: www.api.birca.com
 
@@ -662,7 +663,7 @@ Vary: Access-Control-Request-Headers</code></pre>
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">GET /api/v1/join/check-nickname?nickname=does HTTP/1.1
 Content-Type: application/json;charset=UTF-8
-Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwiaWF0IjoxNzEwMjE4MTU1LCJleHAiOjE3MTAyMTk5NTV9.szoKTyXvxd5JNY4lBAPFN-T04xertK3TnPsXSSE4a1E
+Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwiaWF0IjoxNzEwMjQ2NTU0LCJleHAiOjE3MTAyNDgzNTR9.YuJKsN_Fc6lYQYprVg5fBpVFU8WaayrvxTrnlmADOLQ
 Host: www.api.birca.com</code></pre>
 </div>
 </div>
@@ -736,7 +737,7 @@ Content-Length: 16
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">POST /api/v1/join/register-nickname HTTP/1.1
 Content-Type: application/json;charset=UTF-8
-Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwiaWF0IjoxNzEwMjE4MTUyLCJleHAiOjE3MTAyMTk5NTJ9.xzumzL0e5q3tzCe-TWkLLT2DJs5a-JvgCr_F1TlPV2g
+Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwiaWF0IjoxNzEwMjQ2NTUxLCJleHAiOjE3MTAyNDgzNTF9.fTQR6XbXdZPelNzEQwa0TwLw5SLhkqQx9_ZPWLVWO3A
 Content-Length: 30
 Host: www.api.birca.com
 
@@ -824,7 +825,7 @@ Vary: Access-Control-Request-Headers</code></pre>
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">GET /api/v1/artist-groups?cursor=10&amp;size=3 HTTP/1.1
 Content-Type: application/json;charset=UTF-8
-Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwiaWF0IjoxNzEwMjE4MTU1LCJleHAiOjE3MTAyMTk5NTV9.szoKTyXvxd5JNY4lBAPFN-T04xertK3TnPsXSSE4a1E
+Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwiaWF0IjoxNzEwMjQ2NTU0LCJleHAiOjE3MTAyNDgzNTR9.YuJKsN_Fc6lYQYprVg5fBpVFU8WaayrvxTrnlmADOLQ
 Host: www.api.birca.com</code></pre>
 </div>
 </div>
@@ -924,7 +925,7 @@ Content-Length: 250
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">GET /api/v1/artist-groups/1/artists HTTP/1.1
 Content-Type: application/json;charset=UTF-8
-Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwiaWF0IjoxNzEwMjE4MTU1LCJleHAiOjE3MTAyMTk5NTV9.szoKTyXvxd5JNY4lBAPFN-T04xertK3TnPsXSSE4a1E
+Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwiaWF0IjoxNzEwMjQ2NTU0LCJleHAiOjE3MTAyNDgzNTR9.YuJKsN_Fc6lYQYprVg5fBpVFU8WaayrvxTrnlmADOLQ
 Host: www.api.birca.com</code></pre>
 </div>
 </div>
@@ -1037,7 +1038,7 @@ Content-Length: 565
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">GET /api/v1/artists/solo?cursor=12&amp;size=6 HTTP/1.1
 Content-Type: application/json;charset=UTF-8
-Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwiaWF0IjoxNzEwMjE4MTU1LCJleHAiOjE3MTAyMTk5NTV9.szoKTyXvxd5JNY4lBAPFN-T04xertK3TnPsXSSE4a1E
+Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwiaWF0IjoxNzEwMjQ2NTU0LCJleHAiOjE3MTAyNDgzNTR9.YuJKsN_Fc6lYQYprVg5fBpVFU8WaayrvxTrnlmADOLQ
 Host: www.api.birca.com</code></pre>
 </div>
 </div>
@@ -1149,7 +1150,7 @@ Content-Length: 518
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">POST /api/v1/artists/favorite HTTP/1.1
 Content-Type: application/json;charset=UTF-8
-Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwiaWF0IjoxNzEwMjE4MTQ3LCJleHAiOjE3MTAyMTk5NDd9.bTNKlivKYKdIzEk3GBLk8NUsX0p53w9yRkRpQqGaBhU
+Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwiaWF0IjoxNzEwMjQ2NTQ4LCJleHAiOjE3MTAyNDgzNDh9.fmsrNy9gxkgfsUbRJoo8hdCba2pgz8sUuHy3SlpUDCU
 Content-Length: 20
 Host: www.api.birca.com
 
@@ -1203,7 +1204,7 @@ Vary: Access-Control-Request-Headers</code></pre>
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">POST /api/v1/artists/interest HTTP/1.1
 Content-Type: application/json;charset=UTF-8
-Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwiaWF0IjoxNzEwMjE4MTQ3LCJleHAiOjE3MTAyMTk5NDd9.bTNKlivKYKdIzEk3GBLk8NUsX0p53w9yRkRpQqGaBhU
+Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwiaWF0IjoxNzEwMjQ2NTQ4LCJleHAiOjE3MTAyNDgzNDh9.fmsrNy9gxkgfsUbRJoo8hdCba2pgz8sUuHy3SlpUDCU
 Content-Length: 68
 Host: www.api.birca.com
 
@@ -1261,7 +1262,7 @@ Vary: Access-Control-Request-Headers</code></pre>
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">GET /api/v1/artists/favorite HTTP/1.1
 Content-Type: application/json;charset=UTF-8
-Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwiaWF0IjoxNzEwMjE4MTU1LCJleHAiOjE3MTAyMTk5NTV9.szoKTyXvxd5JNY4lBAPFN-T04xertK3TnPsXSSE4a1E
+Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwiaWF0IjoxNzEwMjQ2NTU0LCJleHAiOjE3MTAyNDgzNTR9.YuJKsN_Fc6lYQYprVg5fBpVFU8WaayrvxTrnlmADOLQ
 Host: www.api.birca.com</code></pre>
 </div>
 </div>
@@ -1328,7 +1329,7 @@ Content-Length: 81
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">GET /api/v1/artists/interest HTTP/1.1
 Content-Type: application/json;charset=UTF-8
-Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwiaWF0IjoxNzEwMjE4MTU1LCJleHAiOjE3MTAyMTk5NTV9.szoKTyXvxd5JNY4lBAPFN-T04xertK3TnPsXSSE4a1E
+Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwiaWF0IjoxNzEwMjQ2NTU0LCJleHAiOjE3MTAyNDgzNTR9.YuJKsN_Fc6lYQYprVg5fBpVFU8WaayrvxTrnlmADOLQ
 Host: www.api.birca.com</code></pre>
 </div>
 </div>
@@ -1411,7 +1412,7 @@ Content-Length: 416
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">GET /api/v1/artists/search?name=%EB%A7%88%ED%81%AC HTTP/1.1
 Content-Type: application/json;charset=UTF-8
-Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwiaWF0IjoxNzEwMjE4MTU1LCJleHAiOjE3MTAyMTk5NTV9.szoKTyXvxd5JNY4lBAPFN-T04xertK3TnPsXSSE4a1E
+Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwiaWF0IjoxNzEwMjQ2NTU0LCJleHAiOjE3MTAyNDgzNTR9.YuJKsN_Fc6lYQYprVg5fBpVFU8WaayrvxTrnlmADOLQ
 Host: www.api.birca.com</code></pre>
 </div>
 </div>
@@ -1476,7 +1477,7 @@ Content-Length: 225
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">POST /api/v1/cafes/license-read HTTP/1.1
 Content-Type: multipart/form-data;charset=UTF-8; boundary=6o2knFse3p53ty9dmcQvWAIx1zInP11uCfbm
-Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwiaWF0IjoxNzEwMjE4MTUyLCJleHAiOjE3MTAyMTk5NTJ9.xzumzL0e5q3tzCe-TWkLLT2DJs5a-JvgCr_F1TlPV2g
+Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwiaWF0IjoxNzEwMjQ2NTUxLCJleHAiOjE3MTAyNDgzNTF9.fTQR6XbXdZPelNzEQwa0TwLw5SLhkqQx9_ZPWLVWO3A
 Host: www.api.birca.com
 
 --6o2knFse3p53ty9dmcQvWAIx1zInP11uCfbm
@@ -1562,7 +1563,7 @@ Content-Length: 141
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">POST /api/v1/cafes/apply HTTP/1.1
 Content-Type: multipart/form-data;charset=UTF-8; boundary=6o2knFse3p53ty9dmcQvWAIx1zInP11uCfbm
-Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwiaWF0IjoxNzEwMjE4MTUyLCJleHAiOjE3MTAyMTk5NTJ9.xzumzL0e5q3tzCe-TWkLLT2DJs5a-JvgCr_F1TlPV2g
+Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwiaWF0IjoxNzEwMjQ2NTUxLCJleHAiOjE3MTAyNDgzNTF9.fTQR6XbXdZPelNzEQwa0TwLw5SLhkqQx9_ZPWLVWO3A
 Host: www.api.birca.com
 
 --6o2knFse3p53ty9dmcQvWAIx1zInP11uCfbm
@@ -1636,7 +1637,7 @@ Vary: Access-Control-Request-Headers</code></pre>
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">POST /api/v1/birthday-cafes HTTP/1.1
 Content-Type: application/json;charset=UTF-8
-Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwiaWF0IjoxNzEwMjE4MTQ5LCJleHAiOjE3MTAyMTk5NDl9.CeXhJjtSqTubynRpbCen9tlq_kqECjSaCUBgw9qaYVU
+Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwiaWF0IjoxNzEwMjQ2NTQ5LCJleHAiOjE3MTAyNDgzNDl9.Z2rIT9jzt77S29k6ODhGGGoCGQGt7Ok0jrNTZxB5SKs
 Content-Length: 234
 Host: www.api.birca.com
 
@@ -1732,7 +1733,7 @@ Vary: Access-Control-Request-Headers</code></pre>
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">POST /api/v1/birthday-cafes/1/cancel HTTP/1.1
 Content-Type: application/json;charset=UTF-8
-Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwiaWF0IjoxNzEwMjE4MTQ5LCJleHAiOjE3MTAyMTk5NDl9.CeXhJjtSqTubynRpbCen9tlq_kqECjSaCUBgw9qaYVU
+Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwiaWF0IjoxNzEwMjQ2NTQ5LCJleHAiOjE3MTAyNDgzNDl9.Z2rIT9jzt77S29k6ODhGGGoCGQGt7Ok0jrNTZxB5SKs
 Host: www.api.birca.com</code></pre>
 </div>
 </div>
@@ -1779,7 +1780,7 @@ Vary: Access-Control-Request-Headers</code></pre>
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">PATCH /api/v1/birthday-cafes/1/congestion HTTP/1.1
 Content-Type: application/json;charset=UTF-8
-Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwiaWF0IjoxNzEwMjE4MTQ5LCJleHAiOjE3MTAyMTk5NDl9.CeXhJjtSqTubynRpbCen9tlq_kqECjSaCUBgw9qaYVU
+Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwiaWF0IjoxNzEwMjQ2NTQ5LCJleHAiOjE3MTAyNDgzNDl9.Z2rIT9jzt77S29k6ODhGGGoCGQGt7Ok0jrNTZxB5SKs
 Content-Length: 26
 Host: www.api.birca.com
 
@@ -1859,7 +1860,7 @@ Vary: Access-Control-Request-Headers</code></pre>
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">POST /api/v1/birthday-cafes/1/like HTTP/1.1
 Content-Type: application/json;charset=UTF-8
-Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwiaWF0IjoxNzEwMjE4MTUwLCJleHAiOjE3MTAyMTk5NTB9.6tGgDarRIsFLGDHsD-KhWv51uPJ5JTxWVLNOc47b5AA
+Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwiaWF0IjoxNzEwMjQ2NTQ5LCJleHAiOjE3MTAyNDgzNDl9.Z2rIT9jzt77S29k6ODhGGGoCGQGt7Ok0jrNTZxB5SKs
 Host: www.api.birca.com</code></pre>
 </div>
 </div>
@@ -1906,7 +1907,7 @@ Vary: Access-Control-Request-Headers</code></pre>
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">DELETE /api/v1/birthday-cafes/1/like HTTP/1.1
 Content-Type: application/json;charset=UTF-8
-Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwiaWF0IjoxNzEwMjE4MTUwLCJleHAiOjE3MTAyMTk5NTB9.6tGgDarRIsFLGDHsD-KhWv51uPJ5JTxWVLNOc47b5AA
+Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwiaWF0IjoxNzEwMjQ2NTQ5LCJleHAiOjE3MTAyNDgzNDl9.Z2rIT9jzt77S29k6ODhGGGoCGQGt7Ok0jrNTZxB5SKs
 Host: www.api.birca.com</code></pre>
 </div>
 </div>
@@ -1953,7 +1954,7 @@ Vary: Access-Control-Request-Headers</code></pre>
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">POST /api/v1/birthday-cafes/1/special-goods HTTP/1.1
 Content-Type: application/json;charset=UTF-8
-Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwiaWF0IjoxNzEwMjE4MTQ5LCJleHAiOjE3MTAyMTk5NDl9.CeXhJjtSqTubynRpbCen9tlq_kqECjSaCUBgw9qaYVU
+Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwiaWF0IjoxNzEwMjQ2NTQ5LCJleHAiOjE3MTAyNDgzNDl9.Z2rIT9jzt77S29k6ODhGGGoCGQGt7Ok0jrNTZxB5SKs
 Content-Length: 147
 Host: www.api.birca.com
 
@@ -2038,7 +2039,7 @@ Vary: Access-Control-Request-Headers</code></pre>
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">POST /api/v1/birthday-cafes/1/menus HTTP/1.1
 Content-Type: application/json;charset=UTF-8
-Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwiaWF0IjoxNzEwMjE4MTQ5LCJleHAiOjE3MTAyMTk5NDl9.CeXhJjtSqTubynRpbCen9tlq_kqECjSaCUBgw9qaYVU
+Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwiaWF0IjoxNzEwMjQ2NTQ5LCJleHAiOjE3MTAyNDgzNDl9.Z2rIT9jzt77S29k6ODhGGGoCGQGt7Ok0jrNTZxB5SKs
 Content-Length: 197
 Host: www.api.birca.com
 
@@ -2123,6 +2124,91 @@ Vary: Access-Control-Request-Headers</code></pre>
 </div>
 </div>
 <div class="sect2">
+<h3 id="_생일_카페_럭키_드로우_등록"><a class="link" href="#_생일_카페_럭키_드로우_등록">생일 카페 럭키 드로우 등록</a></h3>
+<div class="sect3">
+<h4 id="_생일_카페_럭키_드로우_등록_http_request"><a class="link" href="#_생일_카페_럭키_드로우_등록_http_request">HTTP request</a></h4>
+<div class="listingblock">
+<div class="content">
+<pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">POST /api/v1/birthday-cafes/1/lucky-draws HTTP/1.1
+Content-Type: application/json;charset=UTF-8
+Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwiaWF0IjoxNzEwMjQ2NTQ5LCJleHAiOjE3MTAyNDgzNDl9.Z2rIT9jzt77S29k6ODhGGGoCGQGt7Ok0jrNTZxB5SKs
+Content-Length: 92
+Host: www.api.birca.com
+
+[ {
+  "rank" : 1,
+  "prize" : "머그컵"
+}, {
+  "rank" : 2,
+  "prize" : "포토 카드"
+} ]</code></pre>
+</div>
+</div>
+</div>
+<div class="sect3">
+<h4 id="_생일_카페_럭키_드로우_등록_request_fields"><a class="link" href="#_생일_카페_럭키_드로우_등록_request_fields">Request fields</a></h4>
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 33.3333%;">
+<col style="width: 33.3333%;">
+<col style="width: 33.3334%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">Path</th>
+<th class="tableblock halign-left valign-top">Type</th>
+<th class="tableblock halign-left valign-top">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>[].rank</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Number</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">등수</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>[].prize</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">상품</p></td>
+</tr>
+</tbody>
+</table>
+</div>
+<div class="sect3">
+<h4 id="_생일_카페_럭키_드로우_등록_path_parameters"><a class="link" href="#_생일_카페_럭키_드로우_등록_path_parameters">Path parameters</a></h4>
+<table class="tableblock frame-all grid-all stretch">
+<caption class="title">Table 1. /api/v1/birthday-cafes/{birthdayCafeId}/lucky-draws</caption>
+<colgroup>
+<col style="width: 50%;">
+<col style="width: 50%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">Parameter</th>
+<th class="tableblock halign-left valign-top">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>birthdayCafeId</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">메뉴를 추가할 생일 카페 ID</p></td>
+</tr>
+</tbody>
+</table>
+</div>
+<div class="sect3">
+<h4 id="_생일_카페_럭키_드로우_등록_http_response"><a class="link" href="#_생일_카페_럭키_드로우_등록_http_response">HTTP response</a></h4>
+<div class="listingblock">
+<div class="content">
+<pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">HTTP/1.1 200 OK
+Vary: Origin
+Vary: Access-Control-Request-Method
+Vary: Access-Control-Request-Headers</code></pre>
+</div>
+</div>
+</div>
+</div>
+<div class="sect2">
 <h3 id="_에러_코드_5"><a class="link" href="#_에러_코드_5">에러 코드</a></h3>
 <div class="listingblock">
 <div class="content">
@@ -2188,7 +2274,7 @@ Vary: Access-Control-Request-Headers</code></pre>
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">GET /api/v1/cafes/search?name=%EC%BB%A4%ED%94%BC HTTP/1.1
 Content-Type: application/json;charset=UTF-8
-Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwiaWF0IjoxNzEwMjE4MTU1LCJleHAiOjE3MTAyMTk5NTV9.szoKTyXvxd5JNY4lBAPFN-T04xertK3TnPsXSSE4a1E
+Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwiaWF0IjoxNzEwMjQ2NTU0LCJleHAiOjE3MTAyNDgzNTR9.YuJKsN_Fc6lYQYprVg5fBpVFU8WaayrvxTrnlmADOLQ
 Host: www.api.birca.com</code></pre>
 </div>
 </div>
@@ -2221,7 +2307,7 @@ Content-Length: 106
 <div id="footer">
 <div id="footer-text">
 Version 0.0.1-SNAPSHOT<br>
-Last updated 2024-03-12 00:17:38 +0900
+Last updated 2024-03-12 21:28:46 +0900
 </div>
 </div>
 <script src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/9.18.3/highlight.min.js"></script>

--- a/src/test/java/com/birca/bircabackend/command/birca/acceptance/BirthdayCafeAcceptanceTest.java
+++ b/src/test/java/com/birca/bircabackend/command/birca/acceptance/BirthdayCafeAcceptanceTest.java
@@ -1,9 +1,6 @@
 package com.birca.bircabackend.command.birca.acceptance;
 
-import com.birca.bircabackend.command.birca.dto.ApplyRentalRequest;
-import com.birca.bircabackend.command.birca.dto.MenuRequest;
-import com.birca.bircabackend.command.birca.dto.SpecialGoodsRequest;
-import com.birca.bircabackend.command.birca.dto.StateChangeRequest;
+import com.birca.bircabackend.command.birca.dto.*;
 import com.birca.bircabackend.support.enviroment.AcceptanceTest;
 import io.restassured.RestAssured;
 import io.restassured.response.ExtractableResponse;
@@ -154,6 +151,26 @@ public class BirthdayCafeAcceptanceTest extends AcceptanceTest {
                 .header(HttpHeaders.AUTHORIZATION, bearerTokenProvider.getToken(HOST_1_ID))
                 .body(request)
                 .post("/api/v1/birthday-cafes/{birthdayCafeId}/menus", IN_PROGRESS_CAFE)
+                .then().log().all()
+                .extract();
+
+        // then
+        assertThat(response.statusCode()).isEqualTo(HttpStatus.OK.value());
+    }
+
+    @Test
+    void 생일_카페_럭키_드로우를_추가한다() {
+        // given
+        List<LuckyDrawRequest> request = List.of(
+                new LuckyDrawRequest(1, "머그컵"),
+                new LuckyDrawRequest(2, "포토 카드")
+        );
+
+        ExtractableResponse<Response> response = RestAssured.given().log().all()
+                .contentType(MediaType.APPLICATION_JSON_VALUE)
+                .header(HttpHeaders.AUTHORIZATION, bearerTokenProvider.getToken(HOST_1_ID))
+                .body(request)
+                .post("/api/v1/birthday-cafes/{birthdayCafeId}/lucky-draws", IN_PROGRESS_CAFE)
                 .then().log().all()
                 .extract();
 

--- a/src/test/java/com/birca/bircabackend/command/birca/application/BirthdayCafeServiceTest.java
+++ b/src/test/java/com/birca/bircabackend/command/birca/application/BirthdayCafeServiceTest.java
@@ -3,10 +3,7 @@ package com.birca.bircabackend.command.birca.application;
 import com.birca.bircabackend.command.auth.authorization.LoginMember;
 import com.birca.bircabackend.command.birca.domain.BirthdayCafe;
 import com.birca.bircabackend.command.birca.domain.value.*;
-import com.birca.bircabackend.command.birca.dto.ApplyRentalRequest;
-import com.birca.bircabackend.command.birca.dto.MenuRequest;
-import com.birca.bircabackend.command.birca.dto.SpecialGoodsRequest;
-import com.birca.bircabackend.command.birca.dto.StateChangeRequest;
+import com.birca.bircabackend.command.birca.dto.*;
 import com.birca.bircabackend.command.birca.exception.BirthdayCafeErrorCode;
 import com.birca.bircabackend.common.exception.BusinessException;
 import com.birca.bircabackend.support.enviroment.ServiceTest;
@@ -35,6 +32,9 @@ class BirthdayCafeServiceTest extends ServiceTest {
     private static final long ARTIST_ID = 1L;
     private static final long CAFE1_ID = 1L;
     private static final long CAFE2_ID = 2L;
+
+    private static final Long PENDING_BIRTHDAY_CAFE_ID = 1L;
+    private static final Long IN_PROGRESS_BIRTHDAY_CAFE_ID = 2L;
 
     private static final ApplyRentalRequest VALID_REQUEST = new ApplyRentalRequest(
             ARTIST_ID,
@@ -173,35 +173,33 @@ class BirthdayCafeServiceTest extends ServiceTest {
     @DisplayName("생일 카페 대관 신청을 취소할 때")
     class CancelRentalTest {
 
-        private final Long rentalPendingCafeId = 1L;
-
         @Test
         void 주최자_취소한다() {
             // when
-            birthdayCafeService.cancelRental(rentalPendingCafeId, HOST1);
+            birthdayCafeService.cancelRental(PENDING_BIRTHDAY_CAFE_ID, HOST1);
 
             // then
-            BirthdayCafe actual = entityManager.find(BirthdayCafe.class, rentalPendingCafeId);
+            BirthdayCafe actual = entityManager.find(BirthdayCafe.class, PENDING_BIRTHDAY_CAFE_ID);
             assertThat(actual.getProgressState()).isEqualTo(ProgressState.RENTAL_CANCELED);
         }
 
         @Test
         void 카페_사장님이_취소한다() {
             // when
-            birthdayCafeService.cancelRental(rentalPendingCafeId, CAFE_1_OWNER);
+            birthdayCafeService.cancelRental(PENDING_BIRTHDAY_CAFE_ID, CAFE_1_OWNER);
 
             // then
-            BirthdayCafe actual = entityManager.find(BirthdayCafe.class, rentalPendingCafeId);
+            BirthdayCafe actual = entityManager.find(BirthdayCafe.class, PENDING_BIRTHDAY_CAFE_ID);
             assertThat(actual.getProgressState()).isEqualTo(ProgressState.RENTAL_CANCELED);
         }
 
         @Test
         void 대관_대기_상태가_아니면_예외가_발생한다() {
             // given
-            birthdayCafeService.cancelRental(rentalPendingCafeId, HOST1);
+            birthdayCafeService.cancelRental(PENDING_BIRTHDAY_CAFE_ID, HOST1);
 
             // when then
-            assertThatThrownBy(() -> birthdayCafeService.cancelRental(rentalPendingCafeId, HOST1))
+            assertThatThrownBy(() -> birthdayCafeService.cancelRental(PENDING_BIRTHDAY_CAFE_ID, HOST1))
                     .isInstanceOf(BusinessException.class)
                     .extracting("errorCode")
                     .isEqualTo(BirthdayCafeErrorCode.INVALID_CANCEL_RENTAL);
@@ -222,7 +220,7 @@ class BirthdayCafeServiceTest extends ServiceTest {
         @Test
         void 생일_카페_주최자_또는_카페_사장님이_아니면_취소할_수_없다() {
             // when // than
-            assertThatThrownBy(() -> birthdayCafeService.cancelRental(rentalPendingCafeId, ANOTHER_MEMBER))
+            assertThatThrownBy(() -> birthdayCafeService.cancelRental(PENDING_BIRTHDAY_CAFE_ID, ANOTHER_MEMBER))
                     .isInstanceOf(BusinessException.class)
                     .extracting("errorCode")
                     .isEqualTo(BirthdayCafeErrorCode.UNAUTHORIZED_CANCEL);
@@ -278,9 +276,6 @@ class BirthdayCafeServiceTest extends ServiceTest {
     @DisplayName("생일 카페 특전 등록은")
     class SpecialGoodsTest {
 
-        private final Long rentalPendingCafeId = 1L;
-        private final Long inProgressCafeId = 2L;
-
         private final List<SpecialGoodsRequest> request = List.of(
                 new SpecialGoodsRequest("특전", "포토카드"),
                 new SpecialGoodsRequest("디저트", "포토카드, ID 카드")
@@ -289,10 +284,10 @@ class BirthdayCafeServiceTest extends ServiceTest {
         @Test
         void 진행_중인_카페에서_가능하다() {
             // when
-            birthdayCafeService.replaceSpecialGoods(inProgressCafeId, HOST1, request);
+            birthdayCafeService.replaceSpecialGoods(IN_PROGRESS_BIRTHDAY_CAFE_ID, HOST1, request);
 
             // then
-            BirthdayCafe actual = entityManager.find(BirthdayCafe.class, inProgressCafeId);
+            BirthdayCafe actual = entityManager.find(BirthdayCafe.class, IN_PROGRESS_BIRTHDAY_CAFE_ID);
             assertThat(actual.getSpecialGoods())
                     .usingRecursiveComparison()
                     .isEqualTo(List.of(
@@ -304,17 +299,17 @@ class BirthdayCafeServiceTest extends ServiceTest {
         @Test
         void 기존_특전을_완전히_대체한다() {
             // given
-            birthdayCafeService.replaceSpecialGoods(inProgressCafeId, HOST1, request);
+            birthdayCafeService.replaceSpecialGoods(IN_PROGRESS_BIRTHDAY_CAFE_ID, HOST1, request);
 
             // when
-            birthdayCafeService.replaceSpecialGoods(inProgressCafeId, HOST1, List.of(
+            birthdayCafeService.replaceSpecialGoods(IN_PROGRESS_BIRTHDAY_CAFE_ID, HOST1, List.of(
                     new SpecialGoodsRequest("바뀐 특전", "새로운 포토카드"),
                     new SpecialGoodsRequest("바뀐 디저트", "새로운 포토카드, 새로운 ID 카드"),
                     new SpecialGoodsRequest("스페셜", "특별 선물")
             ));
 
             // then
-            BirthdayCafe actual = entityManager.find(BirthdayCafe.class, inProgressCafeId);
+            BirthdayCafe actual = entityManager.find(BirthdayCafe.class, IN_PROGRESS_BIRTHDAY_CAFE_ID);
             assertThat(actual.getSpecialGoods())
                     .usingRecursiveComparison()
                     .isEqualTo(List.of(
@@ -327,7 +322,7 @@ class BirthdayCafeServiceTest extends ServiceTest {
         @Test
         void 대관_대기_상태에선_못한다() {
             // when then
-            assertThatThrownBy(() -> birthdayCafeService.replaceSpecialGoods(rentalPendingCafeId, HOST1, request))
+            assertThatThrownBy(() -> birthdayCafeService.replaceSpecialGoods(PENDING_BIRTHDAY_CAFE_ID, HOST1, request))
                     .isInstanceOf(BusinessException.class)
                     .extracting("errorCode")
                     .isEqualTo(BirthdayCafeErrorCode.INVALID_UPDATE);
@@ -336,7 +331,7 @@ class BirthdayCafeServiceTest extends ServiceTest {
         @Test
         void 주최자가_아니면_못한다() {
             // when then
-            assertThatThrownBy(() -> birthdayCafeService.replaceSpecialGoods(inProgressCafeId, ANOTHER_MEMBER, request))
+            assertThatThrownBy(() -> birthdayCafeService.replaceSpecialGoods(IN_PROGRESS_BIRTHDAY_CAFE_ID, ANOTHER_MEMBER, request))
                     .isInstanceOf(BusinessException.class)
                     .extracting("errorCode")
                     .isEqualTo(BirthdayCafeErrorCode.UNAUTHORIZED_UPDATE);
@@ -347,9 +342,6 @@ class BirthdayCafeServiceTest extends ServiceTest {
     @DisplayName("생일 카페 메뉴 등록은")
     class MenuTest {
 
-        private final Long rentalPendingCafeId = 1L;
-        private final Long inProgressCafeId = 2L;
-
         private final List<MenuRequest> request = List.of(
                 new MenuRequest("기본", "아메리카노+포토카드+ID카드", 10000),
                 new MenuRequest("디저트", "케이크+포토카드+ID카드", 10000)
@@ -358,10 +350,10 @@ class BirthdayCafeServiceTest extends ServiceTest {
         @Test
         void 진행_중인_카페에서_가능하다() {
             // when
-            birthdayCafeService.replaceMenus(inProgressCafeId, HOST1, request);
+            birthdayCafeService.replaceMenus(IN_PROGRESS_BIRTHDAY_CAFE_ID, HOST1, request);
 
             // then
-            BirthdayCafe actual = entityManager.find(BirthdayCafe.class, inProgressCafeId);
+            BirthdayCafe actual = entityManager.find(BirthdayCafe.class, IN_PROGRESS_BIRTHDAY_CAFE_ID);
             assertThat(actual.getMenus())
                     .usingRecursiveComparison()
                     .isEqualTo(List.of(
@@ -374,17 +366,17 @@ class BirthdayCafeServiceTest extends ServiceTest {
         @Test
         void 기존_특전을_완전히_대체한다() {
             // given
-            birthdayCafeService.replaceMenus(inProgressCafeId, HOST1, request);
+            birthdayCafeService.replaceMenus(IN_PROGRESS_BIRTHDAY_CAFE_ID, HOST1, request);
 
             // when
-            birthdayCafeService.replaceMenus(inProgressCafeId, HOST1, List.of(
+            birthdayCafeService.replaceMenus(IN_PROGRESS_BIRTHDAY_CAFE_ID, HOST1, List.of(
                     new MenuRequest("바뀐 기본 메뉴", "새로운 포토카드", 10000),
                     new MenuRequest("바뀐 디저트", "새로운 케이크, 새로운 ID 카드", 8000),
                     new MenuRequest("바뀐 메뉴", "새로운 ID 카드", 7500)
             ));
 
             // then
-            BirthdayCafe actual = entityManager.find(BirthdayCafe.class, inProgressCafeId);
+            BirthdayCafe actual = entityManager.find(BirthdayCafe.class, IN_PROGRESS_BIRTHDAY_CAFE_ID);
             assertThat(actual.getMenus())
                     .usingRecursiveComparison()
                     .isEqualTo(List.of(
@@ -397,7 +389,7 @@ class BirthdayCafeServiceTest extends ServiceTest {
         @Test
         void 대관_대기_상태에선_못한다() {
             // when then
-            assertThatThrownBy(() -> birthdayCafeService.replaceMenus(rentalPendingCafeId, HOST1, request))
+            assertThatThrownBy(() -> birthdayCafeService.replaceMenus(PENDING_BIRTHDAY_CAFE_ID, HOST1, request))
                     .isInstanceOf(BusinessException.class)
                     .extracting("errorCode")
                     .isEqualTo(BirthdayCafeErrorCode.INVALID_UPDATE);
@@ -406,7 +398,65 @@ class BirthdayCafeServiceTest extends ServiceTest {
         @Test
         void 주최자가_아니면_못한다() {
             // when then
-            assertThatThrownBy(() -> birthdayCafeService.replaceMenus(inProgressCafeId, ANOTHER_MEMBER, request))
+            assertThatThrownBy(() -> birthdayCafeService.replaceMenus(IN_PROGRESS_BIRTHDAY_CAFE_ID, ANOTHER_MEMBER, request))
+                    .isInstanceOf(BusinessException.class)
+                    .extracting("errorCode")
+                    .isEqualTo(BirthdayCafeErrorCode.UNAUTHORIZED_UPDATE);
+        }
+    }
+
+    @Nested
+    @DisplayName("생일 카페 럭키 드로우 등록은")
+    class LuckyDrawTest {
+
+        private final List<LuckyDrawRequest> requests = List.of(
+                new LuckyDrawRequest(1, "머그컵"),
+                new LuckyDrawRequest(2, "포토 카드")
+        );
+
+        @Test
+        void 진행_중인_카페에서_가능하다() {
+            // when
+            birthdayCafeService.replaceLuckyDraws(IN_PROGRESS_BIRTHDAY_CAFE_ID, HOST1, requests);
+
+            // then
+            BirthdayCafe actual = entityManager.find(BirthdayCafe.class, IN_PROGRESS_BIRTHDAY_CAFE_ID);
+            assertThat(actual.getLuckyDraws())
+                    .usingRecursiveComparison()
+                    .isEqualTo(List.of(
+                            new LuckyDraw(1, "머그컵"),
+                            new LuckyDraw(2, "포토 카드")
+
+                    ));
+        }
+
+        @Test
+        void 기존_특전을_완전히_대체한다() {
+            // given
+            birthdayCafeService.replaceLuckyDraws(IN_PROGRESS_BIRTHDAY_CAFE_ID, HOST1, requests);
+
+            // when
+            birthdayCafeService.replaceLuckyDraws(IN_PROGRESS_BIRTHDAY_CAFE_ID, HOST1, List.of());
+
+            // then
+            BirthdayCafe actual = entityManager.find(BirthdayCafe.class, IN_PROGRESS_BIRTHDAY_CAFE_ID);
+            assertThat(actual.getLuckyDraws()).isEmpty();
+        }
+
+        @Test
+        void 대관_대기_상태에선_못한다() {
+            // when then
+            assertThatThrownBy(() -> birthdayCafeService.replaceLuckyDraws(PENDING_BIRTHDAY_CAFE_ID, HOST1, requests))
+                    .isInstanceOf(BusinessException.class)
+                    .extracting("errorCode")
+                    .isEqualTo(BirthdayCafeErrorCode.INVALID_UPDATE);
+        }
+
+        @Test
+        void 주최자가_아니면_못한다() {
+            // when then
+            assertThatThrownBy(() ->
+                    birthdayCafeService.replaceLuckyDraws(IN_PROGRESS_BIRTHDAY_CAFE_ID, ANOTHER_MEMBER, requests))
                     .isInstanceOf(BusinessException.class)
                     .extracting("errorCode")
                     .isEqualTo(BirthdayCafeErrorCode.UNAUTHORIZED_UPDATE);

--- a/src/test/java/com/birca/bircabackend/command/birca/application/BirthdayCafeServiceTest.java
+++ b/src/test/java/com/birca/bircabackend/command/birca/application/BirthdayCafeServiceTest.java
@@ -287,8 +287,11 @@ class BirthdayCafeServiceTest extends ServiceTest {
             birthdayCafeService.replaceSpecialGoods(IN_PROGRESS_BIRTHDAY_CAFE_ID, HOST1, request);
 
             // then
-            BirthdayCafe actual = entityManager.find(BirthdayCafe.class, IN_PROGRESS_BIRTHDAY_CAFE_ID);
-            assertThat(actual.getSpecialGoods())
+            List<SpecialGoods> actual = entityManager.createQuery(
+                            "select bc.specialGoods from BirthdayCafe bc where bc.id = :id", SpecialGoods.class)
+                    .setParameter("id", IN_PROGRESS_BIRTHDAY_CAFE_ID)
+                    .getResultList();
+            assertThat(actual)
                     .usingRecursiveComparison()
                     .isEqualTo(List.of(
                             new SpecialGoods("특전", "포토카드"),
@@ -309,8 +312,11 @@ class BirthdayCafeServiceTest extends ServiceTest {
             ));
 
             // then
-            BirthdayCafe actual = entityManager.find(BirthdayCafe.class, IN_PROGRESS_BIRTHDAY_CAFE_ID);
-            assertThat(actual.getSpecialGoods())
+            List<SpecialGoods> actual = entityManager.createQuery(
+                            "select bc.specialGoods from BirthdayCafe bc where bc.id = :id", SpecialGoods.class)
+                    .setParameter("id", IN_PROGRESS_BIRTHDAY_CAFE_ID)
+                    .getResultList();
+            assertThat(actual)
                     .usingRecursiveComparison()
                     .isEqualTo(List.of(
                             new SpecialGoods("바뀐 특전", "새로운 포토카드"),
@@ -353,8 +359,11 @@ class BirthdayCafeServiceTest extends ServiceTest {
             birthdayCafeService.replaceMenus(IN_PROGRESS_BIRTHDAY_CAFE_ID, HOST1, request);
 
             // then
-            BirthdayCafe actual = entityManager.find(BirthdayCafe.class, IN_PROGRESS_BIRTHDAY_CAFE_ID);
-            assertThat(actual.getMenus())
+            List<Menu> actual = entityManager.createQuery(
+                            "select bc.menus from BirthdayCafe bc where bc.id = :id", Menu.class)
+                    .setParameter("id", IN_PROGRESS_BIRTHDAY_CAFE_ID)
+                    .getResultList();
+            assertThat(actual)
                     .usingRecursiveComparison()
                     .isEqualTo(List.of(
                             Menu.of("기본", "아메리카노+포토카드+ID카드", 10000),
@@ -376,8 +385,11 @@ class BirthdayCafeServiceTest extends ServiceTest {
             ));
 
             // then
-            BirthdayCafe actual = entityManager.find(BirthdayCafe.class, IN_PROGRESS_BIRTHDAY_CAFE_ID);
-            assertThat(actual.getMenus())
+            List<Menu> actual = entityManager.createQuery(
+                            "select bc.menus from BirthdayCafe bc where bc.id = :id", Menu.class)
+                    .setParameter("id", IN_PROGRESS_BIRTHDAY_CAFE_ID)
+                    .getResultList();
+            assertThat(actual)
                     .usingRecursiveComparison()
                     .isEqualTo(List.of(
                             new MenuRequest("바뀐 기본 메뉴", "새로운 포토카드", 10000),
@@ -420,8 +432,11 @@ class BirthdayCafeServiceTest extends ServiceTest {
             birthdayCafeService.replaceLuckyDraws(IN_PROGRESS_BIRTHDAY_CAFE_ID, HOST1, requests);
 
             // then
-            BirthdayCafe actual = entityManager.find(BirthdayCafe.class, IN_PROGRESS_BIRTHDAY_CAFE_ID);
-            assertThat(actual.getLuckyDraws())
+            List<LuckyDraw> actual = entityManager.createQuery(
+                            "select bc.luckyDraws from BirthdayCafe bc where bc.id = :id", LuckyDraw.class)
+                    .setParameter("id", IN_PROGRESS_BIRTHDAY_CAFE_ID)
+                    .getResultList();
+            assertThat(actual)
                     .usingRecursiveComparison()
                     .isEqualTo(List.of(
                             new LuckyDraw(1, "머그컵"),
@@ -439,8 +454,11 @@ class BirthdayCafeServiceTest extends ServiceTest {
             birthdayCafeService.replaceLuckyDraws(IN_PROGRESS_BIRTHDAY_CAFE_ID, HOST1, List.of());
 
             // then
-            BirthdayCafe actual = entityManager.find(BirthdayCafe.class, IN_PROGRESS_BIRTHDAY_CAFE_ID);
-            assertThat(actual.getLuckyDraws()).isEmpty();
+            List<LuckyDraw> actual = entityManager.createQuery(
+                            "select bc.luckyDraws from BirthdayCafe bc where bc.id = :id", LuckyDraw.class)
+                    .setParameter("id", IN_PROGRESS_BIRTHDAY_CAFE_ID)
+                    .getResultList();
+            assertThat(actual).isEmpty();
         }
 
         @Test

--- a/src/test/java/com/birca/bircabackend/command/birca/application/BirthdayCafeServiceTest.java
+++ b/src/test/java/com/birca/bircabackend/command/birca/application/BirthdayCafeServiceTest.java
@@ -373,7 +373,7 @@ class BirthdayCafeServiceTest extends ServiceTest {
         }
 
         @Test
-        void 기존_특전을_완전히_대체한다() {
+        void 기존_메뉴를_완전히_대체한다() {
             // given
             birthdayCafeService.replaceMenus(IN_PROGRESS_BIRTHDAY_CAFE_ID, HOST1, request);
 
@@ -446,7 +446,7 @@ class BirthdayCafeServiceTest extends ServiceTest {
         }
 
         @Test
-        void 기존_특전을_완전히_대체한다() {
+        void 기존_럭키드로우를_완전히_대체한다() {
             // given
             birthdayCafeService.replaceLuckyDraws(IN_PROGRESS_BIRTHDAY_CAFE_ID, HOST1, requests);
 

--- a/src/test/java/com/birca/bircabackend/command/birca/presentation/BirthdayCafeControllerTest.java
+++ b/src/test/java/com/birca/bircabackend/command/birca/presentation/BirthdayCafeControllerTest.java
@@ -1,9 +1,6 @@
 package com.birca.bircabackend.command.birca.presentation;
 
-import com.birca.bircabackend.command.birca.dto.ApplyRentalRequest;
-import com.birca.bircabackend.command.birca.dto.MenuRequest;
-import com.birca.bircabackend.command.birca.dto.SpecialGoodsRequest;
-import com.birca.bircabackend.command.birca.dto.StateChangeRequest;
+import com.birca.bircabackend.command.birca.dto.*;
 import com.birca.bircabackend.command.birca.exception.BirthdayCafeErrorCode;
 import com.birca.bircabackend.support.enviroment.DocumentationTest;
 import org.junit.jupiter.api.Test;
@@ -171,6 +168,36 @@ public class BirthdayCafeControllerTest extends DocumentationTest {
                                 fieldWithPath("[].name").type(JsonFieldType.STRING).description("메뉴의 이름"),
                                 fieldWithPath("[].details").type(JsonFieldType.STRING).description("메뉴의 세부 내용"),
                                 fieldWithPath("[].price").type(JsonFieldType.NUMBER).description("메뉴의 가격")
+                        )
+                ));
+    }
+
+    @Test
+    void 생일_카페_럭키_드로우를_추가한다() throws Exception {
+        // given
+        Long birthdayCafeId = 1L;
+        List<LuckyDrawRequest> request = List.of(
+                new LuckyDrawRequest(1, "머그컵"),
+                new LuckyDrawRequest(2, "포토 카드")
+        );
+
+        // when
+        ResultActions result = mockMvc.perform(
+                post("/api/v1/birthday-cafes/{birthdayCafeId}/lucky-draws", birthdayCafeId)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request))
+                        .header(HttpHeaders.AUTHORIZATION, bearerTokenProvider.getToken(MEMBER_ID))
+        );
+
+        // then
+        result.andExpect((status().isOk()))
+                .andDo(document("birthday-cafe-lucky-draw", HOST_INFO, DOCUMENT_RESPONSE,
+                        pathParameters(
+                                parameterWithName("birthdayCafeId").description("메뉴를 추가할 생일 카페 ID")
+                        ),
+                        requestFields(
+                                fieldWithPath("[].rank").type(JsonFieldType.NUMBER).description("등수"),
+                                fieldWithPath("[].prize").type(JsonFieldType.STRING).description("상품")
                         )
                 ));
     }


### PR DESCRIPTION
## 🌍 이슈 번호
- closed #59 

## 📝 구현 내용
- 럭키 드로우 등록/수정/삭제 구현

## 🍀 확인해야 할 부분
- 특전, 메뉴, 럭키 드로우의 fetch type을 EAGER에서 LAZY로 변경했습니다.
  - 일대다 관계에서 EAGER로 해도 하나밖에 조인으로 가져오지 못하고 (나머지는 추가 쿼리로 가져옴) 애초에 EAGER면 나중에 조회 로직 때 N + 1의 위험이 있다고 판단해 LAZY로 변경했습니다.
- `lucky_draw`의 `rank` 칼럼 `ranks`로 변경
  - `rank`가 mysql 예약어라 mysql 테스트에선 실패했습니다. 때문에 `ranks`로 칼럼명을 변경했습니다. 
  - 자바 코드에선 그대로 `rank`로 사용합니다.