### PR TITLE
[FEAT] 주최자의 나의 생일 카페 목록 조회 기능 구현

### DIFF
--- a/.github/workflows/cd-dev.yml
+++ b/.github/workflows/cd-dev.yml
@@ -14,6 +14,11 @@ jobs:
           java-version: 17
           distribution: 'adopt'
 
+      - name: 타임존 설정
+        uses: szenius/set-timezone@v1.2
+        with:
+          timezoneLinux: "Asia/Seoul"
+
       - name: 저장소 Checkout
         uses: actions/checkout@v3
         with:

--- a/src/docs/asciidoc/api.adoc
+++ b/src/docs/asciidoc/api.adoc
@@ -80,6 +80,8 @@ operation::get-lucky-draws[snippets='http-request,path-parameters,http-response'
 operation::birthday-cafe-update[snippets='http-request,path-parameters,request-fields,http-response']
 === 생일 카페 이미지 업로드
 operation::upload-birthday-cafe-image[snippets='http-request,http-response']
+=== 주최자의 나의 생일 카페 목록 조회
+operation::get-my-birthday-cafe-list[snippets='http-request,http-response,response-fields']
 === 에러 코드
 include::{snippets}/birthday-cafe-error-Code/response-body.adoc[]
 

--- a/src/docs/asciidoc/api.adoc
+++ b/src/docs/asciidoc/api.adoc
@@ -83,7 +83,7 @@ operation::upload-birthday-cafe-default-image[snippets='http-request,http-respon
 === 생일 카페 대표 이미지 업로드
 operation::upload-birthday-cafe-main-image[snippets='http-request,http-response']
 === 생일 카페 이미지 업로드
-operation::upload-birthday-cafe-image[snippets='http-request,http-response']
+operation::upload-birthday-cafe-default-image[snippets='http-request,http-response']
 === 주최자의 나의 생일 카페 목록 조회
 operation::get-my-birthday-cafe-list[snippets='http-request,http-response,response-fields']
 === 에러 코드

--- a/src/main/java/com/birca/bircabackend/query/controller/BirthdayCafeQueryController.java
+++ b/src/main/java/com/birca/bircabackend/query/controller/BirthdayCafeQueryController.java
@@ -1,8 +1,10 @@
 package com.birca.bircabackend.query.controller;
 
+import com.birca.bircabackend.command.auth.authorization.LoginMember;
 import com.birca.bircabackend.command.auth.authorization.RequiredLogin;
 import com.birca.bircabackend.query.dto.LuckyDrawResponse;
 import com.birca.bircabackend.query.dto.MenuResponse;
+import com.birca.bircabackend.query.dto.MyBirthdayCafeResponse;
 import com.birca.bircabackend.query.dto.SpecialGoodsResponse;
 import com.birca.bircabackend.query.service.BirthdayCafeQueryService;
 import lombok.RequiredArgsConstructor;
@@ -37,5 +39,11 @@ public class BirthdayCafeQueryController {
     @RequiredLogin
     public ResponseEntity<List<LuckyDrawResponse>> findLuckyDraws(@PathVariable Long birthdayCafeId) {
         return ResponseEntity.ok(birthdayCafeQueryService.findLuckyDraws(birthdayCafeId));
+    }
+
+    @GetMapping("/v1/birthday-cafes/me")
+    @RequiredLogin
+    public ResponseEntity<List<MyBirthdayCafeResponse>> findMyBirthdayCafes(LoginMember loginMember) {
+        return ResponseEntity.ok(birthdayCafeQueryService.findMyBirthdayCafes(loginMember));
     }
 }

--- a/src/main/java/com/birca/bircabackend/query/dto/MyBirthdayCafeResponse.java
+++ b/src/main/java/com/birca/bircabackend/query/dto/MyBirthdayCafeResponse.java
@@ -1,0 +1,26 @@
+package com.birca.bircabackend.query.dto;
+
+import java.time.LocalDateTime;
+
+public record MyBirthdayCafeResponse(
+        BirthdayCafe birthdayCafe
+) {
+
+    public record BirthdayCafe(
+            Long id,
+            String mainImageUrl,
+            LocalDateTime startDate,
+            LocalDateTime endDate,
+            String name,
+            String progressState,
+            Artist artist
+
+    ) {
+    }
+
+    public record Artist(
+            String groupName,
+            String name
+    ){
+    }
+}

--- a/src/main/java/com/birca/bircabackend/query/dto/MyBirthdayCafeResponse.java
+++ b/src/main/java/com/birca/bircabackend/query/dto/MyBirthdayCafeResponse.java
@@ -1,26 +1,53 @@
 package com.birca.bircabackend.query.dto;
 
+import com.birca.bircabackend.command.artist.domain.Artist;
+import com.birca.bircabackend.command.artist.domain.ArtistGroup;
+import com.birca.bircabackend.command.birca.domain.BirthdayCafe;
+import com.birca.bircabackend.command.birca.domain.BirthdayCafeImage;
+import com.birca.bircabackend.query.repository.model.BirthdayCafeView;
+
 import java.time.LocalDateTime;
 
 public record MyBirthdayCafeResponse(
-        BirthdayCafe birthdayCafe
+        BirthdayCafeResponse birthdayCafe
 ) {
 
-    public record BirthdayCafe(
+    public static MyBirthdayCafeResponse from(BirthdayCafeView birthdayCafeView) {
+        BirthdayCafe birthdayCafe = birthdayCafeView.birthdayCafe();
+        BirthdayCafeImage mainImage = birthdayCafeView.mainImage();
+        ArtistGroup artistGroup = birthdayCafeView.artistGroup();
+        Artist artist = birthdayCafeView.artist();
+        return new MyBirthdayCafeResponse(
+                new BirthdayCafeResponse(
+                        birthdayCafe.getId(),
+                        mainImage == null ? null : mainImage.getImageUrl(),
+                        birthdayCafe.getSchedule().getStartDate(),
+                        birthdayCafe.getSchedule().getEndDate(),
+                        birthdayCafe.getName(),
+                        birthdayCafe.getProgressState().name(),
+                        new ArtistResponse(
+                                artistGroup == null ? null : artistGroup.getName(),
+                                artist.getName()
+                        )
+                )
+        );
+    }
+
+    public record BirthdayCafeResponse(
             Long id,
             String mainImageUrl,
             LocalDateTime startDate,
             LocalDateTime endDate,
             String name,
             String progressState,
-            Artist artist
+            ArtistResponse artist
 
     ) {
     }
 
-    public record Artist(
+    public record ArtistResponse(
             String groupName,
             String name
-    ){
+    ) {
     }
 }

--- a/src/main/java/com/birca/bircabackend/query/dto/MyBirthdayCafeResponse.java
+++ b/src/main/java/com/birca/bircabackend/query/dto/MyBirthdayCafeResponse.java
@@ -9,7 +9,13 @@ import com.birca.bircabackend.query.repository.model.BirthdayCafeView;
 import java.time.LocalDateTime;
 
 public record MyBirthdayCafeResponse(
-        BirthdayCafeResponse birthdayCafe
+        Long birthdayCafeId,
+        String mainImageUrl,
+        LocalDateTime startDate,
+        LocalDateTime endDate,
+        String birthdayCafeName,
+        String progressState,
+        ArtistResponse artist
 ) {
 
     public static MyBirthdayCafeResponse from(BirthdayCafeView birthdayCafeView) {
@@ -18,31 +24,18 @@ public record MyBirthdayCafeResponse(
         ArtistGroup artistGroup = birthdayCafeView.artistGroup();
         Artist artist = birthdayCafeView.artist();
         return new MyBirthdayCafeResponse(
-                new BirthdayCafeResponse(
-                        birthdayCafe.getId(),
-                        mainImage == null ? null : mainImage.getImageUrl(),
-                        birthdayCafe.getSchedule().getStartDate(),
-                        birthdayCafe.getSchedule().getEndDate(),
-                        birthdayCafe.getName(),
-                        birthdayCafe.getProgressState().name(),
-                        new ArtistResponse(
-                                artistGroup == null ? null : artistGroup.getName(),
-                                artist.getName()
-                        )
+                birthdayCafe.getId(),
+                mainImage == null ? null : mainImage.getImageUrl(),
+                birthdayCafe.getSchedule().getStartDate(),
+                birthdayCafe.getSchedule().getEndDate(),
+                birthdayCafe.getName(),
+                birthdayCafe.getProgressState().name(),
+                new ArtistResponse(
+                        artistGroup == null ? null : artistGroup.getName(),
+                        artist.getName()
                 )
+
         );
-    }
-
-    public record BirthdayCafeResponse(
-            Long id,
-            String mainImageUrl,
-            LocalDateTime startDate,
-            LocalDateTime endDate,
-            String name,
-            String progressState,
-            ArtistResponse artist
-
-    ) {
     }
 
     public record ArtistResponse(

--- a/src/main/java/com/birca/bircabackend/query/repository/BirthdayCafeQueryRepository.java
+++ b/src/main/java/com/birca/bircabackend/query/repository/BirthdayCafeQueryRepository.java
@@ -29,5 +29,5 @@ public interface BirthdayCafeQueryRepository extends Repository<BirthdayCafe, Lo
             "left join ArtistGroup ag on a.groupId = ag.id " +
             "where bc.hostId = :hostId " +
             "order by bc.id desc")
-    List<BirthdayCafeView> findByHostIdWithArtist(@Param("hostId") Long hostId);
+    List<BirthdayCafeView> findMyBirthdayCafes(@Param("hostId") Long hostId);
 }

--- a/src/main/java/com/birca/bircabackend/query/repository/BirthdayCafeQueryRepository.java
+++ b/src/main/java/com/birca/bircabackend/query/repository/BirthdayCafeQueryRepository.java
@@ -27,6 +27,7 @@ public interface BirthdayCafeQueryRepository extends Repository<BirthdayCafe, Lo
             "join Artist a on a.id = bc.artistId " +
             "left join BirthdayCafeImage bci on bc.id = bci.birthdayCafeId and bci.isMain = true " +
             "left join ArtistGroup ag on a.groupId = ag.id " +
-            "where bc.hostId = :hostId")
+            "where bc.hostId = :hostId " +
+            "order by bc.id desc")
     List<BirthdayCafeView> findByHostIdWithArtist(@Param("hostId") Long hostId);
 }

--- a/src/main/java/com/birca/bircabackend/query/repository/BirthdayCafeQueryRepository.java
+++ b/src/main/java/com/birca/bircabackend/query/repository/BirthdayCafeQueryRepository.java
@@ -4,8 +4,10 @@ import com.birca.bircabackend.command.birca.domain.BirthdayCafe;
 import com.birca.bircabackend.command.birca.domain.value.LuckyDraw;
 import com.birca.bircabackend.command.birca.domain.value.Menu;
 import com.birca.bircabackend.command.birca.domain.value.SpecialGoods;
+import com.birca.bircabackend.query.repository.model.BirthdayCafeView;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.Repository;
+import org.springframework.data.repository.query.Param;
 
 import java.util.List;
 
@@ -19,4 +21,12 @@ public interface BirthdayCafeQueryRepository extends Repository<BirthdayCafe, Lo
 
     @Query("select bc.luckyDraws from BirthdayCafe bc where bc.id = :id")
     List<LuckyDraw> findLuckyDrawsById(Long id);
+
+    @Query("select new com.birca.bircabackend.query.repository.model.BirthdayCafeView(bc, bci, a, ag) " +
+            "from BirthdayCafe bc " +
+            "join Artist a on a.id = bc.artistId " +
+            "left join BirthdayCafeImage bci on bc.id = bci.birthdayCafeId and bci.isMain = true " +
+            "left join ArtistGroup ag on a.groupId = ag.id " +
+            "where bc.hostId = :hostId")
+    List<BirthdayCafeView> findByHostIdWithArtist(@Param("hostId") Long hostId);
 }

--- a/src/main/java/com/birca/bircabackend/query/repository/model/BirthdayCafeView.java
+++ b/src/main/java/com/birca/bircabackend/query/repository/model/BirthdayCafeView.java
@@ -1,0 +1,14 @@
+package com.birca.bircabackend.query.repository.model;
+
+import com.birca.bircabackend.command.artist.domain.Artist;
+import com.birca.bircabackend.command.artist.domain.ArtistGroup;
+import com.birca.bircabackend.command.birca.domain.BirthdayCafe;
+import com.birca.bircabackend.command.birca.domain.BirthdayCafeImage;
+
+public record BirthdayCafeView(
+        BirthdayCafe birthdayCafe,
+        BirthdayCafeImage mainImage,
+        Artist artist,
+        ArtistGroup artistGroup
+) {
+}

--- a/src/main/java/com/birca/bircabackend/query/service/BirthdayCafeQueryService.java
+++ b/src/main/java/com/birca/bircabackend/query/service/BirthdayCafeQueryService.java
@@ -41,7 +41,7 @@ public class BirthdayCafeQueryService {
     }
 
     public List<MyBirthdayCafeResponse> findMyBirthdayCafes(LoginMember loginMember) {
-        return birthdayCafeQueryRepository.findByHostIdWithArtist(loginMember.id())
+        return birthdayCafeQueryRepository.findMyBirthdayCafes(loginMember.id())
                 .stream()
                 .map(MyBirthdayCafeResponse::from)
                 .toList();

--- a/src/main/java/com/birca/bircabackend/query/service/BirthdayCafeQueryService.java
+++ b/src/main/java/com/birca/bircabackend/query/service/BirthdayCafeQueryService.java
@@ -41,6 +41,9 @@ public class BirthdayCafeQueryService {
     }
 
     public List<MyBirthdayCafeResponse> findMyBirthdayCafes(LoginMember loginMember) {
-        return null;
+        return birthdayCafeQueryRepository.findByHostIdWithArtist(loginMember.id())
+                .stream()
+                .map(MyBirthdayCafeResponse::from)
+                .toList();
     }
 }

--- a/src/main/java/com/birca/bircabackend/query/service/BirthdayCafeQueryService.java
+++ b/src/main/java/com/birca/bircabackend/query/service/BirthdayCafeQueryService.java
@@ -1,7 +1,9 @@
 package com.birca.bircabackend.query.service;
 
+import com.birca.bircabackend.command.auth.authorization.LoginMember;
 import com.birca.bircabackend.query.dto.LuckyDrawResponse;
 import com.birca.bircabackend.query.dto.MenuResponse;
+import com.birca.bircabackend.query.dto.MyBirthdayCafeResponse;
 import com.birca.bircabackend.query.dto.SpecialGoodsResponse;
 import com.birca.bircabackend.query.repository.BirthdayCafeQueryRepository;
 import lombok.RequiredArgsConstructor;
@@ -36,5 +38,9 @@ public class BirthdayCafeQueryService {
                 .stream()
                 .map(luckyDraw -> new LuckyDrawResponse(luckyDraw.getRank(), luckyDraw.getPrize()))
                 .toList();
+    }
+
+    public List<MyBirthdayCafeResponse> findMyBirthdayCafes(LoginMember loginMember) {
+        return null;
     }
 }

--- a/src/main/resources/static/docs/api.html
+++ b/src/main/resources/static/docs/api.html
@@ -496,6 +496,7 @@ body.book #toc,body.book #preamble,body.book h1.sect0,body.book .sect1>h2{page-b
 <li><a href="#_생일_카페_럭키_드로우_조회">생일 카페 럭키 드로우 조회</a></li>
 <li><a href="#_생일_카페_정보_수정">생일 카페 정보 수정</a></li>
 <li><a href="#_생일_카페_이미지_업로드">생일 카페 이미지 업로드</a></li>
+<li><a href="#_주최자의_나의_생일_카페_목록_조회">주최자의 나의 생일 카페 목록 조회</a></li>
 <li><a href="#_에러_코드_5">에러 코드</a></li>
 </ul>
 </li>
@@ -638,7 +639,7 @@ Content-Length: 97
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">POST /api/v1/members/role-change HTTP/1.1
 Content-Type: application/json;charset=UTF-8
-Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwiaWF0IjoxNzEwNjA1NzI2LCJleHAiOjE3MTA2MDc1MjZ9.jSXdqkCnt9_PHFQoWJddANfY5jjNn1d7GwaR-jYSlZ0
+Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwiaWF0IjoxNzEwNzcxMzYwLCJleHAiOjE3MTA3NzMxNjB9.5IB2cEtt6b3n1bxQodD_DbV1DP_DsFcql9iskPwKt-E
 Content-Length: 21
 Host: www.api.birca.com
 
@@ -668,7 +669,7 @@ Vary: Access-Control-Request-Headers</code></pre>
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">GET /api/v1/join/check-nickname?nickname=does HTTP/1.1
 Content-Type: application/json;charset=UTF-8
-Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwiaWF0IjoxNzEwNjA1NzI4LCJleHAiOjE3MTA2MDc1Mjh9.rpSmHAQBUuy9LOUyruk4cKVcygiy5hxY9w0IEkPsLY4
+Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwiaWF0IjoxNzEwNzcxMzY0LCJleHAiOjE3MTA3NzMxNjR9.nH33sQxWtsJmd0Syp4gGrhl7D4yoA3wOzAr1xcUSG4M
 Host: www.api.birca.com</code></pre>
 </div>
 </div>
@@ -742,7 +743,7 @@ Content-Length: 16
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">POST /api/v1/join/register-nickname HTTP/1.1
 Content-Type: application/json;charset=UTF-8
-Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwiaWF0IjoxNzEwNjA1NzI2LCJleHAiOjE3MTA2MDc1MjZ9.jSXdqkCnt9_PHFQoWJddANfY5jjNn1d7GwaR-jYSlZ0
+Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwiaWF0IjoxNzEwNzcxMzYwLCJleHAiOjE3MTA3NzMxNjB9.5IB2cEtt6b3n1bxQodD_DbV1DP_DsFcql9iskPwKt-E
 Content-Length: 30
 Host: www.api.birca.com
 
@@ -830,7 +831,7 @@ Vary: Access-Control-Request-Headers</code></pre>
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">GET /api/v1/artist-groups?cursor=10&amp;size=3 HTTP/1.1
 Content-Type: application/json;charset=UTF-8
-Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwiaWF0IjoxNzEwNjA1NzI4LCJleHAiOjE3MTA2MDc1Mjh9.rpSmHAQBUuy9LOUyruk4cKVcygiy5hxY9w0IEkPsLY4
+Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwiaWF0IjoxNzEwNzcxMzY0LCJleHAiOjE3MTA3NzMxNjR9.nH33sQxWtsJmd0Syp4gGrhl7D4yoA3wOzAr1xcUSG4M
 Host: www.api.birca.com</code></pre>
 </div>
 </div>
@@ -930,7 +931,7 @@ Content-Length: 250
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">GET /api/v1/artist-groups/1/artists HTTP/1.1
 Content-Type: application/json;charset=UTF-8
-Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwiaWF0IjoxNzEwNjA1NzI4LCJleHAiOjE3MTA2MDc1Mjh9.rpSmHAQBUuy9LOUyruk4cKVcygiy5hxY9w0IEkPsLY4
+Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwiaWF0IjoxNzEwNzcxMzY0LCJleHAiOjE3MTA3NzMxNjR9.nH33sQxWtsJmd0Syp4gGrhl7D4yoA3wOzAr1xcUSG4M
 Host: www.api.birca.com</code></pre>
 </div>
 </div>
@@ -1043,7 +1044,7 @@ Content-Length: 565
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">GET /api/v1/artists/solo?cursor=12&amp;size=6 HTTP/1.1
 Content-Type: application/json;charset=UTF-8
-Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwiaWF0IjoxNzEwNjA1NzI4LCJleHAiOjE3MTA2MDc1Mjh9.rpSmHAQBUuy9LOUyruk4cKVcygiy5hxY9w0IEkPsLY4
+Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwiaWF0IjoxNzEwNzcxMzY0LCJleHAiOjE3MTA3NzMxNjR9.nH33sQxWtsJmd0Syp4gGrhl7D4yoA3wOzAr1xcUSG4M
 Host: www.api.birca.com</code></pre>
 </div>
 </div>
@@ -1155,7 +1156,7 @@ Content-Length: 518
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">POST /api/v1/artists/favorite HTTP/1.1
 Content-Type: application/json;charset=UTF-8
-Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwiaWF0IjoxNzEwNjA1NzIxLCJleHAiOjE3MTA2MDc1MjF9.6Br9S9l0Ey2ZaxVnmjaU71MI8COc8pcm4gDIClOFqZk
+Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwiaWF0IjoxNzEwNzcxMzU3LCJleHAiOjE3MTA3NzMxNTd9.99-_sUg2DaUTqdBfS-qEgS3sfs7ngRnVOKrl-MSksPM
 Content-Length: 20
 Host: www.api.birca.com
 
@@ -1209,7 +1210,7 @@ Vary: Access-Control-Request-Headers</code></pre>
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">POST /api/v1/artists/interest HTTP/1.1
 Content-Type: application/json;charset=UTF-8
-Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwiaWF0IjoxNzEwNjA1NzIxLCJleHAiOjE3MTA2MDc1MjF9.6Br9S9l0Ey2ZaxVnmjaU71MI8COc8pcm4gDIClOFqZk
+Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwiaWF0IjoxNzEwNzcxMzU3LCJleHAiOjE3MTA3NzMxNTd9.99-_sUg2DaUTqdBfS-qEgS3sfs7ngRnVOKrl-MSksPM
 Content-Length: 68
 Host: www.api.birca.com
 
@@ -1267,7 +1268,7 @@ Vary: Access-Control-Request-Headers</code></pre>
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">GET /api/v1/artists/favorite HTTP/1.1
 Content-Type: application/json;charset=UTF-8
-Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwiaWF0IjoxNzEwNjA1NzI4LCJleHAiOjE3MTA2MDc1Mjh9.rpSmHAQBUuy9LOUyruk4cKVcygiy5hxY9w0IEkPsLY4
+Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwiaWF0IjoxNzEwNzcxMzY0LCJleHAiOjE3MTA3NzMxNjR9.nH33sQxWtsJmd0Syp4gGrhl7D4yoA3wOzAr1xcUSG4M
 Host: www.api.birca.com</code></pre>
 </div>
 </div>
@@ -1334,7 +1335,7 @@ Content-Length: 81
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">GET /api/v1/artists/interest HTTP/1.1
 Content-Type: application/json;charset=UTF-8
-Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwiaWF0IjoxNzEwNjA1NzI4LCJleHAiOjE3MTA2MDc1Mjh9.rpSmHAQBUuy9LOUyruk4cKVcygiy5hxY9w0IEkPsLY4
+Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwiaWF0IjoxNzEwNzcxMzY0LCJleHAiOjE3MTA3NzMxNjR9.nH33sQxWtsJmd0Syp4gGrhl7D4yoA3wOzAr1xcUSG4M
 Host: www.api.birca.com</code></pre>
 </div>
 </div>
@@ -1417,7 +1418,7 @@ Content-Length: 416
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">GET /api/v1/artists/search?name=%EB%A7%88%ED%81%AC HTTP/1.1
 Content-Type: application/json;charset=UTF-8
-Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwiaWF0IjoxNzEwNjA1NzI4LCJleHAiOjE3MTA2MDc1Mjh9.rpSmHAQBUuy9LOUyruk4cKVcygiy5hxY9w0IEkPsLY4
+Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwiaWF0IjoxNzEwNzcxMzY0LCJleHAiOjE3MTA3NzMxNjR9.nH33sQxWtsJmd0Syp4gGrhl7D4yoA3wOzAr1xcUSG4M
 Host: www.api.birca.com</code></pre>
 </div>
 </div>
@@ -1482,7 +1483,7 @@ Content-Length: 225
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">POST /api/v1/cafes/license-read HTTP/1.1
 Content-Type: multipart/form-data;charset=UTF-8; boundary=6o2knFse3p53ty9dmcQvWAIx1zInP11uCfbm
-Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwiaWF0IjoxNzEwNjA1NzI2LCJleHAiOjE3MTA2MDc1MjZ9.jSXdqkCnt9_PHFQoWJddANfY5jjNn1d7GwaR-jYSlZ0
+Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwiaWF0IjoxNzEwNzcxMzYwLCJleHAiOjE3MTA3NzMxNjB9.5IB2cEtt6b3n1bxQodD_DbV1DP_DsFcql9iskPwKt-E
 Host: www.api.birca.com
 
 --6o2knFse3p53ty9dmcQvWAIx1zInP11uCfbm
@@ -1568,7 +1569,7 @@ Content-Length: 141
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">POST /api/v1/cafes/apply HTTP/1.1
 Content-Type: multipart/form-data;charset=UTF-8; boundary=6o2knFse3p53ty9dmcQvWAIx1zInP11uCfbm
-Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwiaWF0IjoxNzEwNjA1NzI2LCJleHAiOjE3MTA2MDc1MjZ9.jSXdqkCnt9_PHFQoWJddANfY5jjNn1d7GwaR-jYSlZ0
+Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwiaWF0IjoxNzEwNzcxMzYwLCJleHAiOjE3MTA3NzMxNjB9.5IB2cEtt6b3n1bxQodD_DbV1DP_DsFcql9iskPwKt-E
 Host: www.api.birca.com
 
 --6o2knFse3p53ty9dmcQvWAIx1zInP11uCfbm
@@ -1642,7 +1643,7 @@ Vary: Access-Control-Request-Headers</code></pre>
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">POST /api/v1/birthday-cafes HTTP/1.1
 Content-Type: application/json;charset=UTF-8
-Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwiaWF0IjoxNzEwNjA1NzIzLCJleHAiOjE3MTA2MDc1MjN9.llKVdPDfhB1vDdFQBYQiJiKDm60XWCxjxwcvkr3eRWE
+Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwiaWF0IjoxNzEwNzcxMzU5LCJleHAiOjE3MTA3NzMxNTl9.Gv0nPm5itQs62tp5QEYmosKGRft1qpv4sjznRbd92HI
 Content-Length: 234
 Host: www.api.birca.com
 
@@ -1738,7 +1739,7 @@ Vary: Access-Control-Request-Headers</code></pre>
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">POST /api/v1/birthday-cafes/1/cancel HTTP/1.1
 Content-Type: application/json;charset=UTF-8
-Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwiaWF0IjoxNzEwNjA1NzIzLCJleHAiOjE3MTA2MDc1MjN9.llKVdPDfhB1vDdFQBYQiJiKDm60XWCxjxwcvkr3eRWE
+Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwiaWF0IjoxNzEwNzcxMzU5LCJleHAiOjE3MTA3NzMxNTl9.Gv0nPm5itQs62tp5QEYmosKGRft1qpv4sjznRbd92HI
 Host: www.api.birca.com</code></pre>
 </div>
 </div>
@@ -1785,7 +1786,7 @@ Vary: Access-Control-Request-Headers</code></pre>
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">PATCH /api/v1/birthday-cafes/1/congestion HTTP/1.1
 Content-Type: application/json;charset=UTF-8
-Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwiaWF0IjoxNzEwNjA1NzIzLCJleHAiOjE3MTA2MDc1MjN9.llKVdPDfhB1vDdFQBYQiJiKDm60XWCxjxwcvkr3eRWE
+Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwiaWF0IjoxNzEwNzcxMzU5LCJleHAiOjE3MTA3NzMxNTl9.Gv0nPm5itQs62tp5QEYmosKGRft1qpv4sjznRbd92HI
 Content-Length: 26
 Host: www.api.birca.com
 
@@ -1865,7 +1866,7 @@ Vary: Access-Control-Request-Headers</code></pre>
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">POST /api/v1/birthday-cafes/1/like HTTP/1.1
 Content-Type: application/json;charset=UTF-8
-Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwiaWF0IjoxNzEwNjA1NzIzLCJleHAiOjE3MTA2MDc1MjN9.llKVdPDfhB1vDdFQBYQiJiKDm60XWCxjxwcvkr3eRWE
+Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwiaWF0IjoxNzEwNzcxMzU5LCJleHAiOjE3MTA3NzMxNTl9.Gv0nPm5itQs62tp5QEYmosKGRft1qpv4sjznRbd92HI
 Host: www.api.birca.com</code></pre>
 </div>
 </div>
@@ -1912,7 +1913,7 @@ Vary: Access-Control-Request-Headers</code></pre>
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">DELETE /api/v1/birthday-cafes/1/like HTTP/1.1
 Content-Type: application/json;charset=UTF-8
-Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwiaWF0IjoxNzEwNjA1NzIzLCJleHAiOjE3MTA2MDc1MjN9.llKVdPDfhB1vDdFQBYQiJiKDm60XWCxjxwcvkr3eRWE
+Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwiaWF0IjoxNzEwNzcxMzU5LCJleHAiOjE3MTA3NzMxNTl9.Gv0nPm5itQs62tp5QEYmosKGRft1qpv4sjznRbd92HI
 Host: www.api.birca.com</code></pre>
 </div>
 </div>
@@ -1959,7 +1960,7 @@ Vary: Access-Control-Request-Headers</code></pre>
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">POST /api/v1/birthday-cafes/1/special-goods HTTP/1.1
 Content-Type: application/json;charset=UTF-8
-Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwiaWF0IjoxNzEwNjA1NzIzLCJleHAiOjE3MTA2MDc1MjN9.llKVdPDfhB1vDdFQBYQiJiKDm60XWCxjxwcvkr3eRWE
+Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwiaWF0IjoxNzEwNzcxMzU4LCJleHAiOjE3MTA3NzMxNTh9.p0FYx0JnzrT_eI8Kv74r9_dUPy23Exc8EaH9Aq5GPMg
 Content-Length: 147
 Host: www.api.birca.com
 
@@ -2044,7 +2045,7 @@ Vary: Access-Control-Request-Headers</code></pre>
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">POST /api/v1/birthday-cafes/1/menus HTTP/1.1
 Content-Type: application/json;charset=UTF-8
-Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwiaWF0IjoxNzEwNjA1NzIzLCJleHAiOjE3MTA2MDc1MjN9.llKVdPDfhB1vDdFQBYQiJiKDm60XWCxjxwcvkr3eRWE
+Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwiaWF0IjoxNzEwNzcxMzU5LCJleHAiOjE3MTA3NzMxNTl9.Gv0nPm5itQs62tp5QEYmosKGRft1qpv4sjznRbd92HI
 Content-Length: 197
 Host: www.api.birca.com
 
@@ -2136,7 +2137,7 @@ Vary: Access-Control-Request-Headers</code></pre>
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">POST /api/v1/birthday-cafes/1/lucky-draws HTTP/1.1
 Content-Type: application/json;charset=UTF-8
-Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwiaWF0IjoxNzEwNjA1NzIzLCJleHAiOjE3MTA2MDc1MjN9.llKVdPDfhB1vDdFQBYQiJiKDm60XWCxjxwcvkr3eRWE
+Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwiaWF0IjoxNzEwNzcxMzU4LCJleHAiOjE3MTA3NzMxNTh9.p0FYx0JnzrT_eI8Kv74r9_dUPy23Exc8EaH9Aq5GPMg
 Content-Length: 92
 Host: www.api.birca.com
 
@@ -2221,7 +2222,7 @@ Vary: Access-Control-Request-Headers</code></pre>
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">GET /api/v1/birthday-cafes/1/special-goods HTTP/1.1
 Content-Type: application/json;charset=UTF-8
-Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwiaWF0IjoxNzEwNjA1NzI4LCJleHAiOjE3MTA2MDc1Mjh9.rpSmHAQBUuy9LOUyruk4cKVcygiy5hxY9w0IEkPsLY4
+Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwiaWF0IjoxNzEwNzcxMzY0LCJleHAiOjE3MTA3NzMxNjR9.nH33sQxWtsJmd0Syp4gGrhl7D4yoA3wOzAr1xcUSG4M
 Host: www.api.birca.com</code></pre>
 </div>
 </div>
@@ -2278,7 +2279,7 @@ Content-Length: 126
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">GET /api/v1/birthday-cafes/1/menus HTTP/1.1
 Content-Type: application/json;charset=UTF-8
-Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwiaWF0IjoxNzEwNjA1NzI4LCJleHAiOjE3MTA2MDc1Mjh9.rpSmHAQBUuy9LOUyruk4cKVcygiy5hxY9w0IEkPsLY4
+Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwiaWF0IjoxNzEwNzcxMzY0LCJleHAiOjE3MTA3NzMxNjR9.nH33sQxWtsJmd0Syp4gGrhl7D4yoA3wOzAr1xcUSG4M
 Host: www.api.birca.com</code></pre>
 </div>
 </div>
@@ -2337,7 +2338,7 @@ Content-Length: 196
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">GET /api/v1/birthday-cafes/1/lucky-draws HTTP/1.1
 Content-Type: application/json;charset=UTF-8
-Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwiaWF0IjoxNzEwNjA1NzI4LCJleHAiOjE3MTA2MDc1Mjh9.rpSmHAQBUuy9LOUyruk4cKVcygiy5hxY9w0IEkPsLY4
+Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwiaWF0IjoxNzEwNzcxMzY0LCJleHAiOjE3MTA3NzMxNjR9.nH33sQxWtsJmd0Syp4gGrhl7D4yoA3wOzAr1xcUSG4M
 Host: www.api.birca.com</code></pre>
 </div>
 </div>
@@ -2394,7 +2395,7 @@ Content-Length: 88
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">PATCH /api/v1/birthday-cafes/1 HTTP/1.1
 Content-Type: application/json;charset=UTF-8
-Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwiaWF0IjoxNzEwNjA1NzIzLCJleHAiOjE3MTA2MDc1MjN9.llKVdPDfhB1vDdFQBYQiJiKDm60XWCxjxwcvkr3eRWE
+Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwiaWF0IjoxNzEwNzcxMzU5LCJleHAiOjE3MTA3NzMxNTl9.Gv0nPm5itQs62tp5QEYmosKGRft1qpv4sjznRbd92HI
 Content-Length: 86
 Host: www.api.birca.com
 
@@ -2476,7 +2477,7 @@ Vary: Access-Control-Request-Headers</code></pre>
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">POST /api/v1/birthday-cafes/1/images HTTP/1.1
 Content-Type: multipart/form-data;charset=UTF-8; boundary=6o2knFse3p53ty9dmcQvWAIx1zInP11uCfbm
-Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwiaWF0IjoxNzEwNjA1NzIzLCJleHAiOjE3MTA2MDc1MjN9.llKVdPDfhB1vDdFQBYQiJiKDm60XWCxjxwcvkr3eRWE
+Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwiaWF0IjoxNzEwNzcxMzU5LCJleHAiOjE3MTA3NzMxNTl9.Gv0nPm5itQs62tp5QEYmosKGRft1qpv4sjznRbd92HI
 Host: www.api.birca.com
 
 --6o2knFse3p53ty9dmcQvWAIx1zInP11uCfbm
@@ -2497,6 +2498,120 @@ Vary: Access-Control-Request-Method
 Vary: Access-Control-Request-Headers</code></pre>
 </div>
 </div>
+</div>
+</div>
+<div class="sect2">
+<h3 id="_주최자의_나의_생일_카페_목록_조회"><a class="link" href="#_주최자의_나의_생일_카페_목록_조회">주최자의 나의 생일 카페 목록 조회</a></h3>
+<div class="sect3">
+<h4 id="_주최자의_나의_생일_카페_목록_조회_http_request"><a class="link" href="#_주최자의_나의_생일_카페_목록_조회_http_request">HTTP request</a></h4>
+<div class="listingblock">
+<div class="content">
+<pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">GET /api/v1/birthday-cafes/me HTTP/1.1
+Content-Type: application/json;charset=UTF-8
+Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwiaWF0IjoxNzEwNzcxMzY0LCJleHAiOjE3MTA3NzMxNjR9.nH33sQxWtsJmd0Syp4gGrhl7D4yoA3wOzAr1xcUSG4M
+Host: www.api.birca.com</code></pre>
+</div>
+</div>
+</div>
+<div class="sect3">
+<h4 id="_주최자의_나의_생일_카페_목록_조회_http_response"><a class="link" href="#_주최자의_나의_생일_카페_목록_조회_http_response">HTTP response</a></h4>
+<div class="listingblock">
+<div class="content">
+<pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">HTTP/1.1 200 OK
+Vary: Origin
+Vary: Access-Control-Request-Method
+Vary: Access-Control-Request-Headers
+Content-Type: application/json
+Content-Length: 628
+
+[ {
+  "birthdayCafe" : {
+    "id" : 1,
+    "mainImageUrl" : "image.com",
+    "startDate" : "2024-03-18T00:00:00",
+    "endDate" : "2024-03-19T00:00:00",
+    "name" : "민호의 생일 카페",
+    "progressState" : "FINISHED",
+    "artist" : {
+      "groupName" : "샤이니",
+      "name" : "민호"
+    }
+  }
+}, {
+  "birthdayCafe" : {
+    "id" : 2,
+    "mainImageUrl" : "image.com",
+    "startDate" : "2024-03-20T00:00:00",
+    "endDate" : "2024-03-23T00:00:00",
+    "name" : "아이유의 생일 카페",
+    "progressState" : "IN_PROGRESS",
+    "artist" : {
+      "groupName" : null,
+      "name" : "아이유"
+    }
+  }
+} ]</code></pre>
+</div>
+</div>
+</div>
+<div class="sect3">
+<h4 id="_주최자의_나의_생일_카페_목록_조회_response_fields"><a class="link" href="#_주최자의_나의_생일_카페_목록_조회_response_fields">Response fields</a></h4>
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 33.3333%;">
+<col style="width: 33.3333%;">
+<col style="width: 33.3334%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">Path</th>
+<th class="tableblock halign-left valign-top">Type</th>
+<th class="tableblock halign-left valign-top">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>[].birthdayCafe.id</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Number</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">생일 카페 ID</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>[].birthdayCafe.mainImageUrl</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">생일 카페 메인 이미지 url</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>[].birthdayCafe.startDate</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">생일 카페 시작일</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>[].birthdayCafe.endDate</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">생일 카페 종료일</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>[].birthdayCafe.name</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">생일 카페 이름</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>[].birthdayCafe.progressState</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">생일 카페 진행 상태</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>[].birthdayCafe.artist.groupName</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">아티스트 그룹 이름</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>[].birthdayCafe.artist.name</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">아티스트 이름</p></td>
+</tr>
+</tbody>
+</table>
 </div>
 </div>
 <div class="sect2">
@@ -2569,7 +2684,7 @@ Vary: Access-Control-Request-Headers</code></pre>
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">GET /api/v1/cafes/search?name=%EC%BB%A4%ED%94%BC HTTP/1.1
 Content-Type: application/json;charset=UTF-8
-Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwiaWF0IjoxNzEwNjA1NzI4LCJleHAiOjE3MTA2MDc1Mjh9.rpSmHAQBUuy9LOUyruk4cKVcygiy5hxY9w0IEkPsLY4
+Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwiaWF0IjoxNzEwNzcxMzY0LCJleHAiOjE3MTA3NzMxNjR9.nH33sQxWtsJmd0Syp4gGrhl7D4yoA3wOzAr1xcUSG4M
 Host: www.api.birca.com</code></pre>
 </div>
 </div>
@@ -2602,7 +2717,7 @@ Content-Length: 106
 <div id="footer">
 <div id="footer-text">
 Version 0.0.1-SNAPSHOT<br>
-Last updated 2024-03-15 20:24:13 +0900
+Last updated 2024-03-18 23:15:14 +0900
 </div>
 </div>
 <script src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/9.18.3/highlight.min.js"></script>

--- a/src/main/resources/static/docs/api.html
+++ b/src/main/resources/static/docs/api.html
@@ -639,7 +639,7 @@ Content-Length: 97
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">POST /api/v1/members/role-change HTTP/1.1
 Content-Type: application/json;charset=UTF-8
-Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwiaWF0IjoxNzEwNzcxMzYwLCJleHAiOjE3MTA3NzMxNjB9.5IB2cEtt6b3n1bxQodD_DbV1DP_DsFcql9iskPwKt-E
+Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwiaWF0IjoxNzEwODI5ODk2LCJleHAiOjE3MTA4MzE2OTZ9.VWTN_AeWFb_qbKm3MdaqFRs0ocIvifw3_76EjwpoxmE
 Content-Length: 21
 Host: www.api.birca.com
 
@@ -669,7 +669,7 @@ Vary: Access-Control-Request-Headers</code></pre>
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">GET /api/v1/join/check-nickname?nickname=does HTTP/1.1
 Content-Type: application/json;charset=UTF-8
-Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwiaWF0IjoxNzEwNzcxMzY0LCJleHAiOjE3MTA3NzMxNjR9.nH33sQxWtsJmd0Syp4gGrhl7D4yoA3wOzAr1xcUSG4M
+Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwiaWF0IjoxNzEwODI5ODk5LCJleHAiOjE3MTA4MzE2OTl9.NVvKKltAZwgKus5VI_0WvEGiLk1aDPu3p2vRsYICMOU
 Host: www.api.birca.com</code></pre>
 </div>
 </div>
@@ -743,7 +743,7 @@ Content-Length: 16
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">POST /api/v1/join/register-nickname HTTP/1.1
 Content-Type: application/json;charset=UTF-8
-Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwiaWF0IjoxNzEwNzcxMzYwLCJleHAiOjE3MTA3NzMxNjB9.5IB2cEtt6b3n1bxQodD_DbV1DP_DsFcql9iskPwKt-E
+Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwiaWF0IjoxNzEwODI5ODk2LCJleHAiOjE3MTA4MzE2OTZ9.VWTN_AeWFb_qbKm3MdaqFRs0ocIvifw3_76EjwpoxmE
 Content-Length: 30
 Host: www.api.birca.com
 
@@ -831,7 +831,7 @@ Vary: Access-Control-Request-Headers</code></pre>
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">GET /api/v1/artist-groups?cursor=10&amp;size=3 HTTP/1.1
 Content-Type: application/json;charset=UTF-8
-Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwiaWF0IjoxNzEwNzcxMzY0LCJleHAiOjE3MTA3NzMxNjR9.nH33sQxWtsJmd0Syp4gGrhl7D4yoA3wOzAr1xcUSG4M
+Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwiaWF0IjoxNzEwODI5ODk5LCJleHAiOjE3MTA4MzE2OTl9.NVvKKltAZwgKus5VI_0WvEGiLk1aDPu3p2vRsYICMOU
 Host: www.api.birca.com</code></pre>
 </div>
 </div>
@@ -931,7 +931,7 @@ Content-Length: 250
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">GET /api/v1/artist-groups/1/artists HTTP/1.1
 Content-Type: application/json;charset=UTF-8
-Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwiaWF0IjoxNzEwNzcxMzY0LCJleHAiOjE3MTA3NzMxNjR9.nH33sQxWtsJmd0Syp4gGrhl7D4yoA3wOzAr1xcUSG4M
+Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwiaWF0IjoxNzEwODI5ODk5LCJleHAiOjE3MTA4MzE2OTl9.NVvKKltAZwgKus5VI_0WvEGiLk1aDPu3p2vRsYICMOU
 Host: www.api.birca.com</code></pre>
 </div>
 </div>
@@ -1044,7 +1044,7 @@ Content-Length: 565
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">GET /api/v1/artists/solo?cursor=12&amp;size=6 HTTP/1.1
 Content-Type: application/json;charset=UTF-8
-Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwiaWF0IjoxNzEwNzcxMzY0LCJleHAiOjE3MTA3NzMxNjR9.nH33sQxWtsJmd0Syp4gGrhl7D4yoA3wOzAr1xcUSG4M
+Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwiaWF0IjoxNzEwODI5ODk5LCJleHAiOjE3MTA4MzE2OTl9.NVvKKltAZwgKus5VI_0WvEGiLk1aDPu3p2vRsYICMOU
 Host: www.api.birca.com</code></pre>
 </div>
 </div>
@@ -1156,7 +1156,7 @@ Content-Length: 518
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">POST /api/v1/artists/favorite HTTP/1.1
 Content-Type: application/json;charset=UTF-8
-Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwiaWF0IjoxNzEwNzcxMzU3LCJleHAiOjE3MTA3NzMxNTd9.99-_sUg2DaUTqdBfS-qEgS3sfs7ngRnVOKrl-MSksPM
+Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwiaWF0IjoxNzEwODI5ODkzLCJleHAiOjE3MTA4MzE2OTN9.UFNKX3XLBilo15a6B8DOxjwLbRHraLgrVQ3UVdkVDFU
 Content-Length: 20
 Host: www.api.birca.com
 
@@ -1210,7 +1210,7 @@ Vary: Access-Control-Request-Headers</code></pre>
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">POST /api/v1/artists/interest HTTP/1.1
 Content-Type: application/json;charset=UTF-8
-Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwiaWF0IjoxNzEwNzcxMzU3LCJleHAiOjE3MTA3NzMxNTd9.99-_sUg2DaUTqdBfS-qEgS3sfs7ngRnVOKrl-MSksPM
+Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwiaWF0IjoxNzEwODI5ODkzLCJleHAiOjE3MTA4MzE2OTN9.UFNKX3XLBilo15a6B8DOxjwLbRHraLgrVQ3UVdkVDFU
 Content-Length: 68
 Host: www.api.birca.com
 
@@ -1268,7 +1268,7 @@ Vary: Access-Control-Request-Headers</code></pre>
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">GET /api/v1/artists/favorite HTTP/1.1
 Content-Type: application/json;charset=UTF-8
-Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwiaWF0IjoxNzEwNzcxMzY0LCJleHAiOjE3MTA3NzMxNjR9.nH33sQxWtsJmd0Syp4gGrhl7D4yoA3wOzAr1xcUSG4M
+Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwiaWF0IjoxNzEwODI5ODk5LCJleHAiOjE3MTA4MzE2OTl9.NVvKKltAZwgKus5VI_0WvEGiLk1aDPu3p2vRsYICMOU
 Host: www.api.birca.com</code></pre>
 </div>
 </div>
@@ -1335,7 +1335,7 @@ Content-Length: 81
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">GET /api/v1/artists/interest HTTP/1.1
 Content-Type: application/json;charset=UTF-8
-Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwiaWF0IjoxNzEwNzcxMzY0LCJleHAiOjE3MTA3NzMxNjR9.nH33sQxWtsJmd0Syp4gGrhl7D4yoA3wOzAr1xcUSG4M
+Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwiaWF0IjoxNzEwODI5ODk5LCJleHAiOjE3MTA4MzE2OTl9.NVvKKltAZwgKus5VI_0WvEGiLk1aDPu3p2vRsYICMOU
 Host: www.api.birca.com</code></pre>
 </div>
 </div>
@@ -1418,7 +1418,7 @@ Content-Length: 416
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">GET /api/v1/artists/search?name=%EB%A7%88%ED%81%AC HTTP/1.1
 Content-Type: application/json;charset=UTF-8
-Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwiaWF0IjoxNzEwNzcxMzY0LCJleHAiOjE3MTA3NzMxNjR9.nH33sQxWtsJmd0Syp4gGrhl7D4yoA3wOzAr1xcUSG4M
+Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwiaWF0IjoxNzEwODI5ODk5LCJleHAiOjE3MTA4MzE2OTl9.NVvKKltAZwgKus5VI_0WvEGiLk1aDPu3p2vRsYICMOU
 Host: www.api.birca.com</code></pre>
 </div>
 </div>
@@ -1483,7 +1483,7 @@ Content-Length: 225
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">POST /api/v1/cafes/license-read HTTP/1.1
 Content-Type: multipart/form-data;charset=UTF-8; boundary=6o2knFse3p53ty9dmcQvWAIx1zInP11uCfbm
-Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwiaWF0IjoxNzEwNzcxMzYwLCJleHAiOjE3MTA3NzMxNjB9.5IB2cEtt6b3n1bxQodD_DbV1DP_DsFcql9iskPwKt-E
+Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwiaWF0IjoxNzEwODI5ODk2LCJleHAiOjE3MTA4MzE2OTZ9.VWTN_AeWFb_qbKm3MdaqFRs0ocIvifw3_76EjwpoxmE
 Host: www.api.birca.com
 
 --6o2knFse3p53ty9dmcQvWAIx1zInP11uCfbm
@@ -1569,7 +1569,7 @@ Content-Length: 141
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">POST /api/v1/cafes/apply HTTP/1.1
 Content-Type: multipart/form-data;charset=UTF-8; boundary=6o2knFse3p53ty9dmcQvWAIx1zInP11uCfbm
-Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwiaWF0IjoxNzEwNzcxMzYwLCJleHAiOjE3MTA3NzMxNjB9.5IB2cEtt6b3n1bxQodD_DbV1DP_DsFcql9iskPwKt-E
+Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwiaWF0IjoxNzEwODI5ODk2LCJleHAiOjE3MTA4MzE2OTZ9.VWTN_AeWFb_qbKm3MdaqFRs0ocIvifw3_76EjwpoxmE
 Host: www.api.birca.com
 
 --6o2knFse3p53ty9dmcQvWAIx1zInP11uCfbm
@@ -1643,7 +1643,7 @@ Vary: Access-Control-Request-Headers</code></pre>
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">POST /api/v1/birthday-cafes HTTP/1.1
 Content-Type: application/json;charset=UTF-8
-Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwiaWF0IjoxNzEwNzcxMzU5LCJleHAiOjE3MTA3NzMxNTl9.Gv0nPm5itQs62tp5QEYmosKGRft1qpv4sjznRbd92HI
+Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwiaWF0IjoxNzEwODI5ODk0LCJleHAiOjE3MTA4MzE2OTR9.o1LA1awOqI1VSCip6kTztPIfQ5PREsTR1YcmBGC_3R8
 Content-Length: 234
 Host: www.api.birca.com
 
@@ -1739,7 +1739,7 @@ Vary: Access-Control-Request-Headers</code></pre>
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">POST /api/v1/birthday-cafes/1/cancel HTTP/1.1
 Content-Type: application/json;charset=UTF-8
-Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwiaWF0IjoxNzEwNzcxMzU5LCJleHAiOjE3MTA3NzMxNTl9.Gv0nPm5itQs62tp5QEYmosKGRft1qpv4sjznRbd92HI
+Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwiaWF0IjoxNzEwODI5ODk0LCJleHAiOjE3MTA4MzE2OTR9.o1LA1awOqI1VSCip6kTztPIfQ5PREsTR1YcmBGC_3R8
 Host: www.api.birca.com</code></pre>
 </div>
 </div>
@@ -1786,7 +1786,7 @@ Vary: Access-Control-Request-Headers</code></pre>
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">PATCH /api/v1/birthday-cafes/1/congestion HTTP/1.1
 Content-Type: application/json;charset=UTF-8
-Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwiaWF0IjoxNzEwNzcxMzU5LCJleHAiOjE3MTA3NzMxNTl9.Gv0nPm5itQs62tp5QEYmosKGRft1qpv4sjznRbd92HI
+Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwiaWF0IjoxNzEwODI5ODk0LCJleHAiOjE3MTA4MzE2OTR9.o1LA1awOqI1VSCip6kTztPIfQ5PREsTR1YcmBGC_3R8
 Content-Length: 26
 Host: www.api.birca.com
 
@@ -1866,7 +1866,7 @@ Vary: Access-Control-Request-Headers</code></pre>
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">POST /api/v1/birthday-cafes/1/like HTTP/1.1
 Content-Type: application/json;charset=UTF-8
-Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwiaWF0IjoxNzEwNzcxMzU5LCJleHAiOjE3MTA3NzMxNTl9.Gv0nPm5itQs62tp5QEYmosKGRft1qpv4sjznRbd92HI
+Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwiaWF0IjoxNzEwODI5ODk0LCJleHAiOjE3MTA4MzE2OTR9.o1LA1awOqI1VSCip6kTztPIfQ5PREsTR1YcmBGC_3R8
 Host: www.api.birca.com</code></pre>
 </div>
 </div>
@@ -1913,7 +1913,7 @@ Vary: Access-Control-Request-Headers</code></pre>
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">DELETE /api/v1/birthday-cafes/1/like HTTP/1.1
 Content-Type: application/json;charset=UTF-8
-Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwiaWF0IjoxNzEwNzcxMzU5LCJleHAiOjE3MTA3NzMxNTl9.Gv0nPm5itQs62tp5QEYmosKGRft1qpv4sjznRbd92HI
+Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwiaWF0IjoxNzEwODI5ODk0LCJleHAiOjE3MTA4MzE2OTR9.o1LA1awOqI1VSCip6kTztPIfQ5PREsTR1YcmBGC_3R8
 Host: www.api.birca.com</code></pre>
 </div>
 </div>
@@ -1960,7 +1960,7 @@ Vary: Access-Control-Request-Headers</code></pre>
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">POST /api/v1/birthday-cafes/1/special-goods HTTP/1.1
 Content-Type: application/json;charset=UTF-8
-Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwiaWF0IjoxNzEwNzcxMzU4LCJleHAiOjE3MTA3NzMxNTh9.p0FYx0JnzrT_eI8Kv74r9_dUPy23Exc8EaH9Aq5GPMg
+Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwiaWF0IjoxNzEwODI5ODk0LCJleHAiOjE3MTA4MzE2OTR9.o1LA1awOqI1VSCip6kTztPIfQ5PREsTR1YcmBGC_3R8
 Content-Length: 147
 Host: www.api.birca.com
 
@@ -2045,7 +2045,7 @@ Vary: Access-Control-Request-Headers</code></pre>
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">POST /api/v1/birthday-cafes/1/menus HTTP/1.1
 Content-Type: application/json;charset=UTF-8
-Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwiaWF0IjoxNzEwNzcxMzU5LCJleHAiOjE3MTA3NzMxNTl9.Gv0nPm5itQs62tp5QEYmosKGRft1qpv4sjznRbd92HI
+Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwiaWF0IjoxNzEwODI5ODk0LCJleHAiOjE3MTA4MzE2OTR9.o1LA1awOqI1VSCip6kTztPIfQ5PREsTR1YcmBGC_3R8
 Content-Length: 197
 Host: www.api.birca.com
 
@@ -2137,7 +2137,7 @@ Vary: Access-Control-Request-Headers</code></pre>
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">POST /api/v1/birthday-cafes/1/lucky-draws HTTP/1.1
 Content-Type: application/json;charset=UTF-8
-Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwiaWF0IjoxNzEwNzcxMzU4LCJleHAiOjE3MTA3NzMxNTh9.p0FYx0JnzrT_eI8Kv74r9_dUPy23Exc8EaH9Aq5GPMg
+Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwiaWF0IjoxNzEwODI5ODk0LCJleHAiOjE3MTA4MzE2OTR9.o1LA1awOqI1VSCip6kTztPIfQ5PREsTR1YcmBGC_3R8
 Content-Length: 92
 Host: www.api.birca.com
 
@@ -2222,7 +2222,7 @@ Vary: Access-Control-Request-Headers</code></pre>
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">GET /api/v1/birthday-cafes/1/special-goods HTTP/1.1
 Content-Type: application/json;charset=UTF-8
-Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwiaWF0IjoxNzEwNzcxMzY0LCJleHAiOjE3MTA3NzMxNjR9.nH33sQxWtsJmd0Syp4gGrhl7D4yoA3wOzAr1xcUSG4M
+Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwiaWF0IjoxNzEwODI5ODk5LCJleHAiOjE3MTA4MzE2OTl9.NVvKKltAZwgKus5VI_0WvEGiLk1aDPu3p2vRsYICMOU
 Host: www.api.birca.com</code></pre>
 </div>
 </div>
@@ -2279,7 +2279,7 @@ Content-Length: 126
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">GET /api/v1/birthday-cafes/1/menus HTTP/1.1
 Content-Type: application/json;charset=UTF-8
-Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwiaWF0IjoxNzEwNzcxMzY0LCJleHAiOjE3MTA3NzMxNjR9.nH33sQxWtsJmd0Syp4gGrhl7D4yoA3wOzAr1xcUSG4M
+Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwiaWF0IjoxNzEwODI5ODk5LCJleHAiOjE3MTA4MzE2OTl9.NVvKKltAZwgKus5VI_0WvEGiLk1aDPu3p2vRsYICMOU
 Host: www.api.birca.com</code></pre>
 </div>
 </div>
@@ -2338,7 +2338,7 @@ Content-Length: 196
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">GET /api/v1/birthday-cafes/1/lucky-draws HTTP/1.1
 Content-Type: application/json;charset=UTF-8
-Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwiaWF0IjoxNzEwNzcxMzY0LCJleHAiOjE3MTA3NzMxNjR9.nH33sQxWtsJmd0Syp4gGrhl7D4yoA3wOzAr1xcUSG4M
+Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwiaWF0IjoxNzEwODI5ODk5LCJleHAiOjE3MTA4MzE2OTl9.NVvKKltAZwgKus5VI_0WvEGiLk1aDPu3p2vRsYICMOU
 Host: www.api.birca.com</code></pre>
 </div>
 </div>
@@ -2395,7 +2395,7 @@ Content-Length: 88
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">PATCH /api/v1/birthday-cafes/1 HTTP/1.1
 Content-Type: application/json;charset=UTF-8
-Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwiaWF0IjoxNzEwNzcxMzU5LCJleHAiOjE3MTA3NzMxNTl9.Gv0nPm5itQs62tp5QEYmosKGRft1qpv4sjznRbd92HI
+Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwiaWF0IjoxNzEwODI5ODk0LCJleHAiOjE3MTA4MzE2OTR9.o1LA1awOqI1VSCip6kTztPIfQ5PREsTR1YcmBGC_3R8
 Content-Length: 86
 Host: www.api.birca.com
 
@@ -2477,7 +2477,7 @@ Vary: Access-Control-Request-Headers</code></pre>
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">POST /api/v1/birthday-cafes/1/images HTTP/1.1
 Content-Type: multipart/form-data;charset=UTF-8; boundary=6o2knFse3p53ty9dmcQvWAIx1zInP11uCfbm
-Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwiaWF0IjoxNzEwNzcxMzU5LCJleHAiOjE3MTA3NzMxNTl9.Gv0nPm5itQs62tp5QEYmosKGRft1qpv4sjznRbd92HI
+Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwiaWF0IjoxNzEwODI5ODk0LCJleHAiOjE3MTA4MzE2OTR9.o1LA1awOqI1VSCip6kTztPIfQ5PREsTR1YcmBGC_3R8
 Host: www.api.birca.com
 
 --6o2knFse3p53ty9dmcQvWAIx1zInP11uCfbm
@@ -2508,7 +2508,7 @@ Vary: Access-Control-Request-Headers</code></pre>
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">GET /api/v1/birthday-cafes/me HTTP/1.1
 Content-Type: application/json;charset=UTF-8
-Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwiaWF0IjoxNzEwNzcxMzY0LCJleHAiOjE3MTA3NzMxNjR9.nH33sQxWtsJmd0Syp4gGrhl7D4yoA3wOzAr1xcUSG4M
+Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwiaWF0IjoxNzEwODI5ODk5LCJleHAiOjE3MTA4MzE2OTl9.NVvKKltAZwgKus5VI_0WvEGiLk1aDPu3p2vRsYICMOU
 Host: www.api.birca.com</code></pre>
 </div>
 </div>
@@ -2522,33 +2522,29 @@ Vary: Origin
 Vary: Access-Control-Request-Method
 Vary: Access-Control-Request-Headers
 Content-Type: application/json
-Content-Length: 628
+Content-Length: 586
 
 [ {
-  "birthdayCafe" : {
-    "id" : 1,
-    "mainImageUrl" : "image.com",
-    "startDate" : "2024-03-18T00:00:00",
-    "endDate" : "2024-03-19T00:00:00",
-    "name" : "민호의 생일 카페",
-    "progressState" : "FINISHED",
-    "artist" : {
-      "groupName" : "샤이니",
-      "name" : "민호"
-    }
+  "birthdayCafeId" : 1,
+  "mainImageUrl" : "image.com",
+  "startDate" : "2024-03-18T00:00:00",
+  "endDate" : "2024-03-19T00:00:00",
+  "birthdayCafeName" : "민호의 생일 카페",
+  "progressState" : "FINISHED",
+  "artist" : {
+    "groupName" : "샤이니",
+    "name" : "민호"
   }
 }, {
-  "birthdayCafe" : {
-    "id" : 2,
-    "mainImageUrl" : "image.com",
-    "startDate" : "2024-03-20T00:00:00",
-    "endDate" : "2024-03-23T00:00:00",
-    "name" : "아이유의 생일 카페",
-    "progressState" : "IN_PROGRESS",
-    "artist" : {
-      "groupName" : null,
-      "name" : "아이유"
-    }
+  "birthdayCafeId" : 2,
+  "mainImageUrl" : "image.com",
+  "startDate" : "2024-03-20T00:00:00",
+  "endDate" : "2024-03-23T00:00:00",
+  "birthdayCafeName" : "아이유의 생일 카페",
+  "progressState" : "IN_PROGRESS",
+  "artist" : {
+    "groupName" : null,
+    "name" : "아이유"
   }
 } ]</code></pre>
 </div>
@@ -2571,42 +2567,42 @@ Content-Length: 628
 </thead>
 <tbody>
 <tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code>[].birthdayCafe.id</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>[].birthdayCafeId</code></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><code>Number</code></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">생일 카페 ID</p></td>
 </tr>
 <tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code>[].birthdayCafe.mainImageUrl</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>[].mainImageUrl</code></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">생일 카페 메인 이미지 url</p></td>
 </tr>
 <tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code>[].birthdayCafe.startDate</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>[].startDate</code></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">생일 카페 시작일</p></td>
 </tr>
 <tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code>[].birthdayCafe.endDate</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>[].endDate</code></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">생일 카페 종료일</p></td>
 </tr>
 <tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code>[].birthdayCafe.name</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>[].birthdayCafeName</code></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">생일 카페 이름</p></td>
 </tr>
 <tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code>[].birthdayCafe.progressState</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>[].progressState</code></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">생일 카페 진행 상태</p></td>
 </tr>
 <tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code>[].birthdayCafe.artist.groupName</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>[].artist.groupName</code></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">아티스트 그룹 이름</p></td>
 </tr>
 <tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code>[].birthdayCafe.artist.name</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>[].artist.name</code></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">아티스트 이름</p></td>
 </tr>
@@ -2684,7 +2680,7 @@ Content-Length: 628
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">GET /api/v1/cafes/search?name=%EC%BB%A4%ED%94%BC HTTP/1.1
 Content-Type: application/json;charset=UTF-8
-Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwiaWF0IjoxNzEwNzcxMzY0LCJleHAiOjE3MTA3NzMxNjR9.nH33sQxWtsJmd0Syp4gGrhl7D4yoA3wOzAr1xcUSG4M
+Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwiaWF0IjoxNzEwODI5ODk5LCJleHAiOjE3MTA4MzE2OTl9.NVvKKltAZwgKus5VI_0WvEGiLk1aDPu3p2vRsYICMOU
 Host: www.api.birca.com</code></pre>
 </div>
 </div>
@@ -2717,7 +2713,7 @@ Content-Length: 106
 <div id="footer">
 <div id="footer-text">
 Version 0.0.1-SNAPSHOT<br>
-Last updated 2024-03-18 23:15:14 +0900
+Last updated 2024-03-19 11:40:00 +0900
 </div>
 </div>
 <script src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/9.18.3/highlight.min.js"></script>

--- a/src/main/resources/static/docs/api.html
+++ b/src/main/resources/static/docs/api.html
@@ -495,7 +495,10 @@ body.book #toc,body.book #preamble,body.book h1.sect0,body.book .sect1>h2{page-b
 <li><a href="#_생일_카페_메뉴_조회">생일 카페 메뉴 조회</a></li>
 <li><a href="#_생일_카페_럭키_드로우_조회">생일 카페 럭키 드로우 조회</a></li>
 <li><a href="#_생일_카페_정보_수정">생일 카페 정보 수정</a></li>
+<li><a href="#_생일_카페_기본_이미지_업로드">생일 카페 기본 이미지 업로드</a></li>
+<li><a href="#_생일_카페_대표_이미지_업로드">생일 카페 대표 이미지 업로드</a></li>
 <li><a href="#_생일_카페_이미지_업로드">생일 카페 이미지 업로드</a></li>
+<li><a href="#_주최자의_나의_생일_카페_목록_조회">주최자의 나의 생일 카페 목록 조회</a></li>
 <li><a href="#_에러_코드_5">에러 코드</a></li>
 </ul>
 </li>
@@ -638,7 +641,7 @@ Content-Length: 97
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">POST /api/v1/members/role-change HTTP/1.1
 Content-Type: application/json;charset=UTF-8
-Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwiaWF0IjoxNzEwNjA1NzI2LCJleHAiOjE3MTA2MDc1MjZ9.jSXdqkCnt9_PHFQoWJddANfY5jjNn1d7GwaR-jYSlZ0
+Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwiaWF0IjoxNzEwODMwMjY0LCJleHAiOjE3MTA4MzIwNjR9.yt2H8r7HLhmpoHOfsNTiAinZZywayvxGXCCHnoH6pN8
 Content-Length: 21
 Host: www.api.birca.com
 
@@ -668,7 +671,7 @@ Vary: Access-Control-Request-Headers</code></pre>
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">GET /api/v1/join/check-nickname?nickname=does HTTP/1.1
 Content-Type: application/json;charset=UTF-8
-Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwiaWF0IjoxNzEwNjA1NzI4LCJleHAiOjE3MTA2MDc1Mjh9.rpSmHAQBUuy9LOUyruk4cKVcygiy5hxY9w0IEkPsLY4
+Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwiaWF0IjoxNzEwODMwMjY3LCJleHAiOjE3MTA4MzIwNjd9.rH0P-fl2kqou1J4ylHrWiTE98yTUhdV3GAQXdZFhkRM
 Host: www.api.birca.com</code></pre>
 </div>
 </div>
@@ -742,7 +745,7 @@ Content-Length: 16
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">POST /api/v1/join/register-nickname HTTP/1.1
 Content-Type: application/json;charset=UTF-8
-Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwiaWF0IjoxNzEwNjA1NzI2LCJleHAiOjE3MTA2MDc1MjZ9.jSXdqkCnt9_PHFQoWJddANfY5jjNn1d7GwaR-jYSlZ0
+Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwiaWF0IjoxNzEwODMwMjY0LCJleHAiOjE3MTA4MzIwNjR9.yt2H8r7HLhmpoHOfsNTiAinZZywayvxGXCCHnoH6pN8
 Content-Length: 30
 Host: www.api.birca.com
 
@@ -830,7 +833,7 @@ Vary: Access-Control-Request-Headers</code></pre>
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">GET /api/v1/artist-groups?cursor=10&amp;size=3 HTTP/1.1
 Content-Type: application/json;charset=UTF-8
-Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwiaWF0IjoxNzEwNjA1NzI4LCJleHAiOjE3MTA2MDc1Mjh9.rpSmHAQBUuy9LOUyruk4cKVcygiy5hxY9w0IEkPsLY4
+Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwiaWF0IjoxNzEwODMwMjY3LCJleHAiOjE3MTA4MzIwNjd9.rH0P-fl2kqou1J4ylHrWiTE98yTUhdV3GAQXdZFhkRM
 Host: www.api.birca.com</code></pre>
 </div>
 </div>
@@ -930,7 +933,7 @@ Content-Length: 250
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">GET /api/v1/artist-groups/1/artists HTTP/1.1
 Content-Type: application/json;charset=UTF-8
-Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwiaWF0IjoxNzEwNjA1NzI4LCJleHAiOjE3MTA2MDc1Mjh9.rpSmHAQBUuy9LOUyruk4cKVcygiy5hxY9w0IEkPsLY4
+Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwiaWF0IjoxNzEwODMwMjY3LCJleHAiOjE3MTA4MzIwNjd9.rH0P-fl2kqou1J4ylHrWiTE98yTUhdV3GAQXdZFhkRM
 Host: www.api.birca.com</code></pre>
 </div>
 </div>
@@ -1043,7 +1046,7 @@ Content-Length: 565
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">GET /api/v1/artists/solo?cursor=12&amp;size=6 HTTP/1.1
 Content-Type: application/json;charset=UTF-8
-Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwiaWF0IjoxNzEwNjA1NzI4LCJleHAiOjE3MTA2MDc1Mjh9.rpSmHAQBUuy9LOUyruk4cKVcygiy5hxY9w0IEkPsLY4
+Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwiaWF0IjoxNzEwODMwMjY3LCJleHAiOjE3MTA4MzIwNjd9.rH0P-fl2kqou1J4ylHrWiTE98yTUhdV3GAQXdZFhkRM
 Host: www.api.birca.com</code></pre>
 </div>
 </div>
@@ -1155,7 +1158,7 @@ Content-Length: 518
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">POST /api/v1/artists/favorite HTTP/1.1
 Content-Type: application/json;charset=UTF-8
-Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwiaWF0IjoxNzEwNjA1NzIxLCJleHAiOjE3MTA2MDc1MjF9.6Br9S9l0Ey2ZaxVnmjaU71MI8COc8pcm4gDIClOFqZk
+Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwiaWF0IjoxNzEwODMwMjYxLCJleHAiOjE3MTA4MzIwNjF9.Wm97ZHFzoWRClxSE6senbO0oZNrCw_qOZ4WZ3AcgJs0
 Content-Length: 20
 Host: www.api.birca.com
 
@@ -1209,7 +1212,7 @@ Vary: Access-Control-Request-Headers</code></pre>
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">POST /api/v1/artists/interest HTTP/1.1
 Content-Type: application/json;charset=UTF-8
-Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwiaWF0IjoxNzEwNjA1NzIxLCJleHAiOjE3MTA2MDc1MjF9.6Br9S9l0Ey2ZaxVnmjaU71MI8COc8pcm4gDIClOFqZk
+Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwiaWF0IjoxNzEwODMwMjYxLCJleHAiOjE3MTA4MzIwNjF9.Wm97ZHFzoWRClxSE6senbO0oZNrCw_qOZ4WZ3AcgJs0
 Content-Length: 68
 Host: www.api.birca.com
 
@@ -1267,7 +1270,7 @@ Vary: Access-Control-Request-Headers</code></pre>
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">GET /api/v1/artists/favorite HTTP/1.1
 Content-Type: application/json;charset=UTF-8
-Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwiaWF0IjoxNzEwNjA1NzI4LCJleHAiOjE3MTA2MDc1Mjh9.rpSmHAQBUuy9LOUyruk4cKVcygiy5hxY9w0IEkPsLY4
+Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwiaWF0IjoxNzEwODMwMjY3LCJleHAiOjE3MTA4MzIwNjd9.rH0P-fl2kqou1J4ylHrWiTE98yTUhdV3GAQXdZFhkRM
 Host: www.api.birca.com</code></pre>
 </div>
 </div>
@@ -1334,7 +1337,7 @@ Content-Length: 81
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">GET /api/v1/artists/interest HTTP/1.1
 Content-Type: application/json;charset=UTF-8
-Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwiaWF0IjoxNzEwNjA1NzI4LCJleHAiOjE3MTA2MDc1Mjh9.rpSmHAQBUuy9LOUyruk4cKVcygiy5hxY9w0IEkPsLY4
+Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwiaWF0IjoxNzEwODMwMjY3LCJleHAiOjE3MTA4MzIwNjd9.rH0P-fl2kqou1J4ylHrWiTE98yTUhdV3GAQXdZFhkRM
 Host: www.api.birca.com</code></pre>
 </div>
 </div>
@@ -1417,7 +1420,7 @@ Content-Length: 416
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">GET /api/v1/artists/search?name=%EB%A7%88%ED%81%AC HTTP/1.1
 Content-Type: application/json;charset=UTF-8
-Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwiaWF0IjoxNzEwNjA1NzI4LCJleHAiOjE3MTA2MDc1Mjh9.rpSmHAQBUuy9LOUyruk4cKVcygiy5hxY9w0IEkPsLY4
+Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwiaWF0IjoxNzEwODMwMjY3LCJleHAiOjE3MTA4MzIwNjd9.rH0P-fl2kqou1J4ylHrWiTE98yTUhdV3GAQXdZFhkRM
 Host: www.api.birca.com</code></pre>
 </div>
 </div>
@@ -1482,7 +1485,7 @@ Content-Length: 225
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">POST /api/v1/cafes/license-read HTTP/1.1
 Content-Type: multipart/form-data;charset=UTF-8; boundary=6o2knFse3p53ty9dmcQvWAIx1zInP11uCfbm
-Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwiaWF0IjoxNzEwNjA1NzI2LCJleHAiOjE3MTA2MDc1MjZ9.jSXdqkCnt9_PHFQoWJddANfY5jjNn1d7GwaR-jYSlZ0
+Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwiaWF0IjoxNzEwODMwMjY0LCJleHAiOjE3MTA4MzIwNjR9.yt2H8r7HLhmpoHOfsNTiAinZZywayvxGXCCHnoH6pN8
 Host: www.api.birca.com
 
 --6o2knFse3p53ty9dmcQvWAIx1zInP11uCfbm
@@ -1568,7 +1571,7 @@ Content-Length: 141
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">POST /api/v1/cafes/apply HTTP/1.1
 Content-Type: multipart/form-data;charset=UTF-8; boundary=6o2knFse3p53ty9dmcQvWAIx1zInP11uCfbm
-Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwiaWF0IjoxNzEwNjA1NzI2LCJleHAiOjE3MTA2MDc1MjZ9.jSXdqkCnt9_PHFQoWJddANfY5jjNn1d7GwaR-jYSlZ0
+Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwiaWF0IjoxNzEwODMwMjY0LCJleHAiOjE3MTA4MzIwNjR9.yt2H8r7HLhmpoHOfsNTiAinZZywayvxGXCCHnoH6pN8
 Host: www.api.birca.com
 
 --6o2knFse3p53ty9dmcQvWAIx1zInP11uCfbm
@@ -1642,7 +1645,7 @@ Vary: Access-Control-Request-Headers</code></pre>
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">POST /api/v1/birthday-cafes HTTP/1.1
 Content-Type: application/json;charset=UTF-8
-Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwiaWF0IjoxNzEwNjA1NzIzLCJleHAiOjE3MTA2MDc1MjN9.llKVdPDfhB1vDdFQBYQiJiKDm60XWCxjxwcvkr3eRWE
+Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwiaWF0IjoxNzEwODMwMjYyLCJleHAiOjE3MTA4MzIwNjJ9.dG_Pjft5qwIuo7RvFR9sVKzsLAyxAytAxeyeRBY8aHs
 Content-Length: 234
 Host: www.api.birca.com
 
@@ -1738,7 +1741,7 @@ Vary: Access-Control-Request-Headers</code></pre>
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">POST /api/v1/birthday-cafes/1/cancel HTTP/1.1
 Content-Type: application/json;charset=UTF-8
-Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwiaWF0IjoxNzEwNjA1NzIzLCJleHAiOjE3MTA2MDc1MjN9.llKVdPDfhB1vDdFQBYQiJiKDm60XWCxjxwcvkr3eRWE
+Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwiaWF0IjoxNzEwODMwMjYyLCJleHAiOjE3MTA4MzIwNjJ9.dG_Pjft5qwIuo7RvFR9sVKzsLAyxAytAxeyeRBY8aHs
 Host: www.api.birca.com</code></pre>
 </div>
 </div>
@@ -1785,7 +1788,7 @@ Vary: Access-Control-Request-Headers</code></pre>
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">PATCH /api/v1/birthday-cafes/1/congestion HTTP/1.1
 Content-Type: application/json;charset=UTF-8
-Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwiaWF0IjoxNzEwNjA1NzIzLCJleHAiOjE3MTA2MDc1MjN9.llKVdPDfhB1vDdFQBYQiJiKDm60XWCxjxwcvkr3eRWE
+Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwiaWF0IjoxNzEwODMwMjYyLCJleHAiOjE3MTA4MzIwNjJ9.dG_Pjft5qwIuo7RvFR9sVKzsLAyxAytAxeyeRBY8aHs
 Content-Length: 26
 Host: www.api.birca.com
 
@@ -1865,7 +1868,7 @@ Vary: Access-Control-Request-Headers</code></pre>
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">POST /api/v1/birthday-cafes/1/like HTTP/1.1
 Content-Type: application/json;charset=UTF-8
-Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwiaWF0IjoxNzEwNjA1NzIzLCJleHAiOjE3MTA2MDc1MjN9.llKVdPDfhB1vDdFQBYQiJiKDm60XWCxjxwcvkr3eRWE
+Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwiaWF0IjoxNzEwODMwMjYyLCJleHAiOjE3MTA4MzIwNjJ9.dG_Pjft5qwIuo7RvFR9sVKzsLAyxAytAxeyeRBY8aHs
 Host: www.api.birca.com</code></pre>
 </div>
 </div>
@@ -1912,7 +1915,7 @@ Vary: Access-Control-Request-Headers</code></pre>
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">DELETE /api/v1/birthday-cafes/1/like HTTP/1.1
 Content-Type: application/json;charset=UTF-8
-Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwiaWF0IjoxNzEwNjA1NzIzLCJleHAiOjE3MTA2MDc1MjN9.llKVdPDfhB1vDdFQBYQiJiKDm60XWCxjxwcvkr3eRWE
+Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwiaWF0IjoxNzEwODMwMjYyLCJleHAiOjE3MTA4MzIwNjJ9.dG_Pjft5qwIuo7RvFR9sVKzsLAyxAytAxeyeRBY8aHs
 Host: www.api.birca.com</code></pre>
 </div>
 </div>
@@ -1959,7 +1962,7 @@ Vary: Access-Control-Request-Headers</code></pre>
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">POST /api/v1/birthday-cafes/1/special-goods HTTP/1.1
 Content-Type: application/json;charset=UTF-8
-Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwiaWF0IjoxNzEwNjA1NzIzLCJleHAiOjE3MTA2MDc1MjN9.llKVdPDfhB1vDdFQBYQiJiKDm60XWCxjxwcvkr3eRWE
+Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwiaWF0IjoxNzEwODMwMjYyLCJleHAiOjE3MTA4MzIwNjJ9.dG_Pjft5qwIuo7RvFR9sVKzsLAyxAytAxeyeRBY8aHs
 Content-Length: 147
 Host: www.api.birca.com
 
@@ -2044,7 +2047,7 @@ Vary: Access-Control-Request-Headers</code></pre>
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">POST /api/v1/birthday-cafes/1/menus HTTP/1.1
 Content-Type: application/json;charset=UTF-8
-Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwiaWF0IjoxNzEwNjA1NzIzLCJleHAiOjE3MTA2MDc1MjN9.llKVdPDfhB1vDdFQBYQiJiKDm60XWCxjxwcvkr3eRWE
+Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwiaWF0IjoxNzEwODMwMjYyLCJleHAiOjE3MTA4MzIwNjJ9.dG_Pjft5qwIuo7RvFR9sVKzsLAyxAytAxeyeRBY8aHs
 Content-Length: 197
 Host: www.api.birca.com
 
@@ -2136,7 +2139,7 @@ Vary: Access-Control-Request-Headers</code></pre>
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">POST /api/v1/birthday-cafes/1/lucky-draws HTTP/1.1
 Content-Type: application/json;charset=UTF-8
-Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwiaWF0IjoxNzEwNjA1NzIzLCJleHAiOjE3MTA2MDc1MjN9.llKVdPDfhB1vDdFQBYQiJiKDm60XWCxjxwcvkr3eRWE
+Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwiaWF0IjoxNzEwODMwMjYyLCJleHAiOjE3MTA4MzIwNjJ9.dG_Pjft5qwIuo7RvFR9sVKzsLAyxAytAxeyeRBY8aHs
 Content-Length: 92
 Host: www.api.birca.com
 
@@ -2221,7 +2224,7 @@ Vary: Access-Control-Request-Headers</code></pre>
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">GET /api/v1/birthday-cafes/1/special-goods HTTP/1.1
 Content-Type: application/json;charset=UTF-8
-Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwiaWF0IjoxNzEwNjA1NzI4LCJleHAiOjE3MTA2MDc1Mjh9.rpSmHAQBUuy9LOUyruk4cKVcygiy5hxY9w0IEkPsLY4
+Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwiaWF0IjoxNzEwODMwMjY3LCJleHAiOjE3MTA4MzIwNjd9.rH0P-fl2kqou1J4ylHrWiTE98yTUhdV3GAQXdZFhkRM
 Host: www.api.birca.com</code></pre>
 </div>
 </div>
@@ -2278,7 +2281,7 @@ Content-Length: 126
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">GET /api/v1/birthday-cafes/1/menus HTTP/1.1
 Content-Type: application/json;charset=UTF-8
-Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwiaWF0IjoxNzEwNjA1NzI4LCJleHAiOjE3MTA2MDc1Mjh9.rpSmHAQBUuy9LOUyruk4cKVcygiy5hxY9w0IEkPsLY4
+Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwiaWF0IjoxNzEwODMwMjY3LCJleHAiOjE3MTA4MzIwNjd9.rH0P-fl2kqou1J4ylHrWiTE98yTUhdV3GAQXdZFhkRM
 Host: www.api.birca.com</code></pre>
 </div>
 </div>
@@ -2337,7 +2340,7 @@ Content-Length: 196
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">GET /api/v1/birthday-cafes/1/lucky-draws HTTP/1.1
 Content-Type: application/json;charset=UTF-8
-Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwiaWF0IjoxNzEwNjA1NzI4LCJleHAiOjE3MTA2MDc1Mjh9.rpSmHAQBUuy9LOUyruk4cKVcygiy5hxY9w0IEkPsLY4
+Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwiaWF0IjoxNzEwODMwMjY3LCJleHAiOjE3MTA4MzIwNjd9.rH0P-fl2kqou1J4ylHrWiTE98yTUhdV3GAQXdZFhkRM
 Host: www.api.birca.com</code></pre>
 </div>
 </div>
@@ -2394,7 +2397,7 @@ Content-Length: 88
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">PATCH /api/v1/birthday-cafes/1 HTTP/1.1
 Content-Type: application/json;charset=UTF-8
-Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwiaWF0IjoxNzEwNjA1NzIzLCJleHAiOjE3MTA2MDc1MjN9.llKVdPDfhB1vDdFQBYQiJiKDm60XWCxjxwcvkr3eRWE
+Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwiaWF0IjoxNzEwODMwMjYyLCJleHAiOjE3MTA4MzIwNjJ9.dG_Pjft5qwIuo7RvFR9sVKzsLAyxAytAxeyeRBY8aHs
 Content-Length: 86
 Host: www.api.birca.com
 
@@ -2469,6 +2472,68 @@ Vary: Access-Control-Request-Headers</code></pre>
 </div>
 </div>
 <div class="sect2">
+<h3 id="_생일_카페_기본_이미지_업로드"><a class="link" href="#_생일_카페_기본_이미지_업로드">생일 카페 기본 이미지 업로드</a></h3>
+<div class="sect3">
+<h4 id="_생일_카페_기본_이미지_업로드_http_request"><a class="link" href="#_생일_카페_기본_이미지_업로드_http_request">HTTP request</a></h4>
+<div class="listingblock">
+<div class="content">
+<pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">POST /api/v1/birthday-cafes/1/images HTTP/1.1
+Content-Type: multipart/form-data;charset=UTF-8; boundary=6o2knFse3p53ty9dmcQvWAIx1zInP11uCfbm
+Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwiaWF0IjoxNzEwODMwMjYyLCJleHAiOjE3MTA4MzIwNjJ9.dG_Pjft5qwIuo7RvFR9sVKzsLAyxAytAxeyeRBY8aHs
+Host: www.api.birca.com
+
+--6o2knFse3p53ty9dmcQvWAIx1zInP11uCfbm
+Content-Disposition: form-data; name=defaultImage
+
+defaultImage
+--6o2knFse3p53ty9dmcQvWAIx1zInP11uCfbm--</code></pre>
+</div>
+</div>
+</div>
+<div class="sect3">
+<h4 id="_생일_카페_기본_이미지_업로드_http_response"><a class="link" href="#_생일_카페_기본_이미지_업로드_http_response">HTTP response</a></h4>
+<div class="listingblock">
+<div class="content">
+<pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">HTTP/1.1 200 OK
+Vary: Origin
+Vary: Access-Control-Request-Method
+Vary: Access-Control-Request-Headers</code></pre>
+</div>
+</div>
+</div>
+</div>
+<div class="sect2">
+<h3 id="_생일_카페_대표_이미지_업로드"><a class="link" href="#_생일_카페_대표_이미지_업로드">생일 카페 대표 이미지 업로드</a></h3>
+<div class="sect3">
+<h4 id="_생일_카페_대표_이미지_업로드_http_request"><a class="link" href="#_생일_카페_대표_이미지_업로드_http_request">HTTP request</a></h4>
+<div class="listingblock">
+<div class="content">
+<pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">POST /api/v1/birthday-cafes/1/images/main HTTP/1.1
+Content-Type: multipart/form-data;charset=UTF-8; boundary=6o2knFse3p53ty9dmcQvWAIx1zInP11uCfbm
+Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwiaWF0IjoxNzEwODMwMjYyLCJleHAiOjE3MTA4MzIwNjJ9.dG_Pjft5qwIuo7RvFR9sVKzsLAyxAytAxeyeRBY8aHs
+Host: www.api.birca.com
+
+--6o2knFse3p53ty9dmcQvWAIx1zInP11uCfbm
+Content-Disposition: form-data; name=mainImage
+
+mainImage
+--6o2knFse3p53ty9dmcQvWAIx1zInP11uCfbm--</code></pre>
+</div>
+</div>
+</div>
+<div class="sect3">
+<h4 id="_생일_카페_대표_이미지_업로드_http_response"><a class="link" href="#_생일_카페_대표_이미지_업로드_http_response">HTTP response</a></h4>
+<div class="listingblock">
+<div class="content">
+<pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">HTTP/1.1 200 OK
+Vary: Origin
+Vary: Access-Control-Request-Method
+Vary: Access-Control-Request-Headers</code></pre>
+</div>
+</div>
+</div>
+</div>
+<div class="sect2">
 <h3 id="_생일_카페_이미지_업로드"><a class="link" href="#_생일_카페_이미지_업로드">생일 카페 이미지 업로드</a></h3>
 <div class="sect3">
 <h4 id="_생일_카페_이미지_업로드_http_request"><a class="link" href="#_생일_카페_이미지_업로드_http_request">HTTP request</a></h4>
@@ -2476,13 +2541,13 @@ Vary: Access-Control-Request-Headers</code></pre>
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">POST /api/v1/birthday-cafes/1/images HTTP/1.1
 Content-Type: multipart/form-data;charset=UTF-8; boundary=6o2knFse3p53ty9dmcQvWAIx1zInP11uCfbm
-Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwiaWF0IjoxNzEwNjA1NzIzLCJleHAiOjE3MTA2MDc1MjN9.llKVdPDfhB1vDdFQBYQiJiKDm60XWCxjxwcvkr3eRWE
+Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwiaWF0IjoxNzEwODMwMjYyLCJleHAiOjE3MTA4MzIwNjJ9.dG_Pjft5qwIuo7RvFR9sVKzsLAyxAytAxeyeRBY8aHs
 Host: www.api.birca.com
 
 --6o2knFse3p53ty9dmcQvWAIx1zInP11uCfbm
-Content-Disposition: form-data; name=birthdayCafeImage
+Content-Disposition: form-data; name=defaultImage
 
-birthdayCafeImage
+defaultImage
 --6o2knFse3p53ty9dmcQvWAIx1zInP11uCfbm--</code></pre>
 </div>
 </div>
@@ -2497,6 +2562,116 @@ Vary: Access-Control-Request-Method
 Vary: Access-Control-Request-Headers</code></pre>
 </div>
 </div>
+</div>
+</div>
+<div class="sect2">
+<h3 id="_주최자의_나의_생일_카페_목록_조회"><a class="link" href="#_주최자의_나의_생일_카페_목록_조회">주최자의 나의 생일 카페 목록 조회</a></h3>
+<div class="sect3">
+<h4 id="_주최자의_나의_생일_카페_목록_조회_http_request"><a class="link" href="#_주최자의_나의_생일_카페_목록_조회_http_request">HTTP request</a></h4>
+<div class="listingblock">
+<div class="content">
+<pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">GET /api/v1/birthday-cafes/me HTTP/1.1
+Content-Type: application/json;charset=UTF-8
+Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwiaWF0IjoxNzEwODMwMjY3LCJleHAiOjE3MTA4MzIwNjd9.rH0P-fl2kqou1J4ylHrWiTE98yTUhdV3GAQXdZFhkRM
+Host: www.api.birca.com</code></pre>
+</div>
+</div>
+</div>
+<div class="sect3">
+<h4 id="_주최자의_나의_생일_카페_목록_조회_http_response"><a class="link" href="#_주최자의_나의_생일_카페_목록_조회_http_response">HTTP response</a></h4>
+<div class="listingblock">
+<div class="content">
+<pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">HTTP/1.1 200 OK
+Vary: Origin
+Vary: Access-Control-Request-Method
+Vary: Access-Control-Request-Headers
+Content-Type: application/json
+Content-Length: 586
+
+[ {
+  "birthdayCafeId" : 1,
+  "mainImageUrl" : "image.com",
+  "startDate" : "2024-03-18T00:00:00",
+  "endDate" : "2024-03-19T00:00:00",
+  "birthdayCafeName" : "민호의 생일 카페",
+  "progressState" : "FINISHED",
+  "artist" : {
+    "groupName" : "샤이니",
+    "name" : "민호"
+  }
+}, {
+  "birthdayCafeId" : 2,
+  "mainImageUrl" : "image.com",
+  "startDate" : "2024-03-20T00:00:00",
+  "endDate" : "2024-03-23T00:00:00",
+  "birthdayCafeName" : "아이유의 생일 카페",
+  "progressState" : "IN_PROGRESS",
+  "artist" : {
+    "groupName" : null,
+    "name" : "아이유"
+  }
+} ]</code></pre>
+</div>
+</div>
+</div>
+<div class="sect3">
+<h4 id="_주최자의_나의_생일_카페_목록_조회_response_fields"><a class="link" href="#_주최자의_나의_생일_카페_목록_조회_response_fields">Response fields</a></h4>
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 33.3333%;">
+<col style="width: 33.3333%;">
+<col style="width: 33.3334%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">Path</th>
+<th class="tableblock halign-left valign-top">Type</th>
+<th class="tableblock halign-left valign-top">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>[].birthdayCafeId</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Number</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">생일 카페 ID</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>[].mainImageUrl</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">생일 카페 메인 이미지 url</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>[].startDate</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">생일 카페 시작일</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>[].endDate</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">생일 카페 종료일</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>[].birthdayCafeName</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">생일 카페 이름</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>[].progressState</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">생일 카페 진행 상태</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>[].artist.groupName</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">아티스트 그룹 이름</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>[].artist.name</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">아티스트 이름</p></td>
+</tr>
+</tbody>
+</table>
 </div>
 </div>
 <div class="sect2">
@@ -2569,7 +2744,7 @@ Vary: Access-Control-Request-Headers</code></pre>
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">GET /api/v1/cafes/search?name=%EC%BB%A4%ED%94%BC HTTP/1.1
 Content-Type: application/json;charset=UTF-8
-Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwiaWF0IjoxNzEwNjA1NzI4LCJleHAiOjE3MTA2MDc1Mjh9.rpSmHAQBUuy9LOUyruk4cKVcygiy5hxY9w0IEkPsLY4
+Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwiaWF0IjoxNzEwODMwMjY3LCJleHAiOjE3MTA4MzIwNjd9.rH0P-fl2kqou1J4ylHrWiTE98yTUhdV3GAQXdZFhkRM
 Host: www.api.birca.com</code></pre>
 </div>
 </div>
@@ -2602,7 +2777,7 @@ Content-Length: 106
 <div id="footer">
 <div id="footer-text">
 Version 0.0.1-SNAPSHOT<br>
-Last updated 2024-03-15 20:24:13 +0900
+Last updated 2024-03-19 15:37:26 +0900
 </div>
 </div>
 <script src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/9.18.3/highlight.min.js"></script>

--- a/src/test/java/com/birca/bircabackend/query/acceptance/BirthdayCafeQueryAcceptanceTest.java
+++ b/src/test/java/com/birca/bircabackend/query/acceptance/BirthdayCafeQueryAcceptanceTest.java
@@ -16,6 +16,7 @@ import static org.junit.jupiter.api.Assertions.assertAll;
 @Sql("/fixture/birthday-cafe-fixture.sql")
 public class BirthdayCafeQueryAcceptanceTest extends AcceptanceTest {
 
+    private static final Long HOST_ID = 1L;
     private static final Long BIRTHDAY_CAFE_ID = 2L;
 
     @Test
@@ -25,7 +26,7 @@ public class BirthdayCafeQueryAcceptanceTest extends AcceptanceTest {
         ExtractableResponse<Response> response = RestAssured.given().log().all()
                 .when()
                 .contentType(MediaType.APPLICATION_JSON_VALUE)
-                .header(HttpHeaders.AUTHORIZATION, bearerTokenProvider.getToken(1L))
+                .header(HttpHeaders.AUTHORIZATION, bearerTokenProvider.getToken(HOST_ID))
                 .get("/api/v1/birthday-cafes/{birthdayCafeId}/special-goods", BIRTHDAY_CAFE_ID)
                 .then().log().all()
                 .extract();
@@ -43,7 +44,7 @@ public class BirthdayCafeQueryAcceptanceTest extends AcceptanceTest {
         ExtractableResponse<Response> response = RestAssured.given().log().all()
                 .when()
                 .contentType(MediaType.APPLICATION_JSON_VALUE)
-                .header(HttpHeaders.AUTHORIZATION, bearerTokenProvider.getToken(1L))
+                .header(HttpHeaders.AUTHORIZATION, bearerTokenProvider.getToken(HOST_ID))
                 .get("/api/v1/birthday-cafes/{birthdayCafeId}/menus", BIRTHDAY_CAFE_ID)
                 .then().log().all()
                 .extract();
@@ -61,8 +62,26 @@ public class BirthdayCafeQueryAcceptanceTest extends AcceptanceTest {
         ExtractableResponse<Response> response = RestAssured.given().log().all()
                 .when()
                 .contentType(MediaType.APPLICATION_JSON_VALUE)
-                .header(HttpHeaders.AUTHORIZATION, bearerTokenProvider.getToken(1L))
+                .header(HttpHeaders.AUTHORIZATION, bearerTokenProvider.getToken(HOST_ID))
                 .get("/api/v1/birthday-cafes/{birthdayCafeId}/lucky-draws", BIRTHDAY_CAFE_ID)
+                .then().log().all()
+                .extract();
+
+        // then
+        assertAll(
+                () -> assertThat(response.statusCode()).isEqualTo(HttpStatus.OK.value()),
+                () -> assertThat(response.jsonPath().getList(".")).hasSize(2)
+        );
+    }
+
+    @Test
+    void 주최자가_나의_생일카페_목록을_조회한다() {
+        // when
+        ExtractableResponse<Response> response = RestAssured.given().log().all()
+                .when()
+                .contentType(MediaType.APPLICATION_JSON_VALUE)
+                .header(HttpHeaders.AUTHORIZATION, bearerTokenProvider.getToken(HOST_ID))
+                .get("/api/v1/birthday-cafes/me")
                 .then().log().all()
                 .extract();
 

--- a/src/test/java/com/birca/bircabackend/query/controller/BirthdayCafeQueryControllerTest.java
+++ b/src/test/java/com/birca/bircabackend/query/controller/BirthdayCafeQueryControllerTest.java
@@ -122,23 +122,23 @@ class BirthdayCafeQueryControllerTest extends DocumentationTest {
         // given
         given(birthdayCafeQueryService.findMyBirthdayCafes(new LoginMember(MEMBER_ID)))
                 .willReturn(List.of(
-                        new MyBirthdayCafeResponse(new MyBirthdayCafeResponse.BirthdayCafe(
+                        new MyBirthdayCafeResponse(new MyBirthdayCafeResponse.BirthdayCafeResponse(
                                 1L,
                                 "image.com",
                                 LocalDateTime.of(2024, 3, 18, 0, 0, 0),
                                 LocalDateTime.of(2024, 3, 19, 0, 0, 0),
                                 "민호의 생일 카페",
                                 "FINISHED",
-                                new MyBirthdayCafeResponse.Artist("샤이니", "민호")
+                                new MyBirthdayCafeResponse.ArtistResponse("샤이니", "민호")
                         )),
-                        new MyBirthdayCafeResponse(new MyBirthdayCafeResponse.BirthdayCafe(
+                        new MyBirthdayCafeResponse(new MyBirthdayCafeResponse.BirthdayCafeResponse(
                                 2L,
                                 "image.com",
                                 LocalDateTime.of(2024, 3, 20, 0, 0, 0),
                                 LocalDateTime.of(2024, 3, 23, 0, 0, 0),
                                 "아이유의 생일 카페",
                                 "IN_PROGRESS",
-                                new MyBirthdayCafeResponse.Artist(null, "아이유")
+                                new MyBirthdayCafeResponse.ArtistResponse(null, "아이유")
                         ))
                 ));
 

--- a/src/test/java/com/birca/bircabackend/query/controller/BirthdayCafeQueryControllerTest.java
+++ b/src/test/java/com/birca/bircabackend/query/controller/BirthdayCafeQueryControllerTest.java
@@ -122,7 +122,7 @@ class BirthdayCafeQueryControllerTest extends DocumentationTest {
         // given
         given(birthdayCafeQueryService.findMyBirthdayCafes(new LoginMember(MEMBER_ID)))
                 .willReturn(List.of(
-                        new MyBirthdayCafeResponse(new MyBirthdayCafeResponse.BirthdayCafeResponse(
+                        new MyBirthdayCafeResponse(
                                 1L,
                                 "image.com",
                                 LocalDateTime.of(2024, 3, 18, 0, 0, 0),
@@ -130,8 +130,8 @@ class BirthdayCafeQueryControllerTest extends DocumentationTest {
                                 "민호의 생일 카페",
                                 "FINISHED",
                                 new MyBirthdayCafeResponse.ArtistResponse("샤이니", "민호")
-                        )),
-                        new MyBirthdayCafeResponse(new MyBirthdayCafeResponse.BirthdayCafeResponse(
+                        ),
+                        new MyBirthdayCafeResponse(
                                 2L,
                                 "image.com",
                                 LocalDateTime.of(2024, 3, 20, 0, 0, 0),
@@ -139,7 +139,7 @@ class BirthdayCafeQueryControllerTest extends DocumentationTest {
                                 "아이유의 생일 카페",
                                 "IN_PROGRESS",
                                 new MyBirthdayCafeResponse.ArtistResponse(null, "아이유")
-                        ))
+                        )
                 ));
 
         // when
@@ -152,14 +152,14 @@ class BirthdayCafeQueryControllerTest extends DocumentationTest {
         result.andExpect((status().isOk()))
                 .andDo(document("get-my-birthday-cafe-list", HOST_INFO, DOCUMENT_RESPONSE,
                         responseFields(
-                                fieldWithPath("[].birthdayCafe.id").type(JsonFieldType.NUMBER).description("생일 카페 ID"),
-                                fieldWithPath("[].birthdayCafe.mainImageUrl").type(JsonFieldType.STRING).description("생일 카페 메인 이미지 url"),
-                                fieldWithPath("[].birthdayCafe.startDate").type(JsonFieldType.STRING).description("생일 카페 시작일"),
-                                fieldWithPath("[].birthdayCafe.endDate").type(JsonFieldType.STRING).description("생일 카페 종료일"),
-                                fieldWithPath("[].birthdayCafe.name").type(JsonFieldType.STRING).description("생일 카페 이름"),
-                                fieldWithPath("[].birthdayCafe.progressState").type(JsonFieldType.STRING).description("생일 카페 진행 상태"),
-                                fieldWithPath("[].birthdayCafe.artist.groupName").type(JsonFieldType.STRING).description("아티스트 그룹 이름").optional(),
-                                fieldWithPath("[].birthdayCafe.artist.name").type(JsonFieldType.STRING).description("아티스트 이름")
+                                fieldWithPath("[].birthdayCafeId").type(JsonFieldType.NUMBER).description("생일 카페 ID"),
+                                fieldWithPath("[].mainImageUrl").type(JsonFieldType.STRING).description("생일 카페 메인 이미지 url"),
+                                fieldWithPath("[].startDate").type(JsonFieldType.STRING).description("생일 카페 시작일"),
+                                fieldWithPath("[].endDate").type(JsonFieldType.STRING).description("생일 카페 종료일"),
+                                fieldWithPath("[].birthdayCafeName").type(JsonFieldType.STRING).description("생일 카페 이름"),
+                                fieldWithPath("[].progressState").type(JsonFieldType.STRING).description("생일 카페 진행 상태"),
+                                fieldWithPath("[].artist.groupName").type(JsonFieldType.STRING).description("아티스트 그룹 이름").optional(),
+                                fieldWithPath("[].artist.name").type(JsonFieldType.STRING).description("아티스트 이름")
                         )
                 ));
     }

--- a/src/test/java/com/birca/bircabackend/query/controller/BirthdayCafeQueryControllerTest.java
+++ b/src/test/java/com/birca/bircabackend/query/controller/BirthdayCafeQueryControllerTest.java
@@ -113,4 +113,30 @@ class BirthdayCafeQueryControllerTest extends DocumentationTest {
                         )
                 ));
     }
+
+    @Test
+    void 주최자의_생일_카페_목록을_조회한다() throws Exception {
+        // given
+
+        // when
+        ResultActions result = mockMvc.perform(
+                get("/api/v1/birthday-cafes/me")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .header(HttpHeaders.AUTHORIZATION, bearerTokenProvider.getToken(MEMBER_ID)));
+
+        // then
+        result.andExpect((status().isOk()))
+                .andDo(document("get-my-birthday-cafe-list", HOST_INFO, DOCUMENT_RESPONSE,
+                        responseFields(
+                                fieldWithPath("[].birthdayCafe.id").type(JsonFieldType.NUMBER).description("생일 카페 ID"),
+                                fieldWithPath("[].birthdayCafe.mainImageUrl").type(JsonFieldType.STRING).description("생일 카페 메인 이미지 url"),
+                                fieldWithPath("[].birthdayCafe.startDate").type(JsonFieldType.STRING).description("생일 카페 시작일"),
+                                fieldWithPath("[].birthdayCafe.endDate").type(JsonFieldType.STRING).description("생일 카페 종료일"),
+                                fieldWithPath("[].birthdayCafe.name").type(JsonFieldType.STRING).description("생일 카페 이름"),
+                                fieldWithPath("[].birthdayCafe.progressState").type(JsonFieldType.STRING).description("생일 카페 진행 상태"),
+                                fieldWithPath("[].birthdayCafe.artist.groupName").type(JsonFieldType.STRING).description("아티스트 그룹 이름"),
+                                fieldWithPath("[].birthdayCafe.artist.name").type(JsonFieldType.STRING).description("아티스트 이름")
+                        )
+                ));
+    }
 }

--- a/src/test/java/com/birca/bircabackend/query/controller/BirthdayCafeQueryControllerTest.java
+++ b/src/test/java/com/birca/bircabackend/query/controller/BirthdayCafeQueryControllerTest.java
@@ -1,7 +1,9 @@
 package com.birca.bircabackend.query.controller;
 
+import com.birca.bircabackend.command.auth.authorization.LoginMember;
 import com.birca.bircabackend.query.dto.LuckyDrawResponse;
 import com.birca.bircabackend.query.dto.MenuResponse;
+import com.birca.bircabackend.query.dto.MyBirthdayCafeResponse;
 import com.birca.bircabackend.query.dto.SpecialGoodsResponse;
 import com.birca.bircabackend.support.enviroment.DocumentationTest;
 import org.junit.jupiter.api.Test;
@@ -10,6 +12,7 @@ import org.springframework.http.MediaType;
 import org.springframework.restdocs.payload.JsonFieldType;
 import org.springframework.test.web.servlet.ResultActions;
 
+import java.time.LocalDateTime;
 import java.util.List;
 
 import static org.mockito.ArgumentMatchers.any;
@@ -117,6 +120,27 @@ class BirthdayCafeQueryControllerTest extends DocumentationTest {
     @Test
     void 주최자의_생일_카페_목록을_조회한다() throws Exception {
         // given
+        given(birthdayCafeQueryService.findMyBirthdayCafes(new LoginMember(MEMBER_ID)))
+                .willReturn(List.of(
+                        new MyBirthdayCafeResponse(new MyBirthdayCafeResponse.BirthdayCafe(
+                                1L,
+                                "image.com",
+                                LocalDateTime.of(2024, 3, 18, 0, 0, 0),
+                                LocalDateTime.of(2024, 3, 19, 0, 0, 0),
+                                "민호의 생일 카페",
+                                "FINISHED",
+                                new MyBirthdayCafeResponse.Artist("샤이니", "민호")
+                        )),
+                        new MyBirthdayCafeResponse(new MyBirthdayCafeResponse.BirthdayCafe(
+                                2L,
+                                "image.com",
+                                LocalDateTime.of(2024, 3, 20, 0, 0, 0),
+                                LocalDateTime.of(2024, 3, 23, 0, 0, 0),
+                                "아이유의 생일 카페",
+                                "IN_PROGRESS",
+                                new MyBirthdayCafeResponse.Artist(null, "아이유")
+                        ))
+                ));
 
         // when
         ResultActions result = mockMvc.perform(
@@ -134,7 +158,7 @@ class BirthdayCafeQueryControllerTest extends DocumentationTest {
                                 fieldWithPath("[].birthdayCafe.endDate").type(JsonFieldType.STRING).description("생일 카페 종료일"),
                                 fieldWithPath("[].birthdayCafe.name").type(JsonFieldType.STRING).description("생일 카페 이름"),
                                 fieldWithPath("[].birthdayCafe.progressState").type(JsonFieldType.STRING).description("생일 카페 진행 상태"),
-                                fieldWithPath("[].birthdayCafe.artist.groupName").type(JsonFieldType.STRING).description("아티스트 그룹 이름"),
+                                fieldWithPath("[].birthdayCafe.artist.groupName").type(JsonFieldType.STRING).description("아티스트 그룹 이름").optional(),
                                 fieldWithPath("[].birthdayCafe.artist.name").type(JsonFieldType.STRING).description("아티스트 이름")
                         )
                 ));

--- a/src/test/java/com/birca/bircabackend/query/service/BirthdayCafeQueryServiceTest.java
+++ b/src/test/java/com/birca/bircabackend/query/service/BirthdayCafeQueryServiceTest.java
@@ -1,13 +1,18 @@
 package com.birca.bircabackend.query.service;
 
+import com.birca.bircabackend.command.auth.authorization.LoginMember;
 import com.birca.bircabackend.query.dto.LuckyDrawResponse;
 import com.birca.bircabackend.query.dto.MenuResponse;
+import com.birca.bircabackend.query.dto.MyBirthdayCafeResponse;
 import com.birca.bircabackend.query.dto.SpecialGoodsResponse;
 import com.birca.bircabackend.support.enviroment.ServiceTest;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.test.context.jdbc.Sql;
 
+import java.time.LocalDateTime;
 import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -16,6 +21,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 class BirthdayCafeQueryServiceTest extends ServiceTest {
 
     private static final Long BIRTHDAY_CAFE_ID = 2L;
+    private static final Long HOST_ID = 1L;
 
     @Autowired
     private BirthdayCafeQueryService birthdayCafeQueryService;
@@ -57,5 +63,41 @@ class BirthdayCafeQueryServiceTest extends ServiceTest {
                         new LuckyDrawResponse(1, "티셔츠"),
                         new LuckyDrawResponse(2, "머그컵")
                 );
+    }
+
+    @Nested
+    @DisplayName("주최자가 나의 생일 카페 목록을")
+    class GetMyBirthdayCafesTest {
+
+        @Test
+        void 조회한다() {
+            // given
+            LoginMember loginMember = new LoginMember(HOST_ID);
+
+            // when
+            List<MyBirthdayCafeResponse> actual = birthdayCafeQueryService.findMyBirthdayCafes(loginMember);
+
+            // then
+            assertThat(actual).containsExactly(
+                    new MyBirthdayCafeResponse(
+                            2L,
+                            "winter-cafe-main-image.com",
+                            LocalDateTime.of(2024, 2, 8, 0, 0, 0),
+                            LocalDateTime.of(2024, 2, 10, 0, 0, 0),
+                            "윈터의 생일 카페",
+                            "IN_PROGRESS",
+                            new MyBirthdayCafeResponse.ArtistResponse("에스파", "윈터")
+                    ),
+                    new MyBirthdayCafeResponse(
+                            1L,
+                            null,
+                            LocalDateTime.of(2024, 2, 8, 0, 0, 0),
+                            LocalDateTime.of(2024, 2, 10, 0, 0, 0),
+                            null,
+                            "RENTAL_PENDING",
+                            new MyBirthdayCafeResponse.ArtistResponse(null, "아이유")
+                    )
+            );
+        }
     }
 }

--- a/src/test/resources/fixture/birthday-cafe-fixture.sql
+++ b/src/test/resources/fixture/birthday-cafe-fixture.sql
@@ -2,57 +2,61 @@ SET foreign_key_checks = 0;
 
 -- 주최자1
 INSERT INTO member (id, nickname, email, social_id, social_provider, member_role)
-VALUES (1, '더즈', 'ldk@gmail.com', '231323', 'kakao', 'HOST');
-
--- 주최자2
-INSERT INTO member (id, nickname, email, social_id, social_provider, member_role)
-VALUES (2, '민혁', 'cm@gmail.com', '341234', 'kakao', 'HOST');
-
--- 사장님
-INSERT INTO member (id, nickname, email, social_id, social_provider, member_role)
-VALUES (3, '카페1 사장', 'owner@gmail.com', '23412', 'kakao', 'OWNER');
+VALUES (1, '더즈', 'ldk@gmail.com', '231323', 'kakao', 'HOST'), -- 주최자1
+       (2, '민혁', 'cm@gmail.com', '341234', 'kakao', 'HOST'), -- 주최자2
+       (3, '카페1 사장', 'owner@gmail.com', '23412', 'kakao', 'OWNER'); -- 사장님
 
 -- 사장님의 사업자 등록증
-INSERT INTO business_license(id, owner_id, owner_name, cafe_name, tax_office_code, business_type_code, serial_code, address, image_url)
+INSERT INTO business_license(id, owner_id, owner_name, cafe_name, tax_office_code, business_type_code, serial_code,
+                             address, image_url)
 VALUES (1, 3, '카페 사장', '스타벅스', '123', '12', '12345', '서울', 'business-license-imgae.com');
 
 -- 사장님의 카페
 INSERT INTO cafe (id, owner_id, business_license_id, name)
-VALUES (1, 3, 1, '메가커피');
-
--- 다른 카페
-INSERT INTO cafe (id, owner_id, business_license_id, name)
-VALUES (2, 4, 2, '스타벅스');
+VALUES (1, 3, 1, '메가커피'), -- 사장님의 카페
+       (2, 4, 2, '스타벅스'); -- 다른 카페
 
 -- 아티스트
+INSERT INTO artist_group (id, name, image_url)
+VALUES (1, '에스파', 'aespa-image.com');
+
 INSERT INTO artist (id, group_id, name, image_url)
-VALUES (1, null, '아이유', 'image1.com');
+VALUES (1, null, '아이유', 'image1.com'),
+       (2, null, '윤종신', 'image1.com'),
+       (3, 1, '윈터', 'image1.com');
 
--- 주최자1의 대관 대기 중 생일 카페
+-- 생일 카페
 INSERT INTO birthday_cafe
-    (id, host_id, artist_id, cafe_id, cafe_owner_id, start_date, end_date, minimum_visitant, maximum_visitant, twitter_account, host_phone_number, progress_state, visibility, congestion_state, special_goods_stock_state)
-VALUES (1, 1, 1, 1, 3, '2024-02-08T00:00:00', '2024-02-10T00:00:00', 5, 10, '@ChaseM', '010-0000-0000', 'RENTAL_PENDING', 'PRIVATE', 'SMOOTH', 'ABUNDANT');
+(id, name, host_id, artist_id, cafe_id, cafe_owner_id, start_date, end_date, minimum_visitant, maximum_visitant,
+ twitter_account, host_phone_number, progress_state, visibility, congestion_state, special_goods_stock_state)
+VALUES (1, null, 1, 1, 1, 3, '2024-02-08T00:00:00', '2024-02-10T00:00:00', 5, 10, '@ChaseM', '010-0000-0000',
+        'RENTAL_PENDING', 'PRIVATE', 'SMOOTH', 'ABUNDANT'), -- 주최자1의 대관 대기 카페
+       (2, '윈터의 생일 카페', 1, 3, 1, 3, '2024-02-08T00:00:00', '2024-02-10T00:00:00', 5, 10, '@ChaseM', '010-0000-0000', 'IN_PROGRESS',
+        'PRIVATE', 'SMOOTH', 'ABUNDANT'), -- 주최자1의 진행 중 카페
+       (3, null, 2, 1, 1, 3, '2024-02-08T00:00:00', '2024-02-10T00:00:00', 5, 10, '@ChaseM', '010-0000-0000', 'IN_PROGRESS',
+        'PRIVATE', 'SMOOTH', 'ABUNDANT'); -- 주최자 2의 진행 중 카페
 
--- 주최자1의 진행 중인 생일 카페
-INSERT INTO birthday_cafe
-(id, host_id, artist_id, cafe_id, cafe_owner_id, start_date, end_date, minimum_visitant, maximum_visitant, twitter_account, host_phone_number, progress_state, visibility, congestion_state, special_goods_stock_state)
-VALUES (2, 1, 1, 1, 3, '2024-02-08T00:00:00', '2024-02-10T00:00:00', 5, 10, '@ChaseM', '010-0000-0000', 'IN_PROGRESS', 'PRIVATE', 'SMOOTH', 'ABUNDANT');
 
+-- 주최자1의 진행 중 생일 카페 특전, 메뉴, 럭키 드로우
 INSERT INTO special_goods
-(birthday_cafe_id, name, details)
-VALUES (2, '특전', '포토카드'), (2, '디저트', '포토카드, ID 카드');
+    (birthday_cafe_id, name, details)
+VALUES (2, '특전', '포토카드'),
+       (2, '디저트', '포토카드, ID 카드');
 
 INSERT INTO menu
-(birthday_cafe_id, name, details, price)
-VALUES (2, '기본', '아메리카노+포토카드+ID카드', 6000), (2, '디저트', '케이크+포토카드+ID카드', 10000);
+    (birthday_cafe_id, name, details, price)
+VALUES (2, '기본', '아메리카노+포토카드+ID카드', 6000),
+       (2, '디저트', '케이크+포토카드+ID카드', 10000);
 
 INSERT INTO lucky_draw
-(birthday_cafe_id, ranks, prize)
-VALUES (2, 1, '티셔츠'), (2, 2, '머그컵');
+    (birthday_cafe_id, ranks, prize)
+VALUES (2, 1, '티셔츠'),
+       (2, 2, '머그컵');
 
---- 주최자2의 진행 중인 생일 카페
-INSERT INTO birthday_cafe
-(id, host_id, artist_id, cafe_id, cafe_owner_id, start_date, end_date, minimum_visitant, maximum_visitant, twitter_account, host_phone_number, progress_state, visibility, congestion_state, special_goods_stock_state)
-VALUES (3, 2, 1, 1, 3, '2024-02-08T00:00:00', '2024-02-10T00:00:00', 5, 10, '@ChaseM', '010-0000-0000', 'IN_PROGRESS', 'PRIVATE', 'SMOOTH', 'ABUNDANT');
+-- 주최자1의 진행 중 생일 카페 이미지
+INSERT INTO birthday_cafe_image (id, birthday_cafe_id, image_url, is_main)
+VALUES (1, 2, 'winter-cafe-main-image.com', true),
+       (2, 2, 'winter-cafe-default-image', false);
 
-SET foreign_key_checks = 1;
+SET
+foreign_key_checks = 1;

--- a/src/test/resources/fixture/birthday-cafe-fixture.sql
+++ b/src/test/resources/fixture/birthday-cafe-fixture.sql
@@ -1,10 +1,10 @@
 SET foreign_key_checks = 0;
 
--- 주최자
+-- 주최자1
 INSERT INTO member (id, nickname, email, social_id, social_provider, member_role)
 VALUES (1, '더즈', 'ldk@gmail.com', '231323', 'kakao', 'HOST');
 
--- 그냥 회원
+-- 주최자2
 INSERT INTO member (id, nickname, email, social_id, social_provider, member_role)
 VALUES (2, '민혁', 'cm@gmail.com', '341234', 'kakao', 'HOST');
 
@@ -28,12 +28,12 @@ VALUES (2, 4, 2, '스타벅스');
 INSERT INTO artist (id, group_id, name, image_url)
 VALUES (1, null, '아이유', 'image1.com');
 
--- 대관 대기 중 생일 카페
+-- 주최자1의 대관 대기 중 생일 카페
 INSERT INTO birthday_cafe
     (id, host_id, artist_id, cafe_id, cafe_owner_id, start_date, end_date, minimum_visitant, maximum_visitant, twitter_account, host_phone_number, progress_state, visibility, congestion_state, special_goods_stock_state)
 VALUES (1, 1, 1, 1, 3, '2024-02-08T00:00:00', '2024-02-10T00:00:00', 5, 10, '@ChaseM', '010-0000-0000', 'RENTAL_PENDING', 'PRIVATE', 'SMOOTH', 'ABUNDANT');
 
--- 진행 중인 생일 카페
+-- 주최자1의 진행 중인 생일 카페
 INSERT INTO birthday_cafe
 (id, host_id, artist_id, cafe_id, cafe_owner_id, start_date, end_date, minimum_visitant, maximum_visitant, twitter_account, host_phone_number, progress_state, visibility, congestion_state, special_goods_stock_state)
 VALUES (2, 1, 1, 1, 3, '2024-02-08T00:00:00', '2024-02-10T00:00:00', 5, 10, '@ChaseM', '010-0000-0000', 'IN_PROGRESS', 'PRIVATE', 'SMOOTH', 'ABUNDANT');
@@ -49,5 +49,10 @@ VALUES (2, '기본', '아메리카노+포토카드+ID카드', 6000), (2, '디저
 INSERT INTO lucky_draw
 (birthday_cafe_id, ranks, prize)
 VALUES (2, 1, '티셔츠'), (2, 2, '머그컵');
+
+--- 주최자2의 진행 중인 생일 카페
+INSERT INTO birthday_cafe
+(id, host_id, artist_id, cafe_id, cafe_owner_id, start_date, end_date, minimum_visitant, maximum_visitant, twitter_account, host_phone_number, progress_state, visibility, congestion_state, special_goods_stock_state)
+VALUES (3, 2, 1, 1, 3, '2024-02-08T00:00:00', '2024-02-10T00:00:00', 5, 10, '@ChaseM', '010-0000-0000', 'IN_PROGRESS', 'PRIVATE', 'SMOOTH', 'ABUNDANT');
 
 SET foreign_key_checks = 1;

--- a/src/test/resources/fixture/birthday-cafe-fixture.sql
+++ b/src/test/resources/fixture/birthday-cafe-fixture.sql
@@ -55,8 +55,9 @@ VALUES (2, 1, '티셔츠'),
 
 -- 주최자1의 진행 중 생일 카페 이미지
 INSERT INTO birthday_cafe_image (id, birthday_cafe_id, image_url, is_main)
-VALUES (1, 2, 'winter-cafe-main-image.com', true),
-       (2, 2, 'winter-cafe-default-image', false);
+VALUES (1, 2, 'winter-cafe-default-image', false),
+       (2, 2, 'winter-cafe-main-image.com', true),
+       (3, 2, 'winter-cafe-default-image', false);
 
 SET
 foreign_key_checks = 1;


### PR DESCRIPTION
## 🌍 이슈 번호
- closed #69 

## 📝 구현 내용
- 주최자의 나의 생일 카페 목록 조회 기능 구현

## 🍀 확인해야 할 부분
- 생일 카페가 기본적으로 연관된 객체를 간접 참조로 가져오고 있기 때문에 조회 시 필요한 연관관계를 가져올 수 있도록 객체를 하나 만들었습니다.
  - 다른 생일 카페 관련 조회에서도 아래 클래스를 사용해 필요한 값을 추출해 사용하면 될 것 같은데 어떨까요?
``` java
public record BirthdayCafeView(
        BirthdayCafe birthdayCafe,
        BirthdayCafeImage mainImage,
        Artist artist,
        ArtistGroup artistGroup
) {
}
```
- 예전에 github action build 과정에서 시간 비교 테스트 관련 에러가 났던 적이 있어서 cd-dev 스크립트에 타임존 설정을 추가해 두었습니다.
  - 다른 프로젝트에서 해당 설정을 넣으니 에러가 해결되었었습니다.
 
++ 각 클래스와 메서드 이름이 적절한지 확인해주면 좋을 것 같아요. 지금은 '주최자의 생일카페 목록' 조회지만 나중에 '방문자의 생일카페 목록 조회'도 추가해야 해요. 각 기능에서 가독성 좋은 이름을 어떻게 지으면 좋을지 고민입니다.