### PR TITLE
[FEAT] 생일 카페 이미지 삭제

### DIFF
--- a/src/docs/asciidoc/api.adoc
+++ b/src/docs/asciidoc/api.adoc
@@ -84,6 +84,8 @@ operation::upload-birthday-cafe-default-image[snippets='http-request,http-respon
 operation::upload-birthday-cafe-main-image[snippets='http-request,http-response']
 === 생일 카페 이미지 업로드
 operation::upload-birthday-cafe-default-image[snippets='http-request,http-response']
+=== 생일 카페 이미지 삭제
+operation::delete-birthday-cafe-image[snippets='http-request,request-fields,http-response']
 === 주최자의 나의 생일 카페 목록 조회
 operation::get-my-birthday-cafe-list[snippets='http-request,http-response,response-fields']
 === 에러 코드

--- a/src/main/java/com/birca/bircabackend/command/birca/application/BirthdayCafeImageFacade.java
+++ b/src/main/java/com/birca/bircabackend/command/birca/application/BirthdayCafeImageFacade.java
@@ -4,6 +4,7 @@ import com.birca.bircabackend.command.birca.domain.BirthdayCafe;
 import com.birca.bircabackend.command.birca.dto.BirthdayCafeImageDeleteRequest;
 import com.birca.bircabackend.command.birca.exception.BirthdayCafeErrorCode;
 import com.birca.bircabackend.common.EntityUtil;
+import com.birca.bircabackend.common.exception.BusinessException;
 import com.birca.bircabackend.common.upload.ImageUploader;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
@@ -35,7 +36,7 @@ public class BirthdayCafeImageFacade {
     public void delete(Long birthdayCafeId, BirthdayCafeImageDeleteRequest request) {
         entityUtil.getEntity(BirthdayCafe.class, birthdayCafeId, BirthdayCafeErrorCode.NOT_FOUND);
         String imageUrl = request.imageUrl();
+        birthdayCafeImageService.delete(imageUrl);
         imageUploader.delete(imageUrl);
-        birthdayCafeImageService.delete(birthdayCafeId, imageUrl);
     }
 }

--- a/src/main/java/com/birca/bircabackend/command/birca/application/BirthdayCafeImageFacade.java
+++ b/src/main/java/com/birca/bircabackend/command/birca/application/BirthdayCafeImageFacade.java
@@ -1,6 +1,7 @@
 package com.birca.bircabackend.command.birca.application;
 
 import com.birca.bircabackend.command.birca.domain.BirthdayCafe;
+import com.birca.bircabackend.command.birca.dto.BirthdayCafeImageDeleteRequest;
 import com.birca.bircabackend.command.birca.exception.BirthdayCafeErrorCode;
 import com.birca.bircabackend.common.EntityUtil;
 import com.birca.bircabackend.common.upload.ImageUploader;
@@ -29,5 +30,12 @@ public class BirthdayCafeImageFacade {
         String imageUrl = imageUploader.upload(mainImage);
         birthdayCafeImageService.updateMainImage(birthdayCafeId, imageUrl)
                 .ifPresent(imageUploader::delete);
+    }
+
+    public void delete(Long birthdayCafeId, BirthdayCafeImageDeleteRequest request) {
+        entityUtil.getEntity(BirthdayCafe.class, birthdayCafeId, BirthdayCafeErrorCode.NOT_FOUND);
+        String imageUrl = request.imageUrl();
+        imageUploader.delete(imageUrl);
+        birthdayCafeImageService.delete(birthdayCafeId, imageUrl);
     }
 }

--- a/src/main/java/com/birca/bircabackend/command/birca/application/BirthdayCafeImageService.java
+++ b/src/main/java/com/birca/bircabackend/command/birca/application/BirthdayCafeImageService.java
@@ -38,7 +38,7 @@ public class BirthdayCafeImageService {
         birthdayCafeImageRepository.save(mainImage);
     }
 
-    public void delete(Long birthdayCafeId, String imageUrl) {
-        birthdayCafeImageRepository.deleteByBirthdayCafeIdAndImageUrl(birthdayCafeId, imageUrl);
+    public void delete(String imageUrl) {
+        birthdayCafeImageRepository.deleteByImageUrl(imageUrl);
     }
 }

--- a/src/main/java/com/birca/bircabackend/command/birca/application/BirthdayCafeImageService.java
+++ b/src/main/java/com/birca/bircabackend/command/birca/application/BirthdayCafeImageService.java
@@ -37,4 +37,8 @@ public class BirthdayCafeImageService {
         BirthdayCafeImage mainImage = BirthdayCafeImage.createMainImage(birthdayCafeId, imageUrl);
         birthdayCafeImageRepository.save(mainImage);
     }
+
+    public void delete(Long birthdayCafeId, String imageUrl) {
+        birthdayCafeImageRepository.deleteByBirthdayCafeIdAndImageUrl(birthdayCafeId, imageUrl);
+    }
 }

--- a/src/main/java/com/birca/bircabackend/command/birca/domain/BirthdayCafeImageRepository.java
+++ b/src/main/java/com/birca/bircabackend/command/birca/domain/BirthdayCafeImageRepository.java
@@ -15,4 +15,6 @@ public interface BirthdayCafeImageRepository extends Repository<BirthdayCafeImag
 
     @Query("select bci from BirthdayCafeImage bci where bci.birthdayCafeId = :birthdayCafeId and bci.isMain = true")
     Optional<BirthdayCafeImage> findMainByBirthdayCafeId(Long birthdayCafeId);
+
+    void deleteByBirthdayCafeIdAndImageUrl(Long birthdayCafeId, String imageUrl);
 }

--- a/src/main/java/com/birca/bircabackend/command/birca/domain/BirthdayCafeImageRepository.java
+++ b/src/main/java/com/birca/bircabackend/command/birca/domain/BirthdayCafeImageRepository.java
@@ -16,5 +16,5 @@ public interface BirthdayCafeImageRepository extends Repository<BirthdayCafeImag
     @Query("select bci from BirthdayCafeImage bci where bci.birthdayCafeId = :birthdayCafeId and bci.isMain = true")
     Optional<BirthdayCafeImage> findMainByBirthdayCafeId(Long birthdayCafeId);
 
-    void deleteByBirthdayCafeIdAndImageUrl(Long birthdayCafeId, String imageUrl);
+    void deleteByImageUrl(String imageUrl);
 }

--- a/src/main/java/com/birca/bircabackend/command/birca/dto/BirthdayCafeImageDeleteRequest.java
+++ b/src/main/java/com/birca/bircabackend/command/birca/dto/BirthdayCafeImageDeleteRequest.java
@@ -1,0 +1,4 @@
+package com.birca.bircabackend.command.birca.dto;
+
+public record BirthdayCafeImageDeleteRequest(String imageUrl) {
+}

--- a/src/main/java/com/birca/bircabackend/command/birca/presentation/BirthdayCafeImageController.java
+++ b/src/main/java/com/birca/bircabackend/command/birca/presentation/BirthdayCafeImageController.java
@@ -2,6 +2,7 @@ package com.birca.bircabackend.command.birca.presentation;
 
 import com.birca.bircabackend.command.auth.authorization.RequiredLogin;
 import com.birca.bircabackend.command.birca.application.BirthdayCafeImageFacade;
+import com.birca.bircabackend.command.birca.dto.BirthdayCafeImageDeleteRequest;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
@@ -17,7 +18,7 @@ public class BirthdayCafeImageController {
     @PostMapping("/v1/birthday-cafes/{birthdayCafeId}/images")
     @RequiredLogin
     public ResponseEntity<Void> uploadDefaultImage(@PathVariable Long birthdayCafeId,
-                                            @ModelAttribute MultipartFile defaultImage) {
+                                                   @ModelAttribute MultipartFile defaultImage) {
         birthdayCafeImageFacade.saveDefaultImage(birthdayCafeId, defaultImage);
         return ResponseEntity.ok().build();
     }
@@ -27,6 +28,14 @@ public class BirthdayCafeImageController {
     public ResponseEntity<Void> uploadMainImage(@PathVariable Long birthdayCafeId,
                                                 @ModelAttribute MultipartFile mainImage) {
         birthdayCafeImageFacade.updateMainImage(birthdayCafeId, mainImage);
+        return ResponseEntity.ok().build();
+    }
+
+    @DeleteMapping("/v1/birthday-cafes/{birthdayCafeId}/images")
+    @RequiredLogin
+    public ResponseEntity<Void> deleteImage(@PathVariable Long birthdayCafeId,
+                                            @RequestBody BirthdayCafeImageDeleteRequest request) {
+        birthdayCafeImageFacade.delete(birthdayCafeId, request);
         return ResponseEntity.ok().build();
     }
 }

--- a/src/main/resources/static/docs/api.html
+++ b/src/main/resources/static/docs/api.html
@@ -498,6 +498,7 @@ body.book #toc,body.book #preamble,body.book h1.sect0,body.book .sect1>h2{page-b
 <li><a href="#_생일_카페_기본_이미지_업로드">생일 카페 기본 이미지 업로드</a></li>
 <li><a href="#_생일_카페_대표_이미지_업로드">생일 카페 대표 이미지 업로드</a></li>
 <li><a href="#_생일_카페_이미지_업로드">생일 카페 이미지 업로드</a></li>
+<li><a href="#_생일_카페_이미지_삭제">생일 카페 이미지 삭제</a></li>
 <li><a href="#_주최자의_나의_생일_카페_목록_조회">주최자의 나의 생일 카페 목록 조회</a></li>
 <li><a href="#_에러_코드_5">에러 코드</a></li>
 </ul>
@@ -641,7 +642,7 @@ Content-Length: 97
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">POST /api/v1/members/role-change HTTP/1.1
 Content-Type: application/json;charset=UTF-8
-Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwiaWF0IjoxNzEwODMwMjY0LCJleHAiOjE3MTA4MzIwNjR9.yt2H8r7HLhmpoHOfsNTiAinZZywayvxGXCCHnoH6pN8
+Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwiaWF0IjoxNzEwODQ4MTA3LCJleHAiOjE3MTA4NDk5MDd9.5lWQeS4CpL_r4uiZ4Lg3jD5Mw2u0maYB8nKqFhxvzbI
 Content-Length: 21
 Host: www.api.birca.com
 
@@ -671,7 +672,7 @@ Vary: Access-Control-Request-Headers</code></pre>
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">GET /api/v1/join/check-nickname?nickname=does HTTP/1.1
 Content-Type: application/json;charset=UTF-8
-Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwiaWF0IjoxNzEwODMwMjY3LCJleHAiOjE3MTA4MzIwNjd9.rH0P-fl2kqou1J4ylHrWiTE98yTUhdV3GAQXdZFhkRM
+Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwiaWF0IjoxNzEwODQ4MTA5LCJleHAiOjE3MTA4NDk5MDl9.VRikiT-g0VaPKpV-salJXdR6J6vKYf3dLimNfBJQZZo
 Host: www.api.birca.com</code></pre>
 </div>
 </div>
@@ -745,7 +746,7 @@ Content-Length: 16
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">POST /api/v1/join/register-nickname HTTP/1.1
 Content-Type: application/json;charset=UTF-8
-Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwiaWF0IjoxNzEwODMwMjY0LCJleHAiOjE3MTA4MzIwNjR9.yt2H8r7HLhmpoHOfsNTiAinZZywayvxGXCCHnoH6pN8
+Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwiaWF0IjoxNzEwODQ4MTA3LCJleHAiOjE3MTA4NDk5MDd9.5lWQeS4CpL_r4uiZ4Lg3jD5Mw2u0maYB8nKqFhxvzbI
 Content-Length: 30
 Host: www.api.birca.com
 
@@ -833,7 +834,7 @@ Vary: Access-Control-Request-Headers</code></pre>
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">GET /api/v1/artist-groups?cursor=10&amp;size=3 HTTP/1.1
 Content-Type: application/json;charset=UTF-8
-Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwiaWF0IjoxNzEwODMwMjY3LCJleHAiOjE3MTA4MzIwNjd9.rH0P-fl2kqou1J4ylHrWiTE98yTUhdV3GAQXdZFhkRM
+Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwiaWF0IjoxNzEwODQ4MTA5LCJleHAiOjE3MTA4NDk5MDl9.VRikiT-g0VaPKpV-salJXdR6J6vKYf3dLimNfBJQZZo
 Host: www.api.birca.com</code></pre>
 </div>
 </div>
@@ -933,7 +934,7 @@ Content-Length: 250
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">GET /api/v1/artist-groups/1/artists HTTP/1.1
 Content-Type: application/json;charset=UTF-8
-Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwiaWF0IjoxNzEwODMwMjY3LCJleHAiOjE3MTA4MzIwNjd9.rH0P-fl2kqou1J4ylHrWiTE98yTUhdV3GAQXdZFhkRM
+Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwiaWF0IjoxNzEwODQ4MTA5LCJleHAiOjE3MTA4NDk5MDl9.VRikiT-g0VaPKpV-salJXdR6J6vKYf3dLimNfBJQZZo
 Host: www.api.birca.com</code></pre>
 </div>
 </div>
@@ -1046,7 +1047,7 @@ Content-Length: 565
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">GET /api/v1/artists/solo?cursor=12&amp;size=6 HTTP/1.1
 Content-Type: application/json;charset=UTF-8
-Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwiaWF0IjoxNzEwODMwMjY3LCJleHAiOjE3MTA4MzIwNjd9.rH0P-fl2kqou1J4ylHrWiTE98yTUhdV3GAQXdZFhkRM
+Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwiaWF0IjoxNzEwODQ4MTA5LCJleHAiOjE3MTA4NDk5MDl9.VRikiT-g0VaPKpV-salJXdR6J6vKYf3dLimNfBJQZZo
 Host: www.api.birca.com</code></pre>
 </div>
 </div>
@@ -1158,7 +1159,7 @@ Content-Length: 518
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">POST /api/v1/artists/favorite HTTP/1.1
 Content-Type: application/json;charset=UTF-8
-Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwiaWF0IjoxNzEwODMwMjYxLCJleHAiOjE3MTA4MzIwNjF9.Wm97ZHFzoWRClxSE6senbO0oZNrCw_qOZ4WZ3AcgJs0
+Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwiaWF0IjoxNzEwODQ4MTAxLCJleHAiOjE3MTA4NDk5MDF9.5ZxsEP0VxYP17V3H__2T-SLxZ0ouajB9DJDWO8bhVso
 Content-Length: 20
 Host: www.api.birca.com
 
@@ -1212,7 +1213,7 @@ Vary: Access-Control-Request-Headers</code></pre>
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">POST /api/v1/artists/interest HTTP/1.1
 Content-Type: application/json;charset=UTF-8
-Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwiaWF0IjoxNzEwODMwMjYxLCJleHAiOjE3MTA4MzIwNjF9.Wm97ZHFzoWRClxSE6senbO0oZNrCw_qOZ4WZ3AcgJs0
+Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwiaWF0IjoxNzEwODQ4MTAxLCJleHAiOjE3MTA4NDk5MDF9.5ZxsEP0VxYP17V3H__2T-SLxZ0ouajB9DJDWO8bhVso
 Content-Length: 68
 Host: www.api.birca.com
 
@@ -1270,7 +1271,7 @@ Vary: Access-Control-Request-Headers</code></pre>
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">GET /api/v1/artists/favorite HTTP/1.1
 Content-Type: application/json;charset=UTF-8
-Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwiaWF0IjoxNzEwODMwMjY3LCJleHAiOjE3MTA4MzIwNjd9.rH0P-fl2kqou1J4ylHrWiTE98yTUhdV3GAQXdZFhkRM
+Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwiaWF0IjoxNzEwODQ4MTA5LCJleHAiOjE3MTA4NDk5MDl9.VRikiT-g0VaPKpV-salJXdR6J6vKYf3dLimNfBJQZZo
 Host: www.api.birca.com</code></pre>
 </div>
 </div>
@@ -1337,7 +1338,7 @@ Content-Length: 81
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">GET /api/v1/artists/interest HTTP/1.1
 Content-Type: application/json;charset=UTF-8
-Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwiaWF0IjoxNzEwODMwMjY3LCJleHAiOjE3MTA4MzIwNjd9.rH0P-fl2kqou1J4ylHrWiTE98yTUhdV3GAQXdZFhkRM
+Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwiaWF0IjoxNzEwODQ4MTA5LCJleHAiOjE3MTA4NDk5MDl9.VRikiT-g0VaPKpV-salJXdR6J6vKYf3dLimNfBJQZZo
 Host: www.api.birca.com</code></pre>
 </div>
 </div>
@@ -1420,7 +1421,7 @@ Content-Length: 416
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">GET /api/v1/artists/search?name=%EB%A7%88%ED%81%AC HTTP/1.1
 Content-Type: application/json;charset=UTF-8
-Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwiaWF0IjoxNzEwODMwMjY3LCJleHAiOjE3MTA4MzIwNjd9.rH0P-fl2kqou1J4ylHrWiTE98yTUhdV3GAQXdZFhkRM
+Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwiaWF0IjoxNzEwODQ4MTA5LCJleHAiOjE3MTA4NDk5MDl9.VRikiT-g0VaPKpV-salJXdR6J6vKYf3dLimNfBJQZZo
 Host: www.api.birca.com</code></pre>
 </div>
 </div>
@@ -1485,7 +1486,7 @@ Content-Length: 225
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">POST /api/v1/cafes/license-read HTTP/1.1
 Content-Type: multipart/form-data;charset=UTF-8; boundary=6o2knFse3p53ty9dmcQvWAIx1zInP11uCfbm
-Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwiaWF0IjoxNzEwODMwMjY0LCJleHAiOjE3MTA4MzIwNjR9.yt2H8r7HLhmpoHOfsNTiAinZZywayvxGXCCHnoH6pN8
+Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwiaWF0IjoxNzEwODQ4MTA3LCJleHAiOjE3MTA4NDk5MDd9.5lWQeS4CpL_r4uiZ4Lg3jD5Mw2u0maYB8nKqFhxvzbI
 Host: www.api.birca.com
 
 --6o2knFse3p53ty9dmcQvWAIx1zInP11uCfbm
@@ -1571,7 +1572,7 @@ Content-Length: 141
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">POST /api/v1/cafes/apply HTTP/1.1
 Content-Type: multipart/form-data;charset=UTF-8; boundary=6o2knFse3p53ty9dmcQvWAIx1zInP11uCfbm
-Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwiaWF0IjoxNzEwODMwMjY0LCJleHAiOjE3MTA4MzIwNjR9.yt2H8r7HLhmpoHOfsNTiAinZZywayvxGXCCHnoH6pN8
+Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwiaWF0IjoxNzEwODQ4MTA3LCJleHAiOjE3MTA4NDk5MDd9.5lWQeS4CpL_r4uiZ4Lg3jD5Mw2u0maYB8nKqFhxvzbI
 Host: www.api.birca.com
 
 --6o2knFse3p53ty9dmcQvWAIx1zInP11uCfbm
@@ -1645,7 +1646,7 @@ Vary: Access-Control-Request-Headers</code></pre>
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">POST /api/v1/birthday-cafes HTTP/1.1
 Content-Type: application/json;charset=UTF-8
-Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwiaWF0IjoxNzEwODMwMjYyLCJleHAiOjE3MTA4MzIwNjJ9.dG_Pjft5qwIuo7RvFR9sVKzsLAyxAytAxeyeRBY8aHs
+Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwiaWF0IjoxNzEwODQ4MTA0LCJleHAiOjE3MTA4NDk5MDR9.qfvY59jRI5-obMnZ8sw_SQfysdFZlUrwjelcWyKj-jk
 Content-Length: 234
 Host: www.api.birca.com
 
@@ -1741,7 +1742,7 @@ Vary: Access-Control-Request-Headers</code></pre>
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">POST /api/v1/birthday-cafes/1/cancel HTTP/1.1
 Content-Type: application/json;charset=UTF-8
-Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwiaWF0IjoxNzEwODMwMjYyLCJleHAiOjE3MTA4MzIwNjJ9.dG_Pjft5qwIuo7RvFR9sVKzsLAyxAytAxeyeRBY8aHs
+Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwiaWF0IjoxNzEwODQ4MTA0LCJleHAiOjE3MTA4NDk5MDR9.qfvY59jRI5-obMnZ8sw_SQfysdFZlUrwjelcWyKj-jk
 Host: www.api.birca.com</code></pre>
 </div>
 </div>
@@ -1788,7 +1789,7 @@ Vary: Access-Control-Request-Headers</code></pre>
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">PATCH /api/v1/birthday-cafes/1/congestion HTTP/1.1
 Content-Type: application/json;charset=UTF-8
-Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwiaWF0IjoxNzEwODMwMjYyLCJleHAiOjE3MTA4MzIwNjJ9.dG_Pjft5qwIuo7RvFR9sVKzsLAyxAytAxeyeRBY8aHs
+Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwiaWF0IjoxNzEwODQ4MTA0LCJleHAiOjE3MTA4NDk5MDR9.qfvY59jRI5-obMnZ8sw_SQfysdFZlUrwjelcWyKj-jk
 Content-Length: 26
 Host: www.api.birca.com
 
@@ -1868,7 +1869,7 @@ Vary: Access-Control-Request-Headers</code></pre>
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">POST /api/v1/birthday-cafes/1/like HTTP/1.1
 Content-Type: application/json;charset=UTF-8
-Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwiaWF0IjoxNzEwODMwMjYyLCJleHAiOjE3MTA4MzIwNjJ9.dG_Pjft5qwIuo7RvFR9sVKzsLAyxAytAxeyeRBY8aHs
+Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwiaWF0IjoxNzEwODQ4MTA0LCJleHAiOjE3MTA4NDk5MDR9.qfvY59jRI5-obMnZ8sw_SQfysdFZlUrwjelcWyKj-jk
 Host: www.api.birca.com</code></pre>
 </div>
 </div>
@@ -1915,7 +1916,7 @@ Vary: Access-Control-Request-Headers</code></pre>
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">DELETE /api/v1/birthday-cafes/1/like HTTP/1.1
 Content-Type: application/json;charset=UTF-8
-Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwiaWF0IjoxNzEwODMwMjYyLCJleHAiOjE3MTA4MzIwNjJ9.dG_Pjft5qwIuo7RvFR9sVKzsLAyxAytAxeyeRBY8aHs
+Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwiaWF0IjoxNzEwODQ4MTA0LCJleHAiOjE3MTA4NDk5MDR9.qfvY59jRI5-obMnZ8sw_SQfysdFZlUrwjelcWyKj-jk
 Host: www.api.birca.com</code></pre>
 </div>
 </div>
@@ -1962,7 +1963,7 @@ Vary: Access-Control-Request-Headers</code></pre>
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">POST /api/v1/birthday-cafes/1/special-goods HTTP/1.1
 Content-Type: application/json;charset=UTF-8
-Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwiaWF0IjoxNzEwODMwMjYyLCJleHAiOjE3MTA4MzIwNjJ9.dG_Pjft5qwIuo7RvFR9sVKzsLAyxAytAxeyeRBY8aHs
+Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwiaWF0IjoxNzEwODQ4MTA0LCJleHAiOjE3MTA4NDk5MDR9.qfvY59jRI5-obMnZ8sw_SQfysdFZlUrwjelcWyKj-jk
 Content-Length: 147
 Host: www.api.birca.com
 
@@ -2047,7 +2048,7 @@ Vary: Access-Control-Request-Headers</code></pre>
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">POST /api/v1/birthday-cafes/1/menus HTTP/1.1
 Content-Type: application/json;charset=UTF-8
-Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwiaWF0IjoxNzEwODMwMjYyLCJleHAiOjE3MTA4MzIwNjJ9.dG_Pjft5qwIuo7RvFR9sVKzsLAyxAytAxeyeRBY8aHs
+Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwiaWF0IjoxNzEwODQ4MTA0LCJleHAiOjE3MTA4NDk5MDR9.qfvY59jRI5-obMnZ8sw_SQfysdFZlUrwjelcWyKj-jk
 Content-Length: 197
 Host: www.api.birca.com
 
@@ -2139,7 +2140,7 @@ Vary: Access-Control-Request-Headers</code></pre>
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">POST /api/v1/birthday-cafes/1/lucky-draws HTTP/1.1
 Content-Type: application/json;charset=UTF-8
-Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwiaWF0IjoxNzEwODMwMjYyLCJleHAiOjE3MTA4MzIwNjJ9.dG_Pjft5qwIuo7RvFR9sVKzsLAyxAytAxeyeRBY8aHs
+Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwiaWF0IjoxNzEwODQ4MTA0LCJleHAiOjE3MTA4NDk5MDR9.qfvY59jRI5-obMnZ8sw_SQfysdFZlUrwjelcWyKj-jk
 Content-Length: 92
 Host: www.api.birca.com
 
@@ -2224,7 +2225,7 @@ Vary: Access-Control-Request-Headers</code></pre>
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">GET /api/v1/birthday-cafes/1/special-goods HTTP/1.1
 Content-Type: application/json;charset=UTF-8
-Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwiaWF0IjoxNzEwODMwMjY3LCJleHAiOjE3MTA4MzIwNjd9.rH0P-fl2kqou1J4ylHrWiTE98yTUhdV3GAQXdZFhkRM
+Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwiaWF0IjoxNzEwODQ4MTA5LCJleHAiOjE3MTA4NDk5MDl9.VRikiT-g0VaPKpV-salJXdR6J6vKYf3dLimNfBJQZZo
 Host: www.api.birca.com</code></pre>
 </div>
 </div>
@@ -2281,7 +2282,7 @@ Content-Length: 126
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">GET /api/v1/birthday-cafes/1/menus HTTP/1.1
 Content-Type: application/json;charset=UTF-8
-Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwiaWF0IjoxNzEwODMwMjY3LCJleHAiOjE3MTA4MzIwNjd9.rH0P-fl2kqou1J4ylHrWiTE98yTUhdV3GAQXdZFhkRM
+Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwiaWF0IjoxNzEwODQ4MTA5LCJleHAiOjE3MTA4NDk5MDl9.VRikiT-g0VaPKpV-salJXdR6J6vKYf3dLimNfBJQZZo
 Host: www.api.birca.com</code></pre>
 </div>
 </div>
@@ -2340,7 +2341,7 @@ Content-Length: 196
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">GET /api/v1/birthday-cafes/1/lucky-draws HTTP/1.1
 Content-Type: application/json;charset=UTF-8
-Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwiaWF0IjoxNzEwODMwMjY3LCJleHAiOjE3MTA4MzIwNjd9.rH0P-fl2kqou1J4ylHrWiTE98yTUhdV3GAQXdZFhkRM
+Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwiaWF0IjoxNzEwODQ4MTA5LCJleHAiOjE3MTA4NDk5MDl9.VRikiT-g0VaPKpV-salJXdR6J6vKYf3dLimNfBJQZZo
 Host: www.api.birca.com</code></pre>
 </div>
 </div>
@@ -2397,7 +2398,7 @@ Content-Length: 88
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">PATCH /api/v1/birthday-cafes/1 HTTP/1.1
 Content-Type: application/json;charset=UTF-8
-Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwiaWF0IjoxNzEwODMwMjYyLCJleHAiOjE3MTA4MzIwNjJ9.dG_Pjft5qwIuo7RvFR9sVKzsLAyxAytAxeyeRBY8aHs
+Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwiaWF0IjoxNzEwODQ4MTA0LCJleHAiOjE3MTA4NDk5MDR9.qfvY59jRI5-obMnZ8sw_SQfysdFZlUrwjelcWyKj-jk
 Content-Length: 86
 Host: www.api.birca.com
 
@@ -2479,7 +2480,7 @@ Vary: Access-Control-Request-Headers</code></pre>
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">POST /api/v1/birthday-cafes/1/images HTTP/1.1
 Content-Type: multipart/form-data;charset=UTF-8; boundary=6o2knFse3p53ty9dmcQvWAIx1zInP11uCfbm
-Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwiaWF0IjoxNzEwODMwMjYyLCJleHAiOjE3MTA4MzIwNjJ9.dG_Pjft5qwIuo7RvFR9sVKzsLAyxAytAxeyeRBY8aHs
+Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwiaWF0IjoxNzEwODQ4MTA0LCJleHAiOjE3MTA4NDk5MDR9.qfvY59jRI5-obMnZ8sw_SQfysdFZlUrwjelcWyKj-jk
 Host: www.api.birca.com
 
 --6o2knFse3p53ty9dmcQvWAIx1zInP11uCfbm
@@ -2510,7 +2511,7 @@ Vary: Access-Control-Request-Headers</code></pre>
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">POST /api/v1/birthday-cafes/1/images/main HTTP/1.1
 Content-Type: multipart/form-data;charset=UTF-8; boundary=6o2knFse3p53ty9dmcQvWAIx1zInP11uCfbm
-Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwiaWF0IjoxNzEwODMwMjYyLCJleHAiOjE3MTA4MzIwNjJ9.dG_Pjft5qwIuo7RvFR9sVKzsLAyxAytAxeyeRBY8aHs
+Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwiaWF0IjoxNzEwODQ4MTA0LCJleHAiOjE3MTA4NDk5MDR9.qfvY59jRI5-obMnZ8sw_SQfysdFZlUrwjelcWyKj-jk
 Host: www.api.birca.com
 
 --6o2knFse3p53ty9dmcQvWAIx1zInP11uCfbm
@@ -2541,7 +2542,7 @@ Vary: Access-Control-Request-Headers</code></pre>
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">POST /api/v1/birthday-cafes/1/images HTTP/1.1
 Content-Type: multipart/form-data;charset=UTF-8; boundary=6o2knFse3p53ty9dmcQvWAIx1zInP11uCfbm
-Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwiaWF0IjoxNzEwODMwMjYyLCJleHAiOjE3MTA4MzIwNjJ9.dG_Pjft5qwIuo7RvFR9sVKzsLAyxAytAxeyeRBY8aHs
+Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwiaWF0IjoxNzEwODQ4MTA0LCJleHAiOjE3MTA4NDk5MDR9.qfvY59jRI5-obMnZ8sw_SQfysdFZlUrwjelcWyKj-jk
 Host: www.api.birca.com
 
 --6o2knFse3p53ty9dmcQvWAIx1zInP11uCfbm
@@ -2565,6 +2566,60 @@ Vary: Access-Control-Request-Headers</code></pre>
 </div>
 </div>
 <div class="sect2">
+<h3 id="_생일_카페_이미지_삭제"><a class="link" href="#_생일_카페_이미지_삭제">생일 카페 이미지 삭제</a></h3>
+<div class="sect3">
+<h4 id="_생일_카페_이미지_삭제_http_request"><a class="link" href="#_생일_카페_이미지_삭제_http_request">HTTP request</a></h4>
+<div class="listingblock">
+<div class="content">
+<pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">DELETE /api/v1/birthday-cafes/1/images HTTP/1.1
+Content-Type: application/json;charset=UTF-8
+Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwiaWF0IjoxNzEwODQ4MTA0LCJleHAiOjE3MTA4NDk5MDR9.qfvY59jRI5-obMnZ8sw_SQfysdFZlUrwjelcWyKj-jk
+Content-Length: 26
+Host: www.api.birca.com
+
+{
+  "imageUrl" : "image"
+}</code></pre>
+</div>
+</div>
+</div>
+<div class="sect3">
+<h4 id="_생일_카페_이미지_삭제_request_fields"><a class="link" href="#_생일_카페_이미지_삭제_request_fields">Request fields</a></h4>
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 33.3333%;">
+<col style="width: 33.3333%;">
+<col style="width: 33.3334%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">Path</th>
+<th class="tableblock halign-left valign-top">Type</th>
+<th class="tableblock halign-left valign-top">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>imageUrl</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">삭제할 생일 카페 이미지</p></td>
+</tr>
+</tbody>
+</table>
+</div>
+<div class="sect3">
+<h4 id="_생일_카페_이미지_삭제_http_response"><a class="link" href="#_생일_카페_이미지_삭제_http_response">HTTP response</a></h4>
+<div class="listingblock">
+<div class="content">
+<pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">HTTP/1.1 200 OK
+Vary: Origin
+Vary: Access-Control-Request-Method
+Vary: Access-Control-Request-Headers</code></pre>
+</div>
+</div>
+</div>
+</div>
+<div class="sect2">
 <h3 id="_주최자의_나의_생일_카페_목록_조회"><a class="link" href="#_주최자의_나의_생일_카페_목록_조회">주최자의 나의 생일 카페 목록 조회</a></h3>
 <div class="sect3">
 <h4 id="_주최자의_나의_생일_카페_목록_조회_http_request"><a class="link" href="#_주최자의_나의_생일_카페_목록_조회_http_request">HTTP request</a></h4>
@@ -2572,7 +2627,7 @@ Vary: Access-Control-Request-Headers</code></pre>
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">GET /api/v1/birthday-cafes/me HTTP/1.1
 Content-Type: application/json;charset=UTF-8
-Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwiaWF0IjoxNzEwODMwMjY3LCJleHAiOjE3MTA4MzIwNjd9.rH0P-fl2kqou1J4ylHrWiTE98yTUhdV3GAQXdZFhkRM
+Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwiaWF0IjoxNzEwODQ4MTA5LCJleHAiOjE3MTA4NDk5MDl9.VRikiT-g0VaPKpV-salJXdR6J6vKYf3dLimNfBJQZZo
 Host: www.api.birca.com</code></pre>
 </div>
 </div>
@@ -2744,7 +2799,7 @@ Content-Length: 586
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">GET /api/v1/cafes/search?name=%EC%BB%A4%ED%94%BC HTTP/1.1
 Content-Type: application/json;charset=UTF-8
-Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwiaWF0IjoxNzEwODMwMjY3LCJleHAiOjE3MTA4MzIwNjd9.rH0P-fl2kqou1J4ylHrWiTE98yTUhdV3GAQXdZFhkRM
+Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwiaWF0IjoxNzEwODQ4MTA5LCJleHAiOjE3MTA4NDk5MDl9.VRikiT-g0VaPKpV-salJXdR6J6vKYf3dLimNfBJQZZo
 Host: www.api.birca.com</code></pre>
 </div>
 </div>
@@ -2777,7 +2832,7 @@ Content-Length: 106
 <div id="footer">
 <div id="footer-text">
 Version 0.0.1-SNAPSHOT<br>
-Last updated 2024-03-19 15:37:26 +0900
+Last updated 2024-03-19 20:34:45 +0900
 </div>
 </div>
 <script src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/9.18.3/highlight.min.js"></script>

--- a/src/test/java/com/birca/bircabackend/command/birca/acceptance/BirthdayCafeImageAcceptanceTest.java
+++ b/src/test/java/com/birca/bircabackend/command/birca/acceptance/BirthdayCafeImageAcceptanceTest.java
@@ -1,5 +1,6 @@
 package com.birca.bircabackend.command.birca.acceptance;
 
+import com.birca.bircabackend.command.birca.dto.BirthdayCafeImageDeleteRequest;
 import com.birca.bircabackend.support.enviroment.AcceptanceTest;
 import io.restassured.RestAssured;
 import io.restassured.response.ExtractableResponse;
@@ -49,6 +50,24 @@ public class BirthdayCafeImageAcceptanceTest extends AcceptanceTest {
                 .header(HttpHeaders.AUTHORIZATION, bearerTokenProvider.getToken(MEMBER_ID))
                 .multiPart("birthdayCafeImage", birthdayCafeImage)
                 .post("/api/v1/birthday-cafes/{birthdayCafeId}/images/main", BIRTHDAY_CAFE_ID)
+                .then().log().all()
+                .extract();
+
+        // then
+        assertThat(response.statusCode()).isEqualTo(HttpStatus.OK.value());
+    }
+
+    @Test
+    void 생일_카페_이미지를_삭제한다() {
+        // given
+        BirthdayCafeImageDeleteRequest request = new BirthdayCafeImageDeleteRequest("image");
+
+        // when
+        ExtractableResponse<Response> response = RestAssured.given().log().all()
+                .contentType(MediaType.APPLICATION_JSON_VALUE)
+                .header(HttpHeaders.AUTHORIZATION, bearerTokenProvider.getToken(MEMBER_ID))
+                .body(request)
+                .delete("/api/v1/birthday-cafes/{birthdayCafeId}/images", BIRTHDAY_CAFE_ID)
                 .then().log().all()
                 .extract();
 

--- a/src/test/java/com/birca/bircabackend/command/birca/application/BirthdayCafeImageFacadeTest.java
+++ b/src/test/java/com/birca/bircabackend/command/birca/application/BirthdayCafeImageFacadeTest.java
@@ -126,14 +126,14 @@ class BirthdayCafeImageFacadeTest extends ServiceTest {
 
             // when
             birthdayCafeImageFacade.delete(birthdayCafeId, request);
-            Long count = em.createQuery(
-                            "select count(*) from BirthdayCafeImage bci where bci.birthdayCafeId = :birthdayCafeId", Long.class)
-                    .setParameter("birthdayCafeId", birthdayCafeId)
+            Boolean isExist = em.createQuery(
+                            "select count(*) > 0 from BirthdayCafeImage bci where bci.imageUrl = :imageUrl", Boolean.class)
+                    .setParameter("imageUrl", request.imageUrl())
                     .getSingleResult();
 
             // then
             verify(imageUploader, times(1)).delete(any());
-            assertThat(count).isEqualTo(10);
+            assertThat(isExist).isFalse();
         }
 
         @Test

--- a/src/test/java/com/birca/bircabackend/command/birca/application/BirthdayCafeImageServiceTest.java
+++ b/src/test/java/com/birca/bircabackend/command/birca/application/BirthdayCafeImageServiceTest.java
@@ -87,17 +87,16 @@ class BirthdayCafeImageServiceTest extends ServiceTest {
     @Test
     void 생일_카페_이미지를_삭제한다() {
         // given
-        Long birthdayCafeId = 1L;
         String imageUrl = "image1.com";
 
         // when
-        birthdayCafeImageService.delete(birthdayCafeId, imageUrl);
-        Long count = em.createQuery(
-                        "select count(*) from BirthdayCafeImage bci where bci.birthdayCafeId = :birthdayCafeId", Long.class)
-                .setParameter("birthdayCafeId", birthdayCafeId)
+        birthdayCafeImageService.delete(imageUrl);
+        Boolean actual = em.createQuery(
+                        "select count(*) > 0 from BirthdayCafeImage bci where bci.imageUrl = :imageUrl", Boolean.class)
+                .setParameter("imageUrl", imageUrl)
                 .getSingleResult();
 
         // then
-        assertThat(count).isEqualTo(10);
+        assertThat(actual).isFalse();
     }
 }

--- a/src/test/java/com/birca/bircabackend/command/birca/application/BirthdayCafeImageServiceTest.java
+++ b/src/test/java/com/birca/bircabackend/command/birca/application/BirthdayCafeImageServiceTest.java
@@ -83,4 +83,21 @@ class BirthdayCafeImageServiceTest extends ServiceTest {
             assertThat(actual.getImageUrl()).isEqualTo(imageUrl);
         }
     }
+
+    @Test
+    void 생일_카페_이미지를_삭제한다() {
+        // given
+        Long birthdayCafeId = 1L;
+        String imageUrl = "image1.com";
+
+        // when
+        birthdayCafeImageService.delete(birthdayCafeId, imageUrl);
+        Long count = em.createQuery(
+                        "select count(*) from BirthdayCafeImage bci where bci.birthdayCafeId = :birthdayCafeId", Long.class)
+                .setParameter("birthdayCafeId", birthdayCafeId)
+                .getSingleResult();
+
+        // then
+        assertThat(count).isEqualTo(10);
+    }
 }

--- a/src/test/java/com/birca/bircabackend/command/birca/presentation/BirthdayCafeImageControllerTest.java
+++ b/src/test/java/com/birca/bircabackend/command/birca/presentation/BirthdayCafeImageControllerTest.java
@@ -1,14 +1,19 @@
 package com.birca.bircabackend.command.birca.presentation;
 
+import com.birca.bircabackend.command.birca.dto.BirthdayCafeImageDeleteRequest;
 import com.birca.bircabackend.support.enviroment.DocumentationTest;
 import org.junit.jupiter.api.Test;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
 import org.springframework.mock.web.MockMultipartFile;
+import org.springframework.restdocs.payload.JsonFieldType;
 import org.springframework.test.web.servlet.ResultActions;
 
 import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.delete;
 import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.multipart;
+import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
+import static org.springframework.restdocs.payload.PayloadDocumentation.requestFields;
 import static org.springframework.restdocs.request.RequestDocumentation.partWithName;
 import static org.springframework.restdocs.request.RequestDocumentation.requestParts;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
@@ -61,6 +66,29 @@ class BirthdayCafeImageControllerTest extends DocumentationTest {
                         DOCUMENT_RESPONSE,
                         requestParts(
                                 partWithName("mainImage").description("생일 카페 대표 이미지")
+                        )
+                ));
+    }
+
+    @Test
+    void 생일_카페_이미지를_삭제한다() throws Exception {
+        // given
+        Long birthdayCafeId = 1L;
+        BirthdayCafeImageDeleteRequest request = new BirthdayCafeImageDeleteRequest("image");
+
+        // when
+        ResultActions result = mockMvc.perform(delete("/api/v1/birthday-cafes/{birthdayCafeId}/images", birthdayCafeId)
+                .contentType(MediaType.APPLICATION_JSON)
+                .header(HttpHeaders.AUTHORIZATION, bearerTokenProvider.getToken(MEMBER_ID))
+                .content(objectMapper.writeValueAsString(request)));
+
+        // then
+        result.andExpect((status().isOk()))
+                .andDo(document("delete-birthday-cafe-image",
+                        HOST_INFO,
+                        DOCUMENT_RESPONSE,
+                        requestFields(
+                                fieldWithPath("imageUrl").type(JsonFieldType.STRING).description("삭제할 생일 카페 이미지")
                         )
                 ));
     }


### PR DESCRIPTION
## 🌍 이슈 번호
* closed #73 

## 📝 구현 내용
* 생일 카페 이미지 삭제

## 🍀 확인해야 할 부분
현재 생일 카페 이미지 url에 공통적으로 ```images```가 들어갑니다. 다중 이미지 처리 -> 단건 이미지 처리로 바뀌었는데, ```image```로 변경하는 게 더 적절할까요? 아니면 굳이 변경할 필요가 없을까요?