### PR TITLE
[FEAT] 생일 카페 대표 이미지 지정

### DIFF
--- a/src/docs/asciidoc/api.adoc
+++ b/src/docs/asciidoc/api.adoc
@@ -78,8 +78,10 @@ operation::get-menus[snippets='http-request,path-parameters,http-response']
 operation::get-lucky-draws[snippets='http-request,path-parameters,http-response']
 === 생일 카페 정보 수정
 operation::birthday-cafe-update[snippets='http-request,path-parameters,request-fields,http-response']
-=== 생일 카페 이미지 업로드
-operation::upload-birthday-cafe-image[snippets='http-request,http-response']
+=== 생일 카페 기본 이미지 업로드
+operation::upload-birthday-cafe-default-image[snippets='http-request,http-response']
+=== 생일 카페 대표 이미지 업로드
+operation::upload-birthday-cafe-main-image[snippets='http-request,http-response']
 === 에러 코드
 include::{snippets}/birthday-cafe-error-Code/response-body.adoc[]
 

--- a/src/main/java/com/birca/bircabackend/command/birca/application/BirthdayCafeImageFacade.java
+++ b/src/main/java/com/birca/bircabackend/command/birca/application/BirthdayCafeImageFacade.java
@@ -5,9 +5,11 @@ import com.birca.bircabackend.command.birca.exception.BirthdayCafeErrorCode;
 import com.birca.bircabackend.common.EntityUtil;
 import com.birca.bircabackend.common.upload.ImageUploader;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
 import org.springframework.web.multipart.MultipartFile;
 
+@Slf4j
 @Component
 @RequiredArgsConstructor
 public class BirthdayCafeImageFacade {
@@ -17,10 +19,17 @@ public class BirthdayCafeImageFacade {
     private final ImageUploader imageUploader;
     private final EntityUtil entityUtil;
 
-    public void save(Long birthdayCafeId, MultipartFile birthdayCafeImage) {
+    public void updateDefaultImage(Long birthdayCafeId, MultipartFile defaultImage) {
         birthdayCafeImageValidator.validateImagesSize(birthdayCafeId);
         entityUtil.getEntity(BirthdayCafe.class, birthdayCafeId, BirthdayCafeErrorCode.NOT_FOUND);
-        String imageUrl = imageUploader.upload(birthdayCafeImage);
-        birthdayCafeImageService.save(birthdayCafeId, imageUrl);
+        String imageUrl = imageUploader.upload(defaultImage);
+        birthdayCafeImageService.saveDefaultImage(birthdayCafeId, imageUrl);
+    }
+
+    public void updateMainImage(Long birthdayCafeId, MultipartFile mainImage) {
+        entityUtil.getEntity(BirthdayCafe.class, birthdayCafeId, BirthdayCafeErrorCode.NOT_FOUND);
+        String imageUrl = imageUploader.upload(mainImage);
+        birthdayCafeImageService.updateMainImage(birthdayCafeId, imageUrl)
+                .ifPresent(imageUploader::delete);
     }
 }

--- a/src/main/java/com/birca/bircabackend/command/birca/application/BirthdayCafeImageFacade.java
+++ b/src/main/java/com/birca/bircabackend/command/birca/application/BirthdayCafeImageFacade.java
@@ -5,11 +5,9 @@ import com.birca.bircabackend.command.birca.exception.BirthdayCafeErrorCode;
 import com.birca.bircabackend.common.EntityUtil;
 import com.birca.bircabackend.common.upload.ImageUploader;
 import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
 import org.springframework.web.multipart.MultipartFile;
 
-@Slf4j
 @Component
 @RequiredArgsConstructor
 public class BirthdayCafeImageFacade {

--- a/src/main/java/com/birca/bircabackend/command/birca/application/BirthdayCafeImageService.java
+++ b/src/main/java/com/birca/bircabackend/command/birca/application/BirthdayCafeImageService.java
@@ -6,6 +6,8 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.Optional;
+
 @Service
 @Transactional
 @RequiredArgsConstructor
@@ -13,8 +15,28 @@ public class BirthdayCafeImageService {
 
     private final BirthdayCafeImageRepository birthdayCafeImageRepository;
 
-    public void save(Long birthdayCafeId, String imageUrl) {
-        BirthdayCafeImage birthdayCafeImage = new BirthdayCafeImage(birthdayCafeId, imageUrl);
+    public void saveDefaultImage(Long birthdayCafeId, String imageUrl) {
+        BirthdayCafeImage birthdayCafeImage = BirthdayCafeImage.createDefaultImage(birthdayCafeId, imageUrl);
         birthdayCafeImageRepository.save(birthdayCafeImage);
+    }
+
+    public Optional<String> updateMainImage(Long birthdayCafeId, String imageUrl) {
+        return birthdayCafeImageRepository.findByBirthdayCafeIdAndIsMain(birthdayCafeId, true)
+                .stream()
+                .findFirst()
+                .map(mainImage -> {
+                    String previousImageUrl = mainImage.getImageUrl();
+                    mainImage.updateMainImage(imageUrl);
+                    return Optional.ofNullable(previousImageUrl);
+                })
+                .orElseGet(() -> {
+                    saveMainImage(birthdayCafeId, imageUrl);
+                    return Optional.empty();
+                });
+    }
+
+    private void saveMainImage(Long birthdayCafeId, String imageUrl) {
+        BirthdayCafeImage mainImage = BirthdayCafeImage.createMainImage(birthdayCafeId, imageUrl);
+        birthdayCafeImageRepository.save(mainImage);
     }
 }

--- a/src/main/java/com/birca/bircabackend/command/birca/domain/BirthdayCafeImage.java
+++ b/src/main/java/com/birca/bircabackend/command/birca/domain/BirthdayCafeImage.java
@@ -21,9 +21,21 @@ public class BirthdayCafeImage extends BaseEntity {
     @Column(nullable = false)
     private Boolean isMain;
 
-    public BirthdayCafeImage(Long birthdayCafeId, String imageUrl) {
+    public static BirthdayCafeImage createDefaultImage(Long birthdayCafeId, String imageUrl) {
+        return new BirthdayCafeImage(birthdayCafeId, imageUrl, false);
+    }
+
+    public static BirthdayCafeImage createMainImage(Long birthdayCafeId, String imageUrl) {
+        return new BirthdayCafeImage(birthdayCafeId, imageUrl, true);
+    }
+
+    private BirthdayCafeImage(Long birthdayCafeId, String imageUrl, Boolean isMain) {
         this.birthdayCafeId = birthdayCafeId;
         this.imageUrl = imageUrl;
-        this.isMain = false;
+        this.isMain = isMain;
+    }
+
+    public void updateMainImage(String imageUrl) {
+        this.imageUrl = imageUrl;
     }
 }

--- a/src/main/java/com/birca/bircabackend/command/birca/presentation/BirthdayCafeImageController.java
+++ b/src/main/java/com/birca/bircabackend/command/birca/presentation/BirthdayCafeImageController.java
@@ -16,9 +16,17 @@ public class BirthdayCafeImageController {
 
     @PostMapping("/v1/birthday-cafes/{birthdayCafeId}/images")
     @RequiredLogin
-    public ResponseEntity<Void> uploadImage(@PathVariable Long birthdayCafeId,
-                                            @ModelAttribute MultipartFile birthdayCafeImage) {
-        birthdayCafeImageFacade.save(birthdayCafeId, birthdayCafeImage);
+    public ResponseEntity<Void> uploadDefaultImage(@PathVariable Long birthdayCafeId,
+                                            @ModelAttribute MultipartFile defaultImage) {
+        birthdayCafeImageFacade.updateDefaultImage(birthdayCafeId, defaultImage);
+        return ResponseEntity.ok().build();
+    }
+
+    @PostMapping("/v1/birthday-cafes/{birthdayCafeId}/images/main")
+    @RequiredLogin
+    public ResponseEntity<Void> uploadMainImage(@PathVariable Long birthdayCafeId,
+                                                @ModelAttribute MultipartFile mainImage) {
+        birthdayCafeImageFacade.updateMainImage(birthdayCafeId, mainImage);
         return ResponseEntity.ok().build();
     }
 }

--- a/src/main/java/com/birca/bircabackend/common/upload/AwsS3Uploader.java
+++ b/src/main/java/com/birca/bircabackend/common/upload/AwsS3Uploader.java
@@ -1,6 +1,7 @@
 package com.birca.bircabackend.common.upload;
 
 import com.amazonaws.services.s3.AmazonS3;
+import com.amazonaws.services.s3.model.DeleteObjectRequest;
 import com.amazonaws.services.s3.model.ObjectMetadata;
 import com.birca.bircabackend.common.exception.BusinessException;
 import com.birca.bircabackend.common.exception.InternalServerErrorCode;
@@ -10,12 +11,16 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 import org.springframework.web.multipart.MultipartFile;
 
+import java.net.URLDecoder;
+import java.nio.charset.StandardCharsets;
 import java.util.UUID;
 
 @Slf4j
 @Component
 @RequiredArgsConstructor
 public class AwsS3Uploader implements ImageUploader {
+
+    private static final String DEFAULT_PATH = "https://birca-bucket.s3.ap-northeast-2.amazonaws.com/";
 
     @Value("${cloud.aws.s3.bucket}")
     private String bucket;
@@ -31,8 +36,18 @@ public class AwsS3Uploader implements ImageUploader {
             amazonS3.putObject(bucket, s3FileName, image.getInputStream(), objectMetadata);
             return amazonS3.getUrl(bucket, s3FileName).toString();
         } catch (Exception e) {
-            log.error("S3 업로드 중 문제가 발생했습니다.");
+            log.error("S3 업로드 중 에러가 발생했습니다.");
             throw BusinessException.from(new InternalServerErrorCode(e.getMessage()));
         }
+    }
+
+    @Override
+    public void delete(String imageUrl) {
+        amazonS3.deleteObject(new DeleteObjectRequest(bucket, getKey(imageUrl)));
+    }
+
+    private String getKey(String imageUrl) {
+        String key = imageUrl.replaceAll(DEFAULT_PATH, "");
+        return URLDecoder.decode(key, StandardCharsets.UTF_8);
     }
 }

--- a/src/main/java/com/birca/bircabackend/common/upload/ImageUploader.java
+++ b/src/main/java/com/birca/bircabackend/common/upload/ImageUploader.java
@@ -5,4 +5,6 @@ import org.springframework.web.multipart.MultipartFile;
 public interface ImageUploader {
 
     String upload(MultipartFile image);
+
+    void delete(String imageUrl);
 }

--- a/src/main/resources/static/docs/api.html
+++ b/src/main/resources/static/docs/api.html
@@ -495,7 +495,8 @@ body.book #toc,body.book #preamble,body.book h1.sect0,body.book .sect1>h2{page-b
 <li><a href="#_생일_카페_메뉴_조회">생일 카페 메뉴 조회</a></li>
 <li><a href="#_생일_카페_럭키_드로우_조회">생일 카페 럭키 드로우 조회</a></li>
 <li><a href="#_생일_카페_정보_수정">생일 카페 정보 수정</a></li>
-<li><a href="#_생일_카페_이미지_업로드">생일 카페 이미지 업로드</a></li>
+<li><a href="#_생일_카페_기본_이미지_업로드">생일 카페 기본 이미지 업로드</a></li>
+<li><a href="#_생일_카페_대표_이미지_업로드">생일 카페 대표 이미지 업로드</a></li>
 <li><a href="#_에러_코드_5">에러 코드</a></li>
 </ul>
 </li>
@@ -638,7 +639,7 @@ Content-Length: 97
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">POST /api/v1/members/role-change HTTP/1.1
 Content-Type: application/json;charset=UTF-8
-Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwiaWF0IjoxNzEwNjA1NzI2LCJleHAiOjE3MTA2MDc1MjZ9.jSXdqkCnt9_PHFQoWJddANfY5jjNn1d7GwaR-jYSlZ0
+Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwiaWF0IjoxNzEwNzY1MjM3LCJleHAiOjE3MTA3NjcwMzd9.Lg5TrQYSwyXYP4AAiG5eNW6LggpdG8HvfbkPIa1Np7o
 Content-Length: 21
 Host: www.api.birca.com
 
@@ -668,7 +669,7 @@ Vary: Access-Control-Request-Headers</code></pre>
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">GET /api/v1/join/check-nickname?nickname=does HTTP/1.1
 Content-Type: application/json;charset=UTF-8
-Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwiaWF0IjoxNzEwNjA1NzI4LCJleHAiOjE3MTA2MDc1Mjh9.rpSmHAQBUuy9LOUyruk4cKVcygiy5hxY9w0IEkPsLY4
+Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwiaWF0IjoxNzEwNzY1MjM5LCJleHAiOjE3MTA3NjcwMzl9.f96IQzNsuu9oY3K4Kxc5N5Q6z9tYlh-BKrtl-_ExPgA
 Host: www.api.birca.com</code></pre>
 </div>
 </div>
@@ -742,7 +743,7 @@ Content-Length: 16
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">POST /api/v1/join/register-nickname HTTP/1.1
 Content-Type: application/json;charset=UTF-8
-Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwiaWF0IjoxNzEwNjA1NzI2LCJleHAiOjE3MTA2MDc1MjZ9.jSXdqkCnt9_PHFQoWJddANfY5jjNn1d7GwaR-jYSlZ0
+Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwiaWF0IjoxNzEwNzY1MjM3LCJleHAiOjE3MTA3NjcwMzd9.Lg5TrQYSwyXYP4AAiG5eNW6LggpdG8HvfbkPIa1Np7o
 Content-Length: 30
 Host: www.api.birca.com
 
@@ -830,7 +831,7 @@ Vary: Access-Control-Request-Headers</code></pre>
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">GET /api/v1/artist-groups?cursor=10&amp;size=3 HTTP/1.1
 Content-Type: application/json;charset=UTF-8
-Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwiaWF0IjoxNzEwNjA1NzI4LCJleHAiOjE3MTA2MDc1Mjh9.rpSmHAQBUuy9LOUyruk4cKVcygiy5hxY9w0IEkPsLY4
+Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwiaWF0IjoxNzEwNzY1MjM5LCJleHAiOjE3MTA3NjcwMzl9.f96IQzNsuu9oY3K4Kxc5N5Q6z9tYlh-BKrtl-_ExPgA
 Host: www.api.birca.com</code></pre>
 </div>
 </div>
@@ -930,7 +931,7 @@ Content-Length: 250
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">GET /api/v1/artist-groups/1/artists HTTP/1.1
 Content-Type: application/json;charset=UTF-8
-Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwiaWF0IjoxNzEwNjA1NzI4LCJleHAiOjE3MTA2MDc1Mjh9.rpSmHAQBUuy9LOUyruk4cKVcygiy5hxY9w0IEkPsLY4
+Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwiaWF0IjoxNzEwNzY1MjM5LCJleHAiOjE3MTA3NjcwMzl9.f96IQzNsuu9oY3K4Kxc5N5Q6z9tYlh-BKrtl-_ExPgA
 Host: www.api.birca.com</code></pre>
 </div>
 </div>
@@ -1043,7 +1044,7 @@ Content-Length: 565
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">GET /api/v1/artists/solo?cursor=12&amp;size=6 HTTP/1.1
 Content-Type: application/json;charset=UTF-8
-Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwiaWF0IjoxNzEwNjA1NzI4LCJleHAiOjE3MTA2MDc1Mjh9.rpSmHAQBUuy9LOUyruk4cKVcygiy5hxY9w0IEkPsLY4
+Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwiaWF0IjoxNzEwNzY1MjM5LCJleHAiOjE3MTA3NjcwMzl9.f96IQzNsuu9oY3K4Kxc5N5Q6z9tYlh-BKrtl-_ExPgA
 Host: www.api.birca.com</code></pre>
 </div>
 </div>
@@ -1155,7 +1156,7 @@ Content-Length: 518
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">POST /api/v1/artists/favorite HTTP/1.1
 Content-Type: application/json;charset=UTF-8
-Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwiaWF0IjoxNzEwNjA1NzIxLCJleHAiOjE3MTA2MDc1MjF9.6Br9S9l0Ey2ZaxVnmjaU71MI8COc8pcm4gDIClOFqZk
+Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwiaWF0IjoxNzEwNzY1MjMwLCJleHAiOjE3MTA3NjcwMzB9._7dQg_UbKCUps2mW9vblZlzY1AZg6TRamQhZ4XeBdlg
 Content-Length: 20
 Host: www.api.birca.com
 
@@ -1209,7 +1210,7 @@ Vary: Access-Control-Request-Headers</code></pre>
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">POST /api/v1/artists/interest HTTP/1.1
 Content-Type: application/json;charset=UTF-8
-Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwiaWF0IjoxNzEwNjA1NzIxLCJleHAiOjE3MTA2MDc1MjF9.6Br9S9l0Ey2ZaxVnmjaU71MI8COc8pcm4gDIClOFqZk
+Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwiaWF0IjoxNzEwNzY1MjMwLCJleHAiOjE3MTA3NjcwMzB9._7dQg_UbKCUps2mW9vblZlzY1AZg6TRamQhZ4XeBdlg
 Content-Length: 68
 Host: www.api.birca.com
 
@@ -1267,7 +1268,7 @@ Vary: Access-Control-Request-Headers</code></pre>
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">GET /api/v1/artists/favorite HTTP/1.1
 Content-Type: application/json;charset=UTF-8
-Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwiaWF0IjoxNzEwNjA1NzI4LCJleHAiOjE3MTA2MDc1Mjh9.rpSmHAQBUuy9LOUyruk4cKVcygiy5hxY9w0IEkPsLY4
+Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwiaWF0IjoxNzEwNzY1MjM5LCJleHAiOjE3MTA3NjcwMzl9.f96IQzNsuu9oY3K4Kxc5N5Q6z9tYlh-BKrtl-_ExPgA
 Host: www.api.birca.com</code></pre>
 </div>
 </div>
@@ -1334,7 +1335,7 @@ Content-Length: 81
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">GET /api/v1/artists/interest HTTP/1.1
 Content-Type: application/json;charset=UTF-8
-Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwiaWF0IjoxNzEwNjA1NzI4LCJleHAiOjE3MTA2MDc1Mjh9.rpSmHAQBUuy9LOUyruk4cKVcygiy5hxY9w0IEkPsLY4
+Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwiaWF0IjoxNzEwNzY1MjM5LCJleHAiOjE3MTA3NjcwMzl9.f96IQzNsuu9oY3K4Kxc5N5Q6z9tYlh-BKrtl-_ExPgA
 Host: www.api.birca.com</code></pre>
 </div>
 </div>
@@ -1417,7 +1418,7 @@ Content-Length: 416
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">GET /api/v1/artists/search?name=%EB%A7%88%ED%81%AC HTTP/1.1
 Content-Type: application/json;charset=UTF-8
-Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwiaWF0IjoxNzEwNjA1NzI4LCJleHAiOjE3MTA2MDc1Mjh9.rpSmHAQBUuy9LOUyruk4cKVcygiy5hxY9w0IEkPsLY4
+Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwiaWF0IjoxNzEwNzY1MjM5LCJleHAiOjE3MTA3NjcwMzl9.f96IQzNsuu9oY3K4Kxc5N5Q6z9tYlh-BKrtl-_ExPgA
 Host: www.api.birca.com</code></pre>
 </div>
 </div>
@@ -1482,7 +1483,7 @@ Content-Length: 225
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">POST /api/v1/cafes/license-read HTTP/1.1
 Content-Type: multipart/form-data;charset=UTF-8; boundary=6o2knFse3p53ty9dmcQvWAIx1zInP11uCfbm
-Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwiaWF0IjoxNzEwNjA1NzI2LCJleHAiOjE3MTA2MDc1MjZ9.jSXdqkCnt9_PHFQoWJddANfY5jjNn1d7GwaR-jYSlZ0
+Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwiaWF0IjoxNzEwNzY1MjM3LCJleHAiOjE3MTA3NjcwMzd9.Lg5TrQYSwyXYP4AAiG5eNW6LggpdG8HvfbkPIa1Np7o
 Host: www.api.birca.com
 
 --6o2knFse3p53ty9dmcQvWAIx1zInP11uCfbm
@@ -1568,7 +1569,7 @@ Content-Length: 141
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">POST /api/v1/cafes/apply HTTP/1.1
 Content-Type: multipart/form-data;charset=UTF-8; boundary=6o2knFse3p53ty9dmcQvWAIx1zInP11uCfbm
-Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwiaWF0IjoxNzEwNjA1NzI2LCJleHAiOjE3MTA2MDc1MjZ9.jSXdqkCnt9_PHFQoWJddANfY5jjNn1d7GwaR-jYSlZ0
+Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwiaWF0IjoxNzEwNzY1MjM3LCJleHAiOjE3MTA3NjcwMzd9.Lg5TrQYSwyXYP4AAiG5eNW6LggpdG8HvfbkPIa1Np7o
 Host: www.api.birca.com
 
 --6o2knFse3p53ty9dmcQvWAIx1zInP11uCfbm
@@ -1642,7 +1643,7 @@ Vary: Access-Control-Request-Headers</code></pre>
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">POST /api/v1/birthday-cafes HTTP/1.1
 Content-Type: application/json;charset=UTF-8
-Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwiaWF0IjoxNzEwNjA1NzIzLCJleHAiOjE3MTA2MDc1MjN9.llKVdPDfhB1vDdFQBYQiJiKDm60XWCxjxwcvkr3eRWE
+Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwiaWF0IjoxNzEwNzY1MjM0LCJleHAiOjE3MTA3NjcwMzR9.4hzNKK8_N311O_lRqvgHDIiel5DtVBqjI2uAYQfqK3Y
 Content-Length: 234
 Host: www.api.birca.com
 
@@ -1738,7 +1739,7 @@ Vary: Access-Control-Request-Headers</code></pre>
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">POST /api/v1/birthday-cafes/1/cancel HTTP/1.1
 Content-Type: application/json;charset=UTF-8
-Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwiaWF0IjoxNzEwNjA1NzIzLCJleHAiOjE3MTA2MDc1MjN9.llKVdPDfhB1vDdFQBYQiJiKDm60XWCxjxwcvkr3eRWE
+Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwiaWF0IjoxNzEwNzY1MjM0LCJleHAiOjE3MTA3NjcwMzR9.4hzNKK8_N311O_lRqvgHDIiel5DtVBqjI2uAYQfqK3Y
 Host: www.api.birca.com</code></pre>
 </div>
 </div>
@@ -1785,7 +1786,7 @@ Vary: Access-Control-Request-Headers</code></pre>
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">PATCH /api/v1/birthday-cafes/1/congestion HTTP/1.1
 Content-Type: application/json;charset=UTF-8
-Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwiaWF0IjoxNzEwNjA1NzIzLCJleHAiOjE3MTA2MDc1MjN9.llKVdPDfhB1vDdFQBYQiJiKDm60XWCxjxwcvkr3eRWE
+Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwiaWF0IjoxNzEwNzY1MjM0LCJleHAiOjE3MTA3NjcwMzR9.4hzNKK8_N311O_lRqvgHDIiel5DtVBqjI2uAYQfqK3Y
 Content-Length: 26
 Host: www.api.birca.com
 
@@ -1865,7 +1866,7 @@ Vary: Access-Control-Request-Headers</code></pre>
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">POST /api/v1/birthday-cafes/1/like HTTP/1.1
 Content-Type: application/json;charset=UTF-8
-Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwiaWF0IjoxNzEwNjA1NzIzLCJleHAiOjE3MTA2MDc1MjN9.llKVdPDfhB1vDdFQBYQiJiKDm60XWCxjxwcvkr3eRWE
+Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwiaWF0IjoxNzEwNzY1MjM0LCJleHAiOjE3MTA3NjcwMzR9.4hzNKK8_N311O_lRqvgHDIiel5DtVBqjI2uAYQfqK3Y
 Host: www.api.birca.com</code></pre>
 </div>
 </div>
@@ -1912,7 +1913,7 @@ Vary: Access-Control-Request-Headers</code></pre>
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">DELETE /api/v1/birthday-cafes/1/like HTTP/1.1
 Content-Type: application/json;charset=UTF-8
-Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwiaWF0IjoxNzEwNjA1NzIzLCJleHAiOjE3MTA2MDc1MjN9.llKVdPDfhB1vDdFQBYQiJiKDm60XWCxjxwcvkr3eRWE
+Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwiaWF0IjoxNzEwNzY1MjM0LCJleHAiOjE3MTA3NjcwMzR9.4hzNKK8_N311O_lRqvgHDIiel5DtVBqjI2uAYQfqK3Y
 Host: www.api.birca.com</code></pre>
 </div>
 </div>
@@ -1959,7 +1960,7 @@ Vary: Access-Control-Request-Headers</code></pre>
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">POST /api/v1/birthday-cafes/1/special-goods HTTP/1.1
 Content-Type: application/json;charset=UTF-8
-Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwiaWF0IjoxNzEwNjA1NzIzLCJleHAiOjE3MTA2MDc1MjN9.llKVdPDfhB1vDdFQBYQiJiKDm60XWCxjxwcvkr3eRWE
+Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwiaWF0IjoxNzEwNzY1MjM0LCJleHAiOjE3MTA3NjcwMzR9.4hzNKK8_N311O_lRqvgHDIiel5DtVBqjI2uAYQfqK3Y
 Content-Length: 147
 Host: www.api.birca.com
 
@@ -2044,7 +2045,7 @@ Vary: Access-Control-Request-Headers</code></pre>
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">POST /api/v1/birthday-cafes/1/menus HTTP/1.1
 Content-Type: application/json;charset=UTF-8
-Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwiaWF0IjoxNzEwNjA1NzIzLCJleHAiOjE3MTA2MDc1MjN9.llKVdPDfhB1vDdFQBYQiJiKDm60XWCxjxwcvkr3eRWE
+Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwiaWF0IjoxNzEwNzY1MjM0LCJleHAiOjE3MTA3NjcwMzR9.4hzNKK8_N311O_lRqvgHDIiel5DtVBqjI2uAYQfqK3Y
 Content-Length: 197
 Host: www.api.birca.com
 
@@ -2136,7 +2137,7 @@ Vary: Access-Control-Request-Headers</code></pre>
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">POST /api/v1/birthday-cafes/1/lucky-draws HTTP/1.1
 Content-Type: application/json;charset=UTF-8
-Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwiaWF0IjoxNzEwNjA1NzIzLCJleHAiOjE3MTA2MDc1MjN9.llKVdPDfhB1vDdFQBYQiJiKDm60XWCxjxwcvkr3eRWE
+Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwiaWF0IjoxNzEwNzY1MjM0LCJleHAiOjE3MTA3NjcwMzR9.4hzNKK8_N311O_lRqvgHDIiel5DtVBqjI2uAYQfqK3Y
 Content-Length: 92
 Host: www.api.birca.com
 
@@ -2221,7 +2222,7 @@ Vary: Access-Control-Request-Headers</code></pre>
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">GET /api/v1/birthday-cafes/1/special-goods HTTP/1.1
 Content-Type: application/json;charset=UTF-8
-Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwiaWF0IjoxNzEwNjA1NzI4LCJleHAiOjE3MTA2MDc1Mjh9.rpSmHAQBUuy9LOUyruk4cKVcygiy5hxY9w0IEkPsLY4
+Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwiaWF0IjoxNzEwNzY1MjM5LCJleHAiOjE3MTA3NjcwMzl9.f96IQzNsuu9oY3K4Kxc5N5Q6z9tYlh-BKrtl-_ExPgA
 Host: www.api.birca.com</code></pre>
 </div>
 </div>
@@ -2278,7 +2279,7 @@ Content-Length: 126
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">GET /api/v1/birthday-cafes/1/menus HTTP/1.1
 Content-Type: application/json;charset=UTF-8
-Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwiaWF0IjoxNzEwNjA1NzI4LCJleHAiOjE3MTA2MDc1Mjh9.rpSmHAQBUuy9LOUyruk4cKVcygiy5hxY9w0IEkPsLY4
+Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwiaWF0IjoxNzEwNzY1MjM5LCJleHAiOjE3MTA3NjcwMzl9.f96IQzNsuu9oY3K4Kxc5N5Q6z9tYlh-BKrtl-_ExPgA
 Host: www.api.birca.com</code></pre>
 </div>
 </div>
@@ -2337,7 +2338,7 @@ Content-Length: 196
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">GET /api/v1/birthday-cafes/1/lucky-draws HTTP/1.1
 Content-Type: application/json;charset=UTF-8
-Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwiaWF0IjoxNzEwNjA1NzI4LCJleHAiOjE3MTA2MDc1Mjh9.rpSmHAQBUuy9LOUyruk4cKVcygiy5hxY9w0IEkPsLY4
+Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwiaWF0IjoxNzEwNzY1MjM5LCJleHAiOjE3MTA3NjcwMzl9.f96IQzNsuu9oY3K4Kxc5N5Q6z9tYlh-BKrtl-_ExPgA
 Host: www.api.birca.com</code></pre>
 </div>
 </div>
@@ -2394,7 +2395,7 @@ Content-Length: 88
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">PATCH /api/v1/birthday-cafes/1 HTTP/1.1
 Content-Type: application/json;charset=UTF-8
-Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwiaWF0IjoxNzEwNjA1NzIzLCJleHAiOjE3MTA2MDc1MjN9.llKVdPDfhB1vDdFQBYQiJiKDm60XWCxjxwcvkr3eRWE
+Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwiaWF0IjoxNzEwNzY1MjM0LCJleHAiOjE3MTA3NjcwMzR9.4hzNKK8_N311O_lRqvgHDIiel5DtVBqjI2uAYQfqK3Y
 Content-Length: 86
 Host: www.api.birca.com
 
@@ -2469,26 +2470,57 @@ Vary: Access-Control-Request-Headers</code></pre>
 </div>
 </div>
 <div class="sect2">
-<h3 id="_생일_카페_이미지_업로드"><a class="link" href="#_생일_카페_이미지_업로드">생일 카페 이미지 업로드</a></h3>
+<h3 id="_생일_카페_기본_이미지_업로드"><a class="link" href="#_생일_카페_기본_이미지_업로드">생일 카페 기본 이미지 업로드</a></h3>
 <div class="sect3">
-<h4 id="_생일_카페_이미지_업로드_http_request"><a class="link" href="#_생일_카페_이미지_업로드_http_request">HTTP request</a></h4>
+<h4 id="_생일_카페_기본_이미지_업로드_http_request"><a class="link" href="#_생일_카페_기본_이미지_업로드_http_request">HTTP request</a></h4>
 <div class="listingblock">
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">POST /api/v1/birthday-cafes/1/images HTTP/1.1
 Content-Type: multipart/form-data;charset=UTF-8; boundary=6o2knFse3p53ty9dmcQvWAIx1zInP11uCfbm
-Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwiaWF0IjoxNzEwNjA1NzIzLCJleHAiOjE3MTA2MDc1MjN9.llKVdPDfhB1vDdFQBYQiJiKDm60XWCxjxwcvkr3eRWE
+Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwiaWF0IjoxNzEwNzY1MjM0LCJleHAiOjE3MTA3NjcwMzR9.4hzNKK8_N311O_lRqvgHDIiel5DtVBqjI2uAYQfqK3Y
 Host: www.api.birca.com
 
 --6o2knFse3p53ty9dmcQvWAIx1zInP11uCfbm
-Content-Disposition: form-data; name=birthdayCafeImage
+Content-Disposition: form-data; name=defaultImage
 
-birthdayCafeImage
+defaultImage
 --6o2knFse3p53ty9dmcQvWAIx1zInP11uCfbm--</code></pre>
 </div>
 </div>
 </div>
 <div class="sect3">
-<h4 id="_생일_카페_이미지_업로드_http_response"><a class="link" href="#_생일_카페_이미지_업로드_http_response">HTTP response</a></h4>
+<h4 id="_생일_카페_기본_이미지_업로드_http_response"><a class="link" href="#_생일_카페_기본_이미지_업로드_http_response">HTTP response</a></h4>
+<div class="listingblock">
+<div class="content">
+<pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">HTTP/1.1 200 OK
+Vary: Origin
+Vary: Access-Control-Request-Method
+Vary: Access-Control-Request-Headers</code></pre>
+</div>
+</div>
+</div>
+</div>
+<div class="sect2">
+<h3 id="_생일_카페_대표_이미지_업로드"><a class="link" href="#_생일_카페_대표_이미지_업로드">생일 카페 대표 이미지 업로드</a></h3>
+<div class="sect3">
+<h4 id="_생일_카페_대표_이미지_업로드_http_request"><a class="link" href="#_생일_카페_대표_이미지_업로드_http_request">HTTP request</a></h4>
+<div class="listingblock">
+<div class="content">
+<pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">POST /api/v1/birthday-cafes/1/images/main HTTP/1.1
+Content-Type: multipart/form-data;charset=UTF-8; boundary=6o2knFse3p53ty9dmcQvWAIx1zInP11uCfbm
+Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwiaWF0IjoxNzEwNzY1MjM0LCJleHAiOjE3MTA3NjcwMzR9.4hzNKK8_N311O_lRqvgHDIiel5DtVBqjI2uAYQfqK3Y
+Host: www.api.birca.com
+
+--6o2knFse3p53ty9dmcQvWAIx1zInP11uCfbm
+Content-Disposition: form-data; name=mainImage
+
+mainImage
+--6o2knFse3p53ty9dmcQvWAIx1zInP11uCfbm--</code></pre>
+</div>
+</div>
+</div>
+<div class="sect3">
+<h4 id="_생일_카페_대표_이미지_업로드_http_response"><a class="link" href="#_생일_카페_대표_이미지_업로드_http_response">HTTP response</a></h4>
 <div class="listingblock">
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">HTTP/1.1 200 OK
@@ -2569,7 +2601,7 @@ Vary: Access-Control-Request-Headers</code></pre>
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">GET /api/v1/cafes/search?name=%EC%BB%A4%ED%94%BC HTTP/1.1
 Content-Type: application/json;charset=UTF-8
-Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwiaWF0IjoxNzEwNjA1NzI4LCJleHAiOjE3MTA2MDc1Mjh9.rpSmHAQBUuy9LOUyruk4cKVcygiy5hxY9w0IEkPsLY4
+Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwiaWF0IjoxNzEwNzY1MjM5LCJleHAiOjE3MTA3NjcwMzl9.f96IQzNsuu9oY3K4Kxc5N5Q6z9tYlh-BKrtl-_ExPgA
 Host: www.api.birca.com</code></pre>
 </div>
 </div>
@@ -2602,7 +2634,7 @@ Content-Length: 106
 <div id="footer">
 <div id="footer-text">
 Version 0.0.1-SNAPSHOT<br>
-Last updated 2024-03-15 20:24:13 +0900
+Last updated 2024-03-18 21:20:34 +0900
 </div>
 </div>
 <script src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/9.18.3/highlight.min.js"></script>

--- a/src/test/java/com/birca/bircabackend/command/birca/acceptance/BirthdayCafeImageAcceptanceTest.java
+++ b/src/test/java/com/birca/bircabackend/command/birca/acceptance/BirthdayCafeImageAcceptanceTest.java
@@ -21,7 +21,7 @@ public class BirthdayCafeImageAcceptanceTest extends AcceptanceTest {
     private static final Long BIRTHDAY_CAFE_ID = 2L;
 
     @Test
-    void 생일_카페_이미지를_저장한다() {
+    void 생일_카페_기본_이미지를_업로드한다() {
         //given
         File birthdayCafeImage = new File("src/test/resources/birthdayCafe.jpeg");
 
@@ -31,6 +31,24 @@ public class BirthdayCafeImageAcceptanceTest extends AcceptanceTest {
                 .header(HttpHeaders.AUTHORIZATION, bearerTokenProvider.getToken(MEMBER_ID))
                 .multiPart("birthdayCafeImage", birthdayCafeImage)
                 .post("/api/v1/birthday-cafes/{birthdayCafeId}/images", BIRTHDAY_CAFE_ID)
+                .then().log().all()
+                .extract();
+
+        // then
+        assertThat(response.statusCode()).isEqualTo(HttpStatus.OK.value());
+    }
+
+    @Test
+    void 생일_카페_대표_이미지를_업로드한다() {
+        //given
+        File birthdayCafeImage = new File("src/test/resources/birthdayCafe.jpeg");
+
+        // when
+        ExtractableResponse<Response> response = RestAssured.given().log().all()
+                .contentType(MediaType.MULTIPART_FORM_DATA_VALUE)
+                .header(HttpHeaders.AUTHORIZATION, bearerTokenProvider.getToken(MEMBER_ID))
+                .multiPart("birthdayCafeImage", birthdayCafeImage)
+                .post("/api/v1/birthday-cafes/{birthdayCafeId}/images/main", BIRTHDAY_CAFE_ID)
                 .then().log().all()
                 .extract();
 

--- a/src/test/java/com/birca/bircabackend/command/birca/application/BirthdayCafeImageFacadeTest.java
+++ b/src/test/java/com/birca/bircabackend/command/birca/application/BirthdayCafeImageFacadeTest.java
@@ -26,8 +26,8 @@ class BirthdayCafeImageFacadeTest extends ServiceTest {
             new MockMultipartFile("birthdayCafeImage",  "image1".getBytes());
 
     @Nested
-    @DisplayName("생일 카페 이미지 업로드 시")
-    class UploadTest {
+    @DisplayName("생일 카페 기본 이미지 업로드 시")
+    class UploadDefaultImageTest {
 
         @Test
         void 정상적으로_저장한다() {
@@ -35,7 +35,7 @@ class BirthdayCafeImageFacadeTest extends ServiceTest {
             Long birthdayCafeId = 2L;
 
             // when
-            birthdayCafeImageFacade.save(birthdayCafeId, BIRTHDAY_CAFE_IMAGE);
+            birthdayCafeImageFacade.updateDefaultImage(birthdayCafeId, BIRTHDAY_CAFE_IMAGE);
 
             // then
             verify(imageUploader, times(1)).upload(any());
@@ -47,7 +47,7 @@ class BirthdayCafeImageFacadeTest extends ServiceTest {
             Long birthdayCafeId = 1L;
 
             // when then
-            assertThatThrownBy(() -> birthdayCafeImageFacade.save(birthdayCafeId, BIRTHDAY_CAFE_IMAGE))
+            assertThatThrownBy(() -> birthdayCafeImageFacade.updateDefaultImage(birthdayCafeId, BIRTHDAY_CAFE_IMAGE))
                     .isInstanceOf(BusinessException.class)
                     .extracting("errorCode")
                     .isEqualTo(BirthdayCafeErrorCode.INVALID_UPLOAD_SIZE_REQUEST);
@@ -59,7 +59,48 @@ class BirthdayCafeImageFacadeTest extends ServiceTest {
             Long birthdayCafeId = 100L;
 
             // when then
-            assertThatThrownBy(() -> birthdayCafeImageFacade.save(birthdayCafeId, BIRTHDAY_CAFE_IMAGE))
+            assertThatThrownBy(() -> birthdayCafeImageFacade.updateDefaultImage(birthdayCafeId, BIRTHDAY_CAFE_IMAGE))
+                    .isInstanceOf(BusinessException.class)
+                    .extracting("errorCode")
+                    .isEqualTo(BirthdayCafeErrorCode.NOT_FOUND);
+        }
+    }
+
+    @Nested
+    @DisplayName("생일 카페 대표 이미지 업로드 시")
+    class uploadMainImageTest {
+
+        @Test
+        void 존재하면_변경한다() {
+            // given
+            Long birthdayCafeId = 1L;
+
+            // when
+            birthdayCafeImageFacade.updateMainImage(birthdayCafeId, BIRTHDAY_CAFE_IMAGE);
+
+            // then
+            verify(imageUploader, times(1)).upload(any());
+            verify(imageUploader, times(1)).delete(any());
+        }
+
+        @Test
+        void 존재하지_않으면_새로_저장한다() {
+            // given
+            Long birthdayCafeId = 2L;
+
+            // when
+            birthdayCafeImageFacade.updateMainImage(birthdayCafeId, BIRTHDAY_CAFE_IMAGE);
+            verify(imageUploader, times(1)).upload(any());
+            verify(imageUploader, times(0)).delete(any());
+        }
+
+        @Test
+        void 존재하지_생일_카페는_예외가_발생한다() {
+            // given
+            Long birthdayCafeId = 100L;
+
+            // when then
+            assertThatThrownBy(() -> birthdayCafeImageFacade.updateDefaultImage(birthdayCafeId, BIRTHDAY_CAFE_IMAGE))
                     .isInstanceOf(BusinessException.class)
                     .extracting("errorCode")
                     .isEqualTo(BirthdayCafeErrorCode.NOT_FOUND);

--- a/src/test/java/com/birca/bircabackend/command/birca/application/BirthdayCafeImageFacadeTest.java
+++ b/src/test/java/com/birca/bircabackend/command/birca/application/BirthdayCafeImageFacadeTest.java
@@ -100,7 +100,7 @@ class BirthdayCafeImageFacadeTest extends ServiceTest {
             Long birthdayCafeId = 100L;
 
             // when then
-            assertThatThrownBy(() -> birthdayCafeImageFacade.updateDefaultImage(birthdayCafeId, BIRTHDAY_CAFE_IMAGE))
+            assertThatThrownBy(() -> birthdayCafeImageFacade.updateMainImage(birthdayCafeId, BIRTHDAY_CAFE_IMAGE))
                     .isInstanceOf(BusinessException.class)
                     .extracting("errorCode")
                     .isEqualTo(BirthdayCafeErrorCode.NOT_FOUND);

--- a/src/test/java/com/birca/bircabackend/command/birca/application/BirthdayCafeImageServiceTest.java
+++ b/src/test/java/com/birca/bircabackend/command/birca/application/BirthdayCafeImageServiceTest.java
@@ -4,6 +4,8 @@ import com.birca.bircabackend.command.birca.domain.BirthdayCafeImage;
 import com.birca.bircabackend.support.enviroment.ServiceTest;
 import jakarta.persistence.EntityManager;
 import jakarta.persistence.PersistenceContext;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.test.context.jdbc.Sql;
@@ -22,13 +24,13 @@ class BirthdayCafeImageServiceTest extends ServiceTest {
     private EntityManager em;
 
     @Test
-    void 생일_카페_이미지를_저장한다() {
+    void 생일_카페_기본_이미지를_저장한다() {
         // given
         Long birthdayCafeId = 2L;
         String imageUrl = "mega-coffee.png";
 
         // when
-        birthdayCafeImageService.save(birthdayCafeId, imageUrl);
+        birthdayCafeImageService.saveDefaultImage(birthdayCafeId, imageUrl);
         List<BirthdayCafeImage> actual = em.createQuery(
                         "select bci from BirthdayCafeImage bci where bci.birthdayCafeId = :birthdayCafeId", BirthdayCafeImage.class)
                 .setParameter("birthdayCafeId", birthdayCafeId)
@@ -39,5 +41,46 @@ class BirthdayCafeImageServiceTest extends ServiceTest {
         assertThat(actual)
                 .extracting(BirthdayCafeImage::getIsMain)
                 .containsExactlyElementsOf(List.of(false, false, false, false));
+    }
+
+    @Nested
+    @DisplayName("생일 카페 대표 이미지를 저장할 때")
+    class saveMainImageTest {
+
+        @Test
+        void 존재하면_변경한다() {
+            // given
+            Long birthdayCafeId = 1L;
+            String imageUrl = "update-cafe.png";
+
+            // when
+            birthdayCafeImageService.updateMainImage(birthdayCafeId, imageUrl);
+            BirthdayCafeImage actual = em.createQuery(
+                            "select bci from BirthdayCafeImage bci where bci.birthdayCafeId = :birthdayCafeId and bci.isMain = :isMain", BirthdayCafeImage.class)
+                    .setParameter("birthdayCafeId", birthdayCafeId)
+                    .setParameter("isMain", true)
+                    .getSingleResult();
+
+            // then
+            assertThat(actual.getImageUrl()).isEqualTo(imageUrl);
+        }
+
+        @Test
+        void 존재하지_않으면_새로_저장한다() {
+            // given
+            Long birthdayCafeId = 2L;
+            String imageUrl = "new-cafe.png";
+
+            // when
+            birthdayCafeImageService.updateMainImage(birthdayCafeId, imageUrl);
+            BirthdayCafeImage actual = em.createQuery(
+                            "select bci from BirthdayCafeImage bci where bci.birthdayCafeId = :birthdayCafeId and bci.isMain = :isMain", BirthdayCafeImage.class)
+                    .setParameter("birthdayCafeId", birthdayCafeId)
+                    .setParameter("isMain", true)
+                    .getSingleResult();
+
+            // then
+            assertThat(actual.getImageUrl()).isEqualTo(imageUrl);
+        }
     }
 }

--- a/src/test/java/com/birca/bircabackend/command/birca/domain/BirthdayCafeImageTest.java
+++ b/src/test/java/com/birca/bircabackend/command/birca/domain/BirthdayCafeImageTest.java
@@ -1,23 +1,52 @@
 package com.birca.bircabackend.command.birca.domain;
 
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
 class BirthdayCafeImageTest {
 
+    private static final Long BIRTHDAY_CAFE_ID = 1L;
+    private static final String IMAGE_URL = "cafe.png";
+
+    @Nested
+    @DisplayName("생일 카페 이미지 생성할 때")
+    class createBirthdayCafeImageTest {
+
+        @Test
+        void 기본_이미지는_false로_생성된다() {
+            // when
+            BirthdayCafeImage birthdayCafeImage = BirthdayCafeImage.createDefaultImage(BIRTHDAY_CAFE_ID, IMAGE_URL);
+
+            // then
+            assertThat(birthdayCafeImage.getIsMain()).isFalse();
+            assertThat(birthdayCafeImage.getBirthdayCafeId()).isEqualTo(1L);
+            assertThat(birthdayCafeImage.getImageUrl()).isEqualTo(IMAGE_URL);
+        }
+
+        @Test
+        void 대표_이미지는_true로_생성된다() {
+            // when
+            BirthdayCafeImage birthdayCafeImage = BirthdayCafeImage.createMainImage(BIRTHDAY_CAFE_ID, IMAGE_URL);
+
+            // then
+            assertThat(birthdayCafeImage.getIsMain()).isTrue();
+            assertThat(birthdayCafeImage.getBirthdayCafeId()).isEqualTo(1L);
+            assertThat(birthdayCafeImage.getImageUrl()).isEqualTo(IMAGE_URL);
+        }
+    }
+
     @Test
-    void 생일_카페_저장_시_대표_이미지는_false로_생성된다() {
+    void 생일_카페_대표_이미지를_변경한다() {
         // given
-        Long birthdayCafeId = 1L;
-        String imageUrl = "cafe.png";
+        BirthdayCafeImage birthdayCafeImage = BirthdayCafeImage.createMainImage(BIRTHDAY_CAFE_ID, IMAGE_URL);
 
         // when
-        BirthdayCafeImage birthdayCafeImage = new BirthdayCafeImage(birthdayCafeId, imageUrl);
+        birthdayCafeImage.updateMainImage("mega-coffee.png");
 
         // then
-        assertThat(birthdayCafeImage.getIsMain()).isFalse();
-        assertThat(birthdayCafeImage.getBirthdayCafeId()).isEqualTo(1L);
-        assertThat(birthdayCafeImage.getImageUrl()).isEqualTo(imageUrl);
+        assertThat(birthdayCafeImage.getImageUrl()).isEqualTo("mega-coffee.png");
     }
 }

--- a/src/test/java/com/birca/bircabackend/command/birca/presentation/BirthdayCafeImageControllerTest.java
+++ b/src/test/java/com/birca/bircabackend/command/birca/presentation/BirthdayCafeImageControllerTest.java
@@ -18,26 +18,49 @@ class BirthdayCafeImageControllerTest extends DocumentationTest {
     private static final Long MEMBER_ID = 1L;
 
     @Test
-    void 생일_카페_이미지를_저장한다() throws Exception {
+    void 생일_카페_기본_이미지를_저장한다() throws Exception {
         // given
         Long birthdayCafeId = 1L;
-        MockMultipartFile birthdayCafeImage =
-                new MockMultipartFile("birthdayCafeImage",  "birthdayCafeImage".getBytes());
+        MockMultipartFile defaultImage = new MockMultipartFile("defaultImage",  "defaultImage".getBytes());
 
         // when
         ResultActions result = mockMvc.perform(multipart("/api/v1/birthday-cafes/{birthdayCafeId}/images", birthdayCafeId)
-                .file(birthdayCafeImage)
+                .file(defaultImage)
                 .contentType(MediaType.MULTIPART_FORM_DATA)
                 .header(HttpHeaders.AUTHORIZATION, bearerTokenProvider.getToken(MEMBER_ID)
                 ));
 
         // then
         result.andExpect((status().isOk()))
-                .andDo(document("upload-birthday-cafe-image",
+                .andDo(document("upload-birthday-cafe-default-image",
                         HOST_INFO,
                         DOCUMENT_RESPONSE,
                         requestParts(
-                                partWithName("birthdayCafeImage").description("생일 카페 이미지")
+                                partWithName("defaultImage").description("생일 카페 기본 이미지")
+                        )
+                ));
+    }
+
+    @Test
+    void 생일_카페_대표_이미지를_저장한다() throws Exception {
+        // given
+        Long birthdayCafeId = 1L;
+        MockMultipartFile mainImage = new MockMultipartFile("mainImage",  "mainImage".getBytes());
+
+        // when
+        ResultActions result = mockMvc.perform(multipart("/api/v1/birthday-cafes/{birthdayCafeId}/images/main", birthdayCafeId)
+                .file(mainImage)
+                .contentType(MediaType.MULTIPART_FORM_DATA)
+                .header(HttpHeaders.AUTHORIZATION, bearerTokenProvider.getToken(MEMBER_ID)
+                ));
+
+        // then
+        result.andExpect((status().isOk()))
+                .andDo(document("upload-birthday-cafe-main-image",
+                        HOST_INFO,
+                        DOCUMENT_RESPONSE,
+                        requestParts(
+                                partWithName("mainImage").description("생일 카페 대표 이미지")
                         )
                 ));
     }

--- a/src/test/java/com/birca/bircabackend/support/enviroment/MockEnvironment.java
+++ b/src/test/java/com/birca/bircabackend/support/enviroment/MockEnvironment.java
@@ -9,6 +9,7 @@ import org.springframework.boot.test.mock.mockito.MockBean;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.doNothing;
 
 public class MockEnvironment {
 
@@ -41,5 +42,7 @@ public class MockEnvironment {
     void mockImageUploader() {
         given(imageUploader.upload(any()))
                 .willReturn(URL);
+        doNothing().when(imageUploader)
+                .delete(any());
     }
 }


### PR DESCRIPTION
## 🌍 이슈 번호
* closed #68 

## 📝 구현 내용
* 생일 카페 대표 이미지 업로드

## 🍀 확인해야 할 부분
- 대표 이미지 조회
    - 존재 → S3에 새로운 대표 이미지 저장 → db 파일명 업데이트 → 기존 S3에 저장된 대표이미지 삭제
    - 존재 x → S3와 DB에 새로 저장

제가 구현한 방식 외에 더 좋은 방식이나 잘못된 로직이 있다면 말씀해주세요 !

```java
    @Override
    public void delete(String imageUrl) {
        amazonS3.deleteObject(new DeleteObjectRequest(bucket, getKey(imageUrl)));
    }

    private String getKey(String imageUrl) {
        String key = imageUrl.replaceAll(DEFAULT_PATH, "");
        return URLDecoder.decode(key, StandardCharsets.UTF_8);
    }
```

이미지 파일명이 한글이면 S3엔 한글이 깨지지 않고 저장이 되는데, 조회할 때는 한글 깨짐 현상이 있습니다. 그냥 삭제하면 삭제가 안돼서 디코딩 후 삭제하도록 했습니다.