### PR TITLE
[FEAT] 방문자의 생일 카페 목록 조회 구현

### DIFF
--- a/src/docs/asciidoc/api.adoc
+++ b/src/docs/asciidoc/api.adoc
@@ -86,6 +86,8 @@ operation::delete-birthday-cafe-image[snippets='http-request,request-fields,http
 operation::get-my-birthday-cafe-list[snippets='http-request,http-response,response-fields']
 === 찜한 생일 카페 목록 조회
 operation::get-birthday-cafe-likes[snippets='http-request,http-response,response-fields']
+=== 방문자의 생일 카페 목록 조회
+operation::get-birthday-cafe-list[snippets='http-request,query-parameters,http-response,response-fields']
 === 에러 코드
 include::{snippets}/birthday-cafe-error-Code/response-body.adoc[]
 

--- a/src/main/java/com/birca/bircabackend/command/birca/domain/BirthdayCafe.java
+++ b/src/main/java/com/birca/bircabackend/command/birca/domain/BirthdayCafe.java
@@ -12,6 +12,7 @@ import java.util.List;
 import static com.birca.bircabackend.command.birca.exception.BirthdayCafeErrorCode.*;
 
 @Entity
+@Table(indexes = @Index(name = "idx_start_date", columnList = "startDate"))
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
 @Builder(access = AccessLevel.PRIVATE)

--- a/src/main/java/com/birca/bircabackend/query/controller/BirthdayCafeQueryController.java
+++ b/src/main/java/com/birca/bircabackend/query/controller/BirthdayCafeQueryController.java
@@ -44,7 +44,8 @@ public class BirthdayCafeQueryController {
     @GetMapping("/v1/birthday-cafes")
     @RequiredLogin
     public ResponseEntity<List<BirthdayCafeResponse>> findBirthdayCafes(@ModelAttribute BirthdayCafeParams birthdayCafeParams,
-                                                                        @ModelAttribute PagingParams pagingParams) {
-        return ResponseEntity.ok(birthdayCafeQueryService.findBirthdayCafes(birthdayCafeParams, pagingParams));
+                                                                        @ModelAttribute PagingParams pagingParams,
+                                                                        LoginMember loginMember) {
+        return ResponseEntity.ok(birthdayCafeQueryService.findBirthdayCafes(birthdayCafeParams, pagingParams, loginMember));
     }
 }

--- a/src/main/java/com/birca/bircabackend/query/controller/BirthdayCafeQueryController.java
+++ b/src/main/java/com/birca/bircabackend/query/controller/BirthdayCafeQueryController.java
@@ -2,17 +2,11 @@ package com.birca.bircabackend.query.controller;
 
 import com.birca.bircabackend.command.auth.authorization.LoginMember;
 import com.birca.bircabackend.command.auth.authorization.RequiredLogin;
-import com.birca.bircabackend.query.dto.LuckyDrawResponse;
-import com.birca.bircabackend.query.dto.MenuResponse;
-import com.birca.bircabackend.query.dto.MyBirthdayCafeResponse;
-import com.birca.bircabackend.query.dto.SpecialGoodsResponse;
+import com.birca.bircabackend.query.dto.*;
 import com.birca.bircabackend.query.service.BirthdayCafeQueryService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
 
@@ -45,5 +39,12 @@ public class BirthdayCafeQueryController {
     @RequiredLogin
     public ResponseEntity<List<MyBirthdayCafeResponse>> findMyBirthdayCafes(LoginMember loginMember) {
         return ResponseEntity.ok(birthdayCafeQueryService.findMyBirthdayCafes(loginMember));
+    }
+
+    @GetMapping("/v1/birthday-cafes")
+    @RequiredLogin
+    public ResponseEntity<List<BirthdayCafeResponse>> findBirthdayCafes(@ModelAttribute BirthdayCafeParams birthdayCafeParams,
+                                                                        @ModelAttribute PagingParams pagingParams) {
+        return ResponseEntity.ok(birthdayCafeQueryService.findBirthdayCafes(birthdayCafeParams, pagingParams));
     }
 }

--- a/src/main/java/com/birca/bircabackend/query/dto/BirthdayCafeParams.java
+++ b/src/main/java/com/birca/bircabackend/query/dto/BirthdayCafeParams.java
@@ -9,11 +9,9 @@ import lombok.Setter;
 @NoArgsConstructor
 @Setter
 @EqualsAndHashCode
-public class PagingParams {
+public class BirthdayCafeParams {
 
-    private static Long DEFAULT_CURSOR = 0L;
-    private static Integer DEFAULT_SIZE = 6;
-
-    private Long cursor = DEFAULT_CURSOR;
-    private Integer size = DEFAULT_SIZE;
+    private String progressState;
+    private Long artistId;
+    private Long cafeId;
 }

--- a/src/main/java/com/birca/bircabackend/query/dto/BirthdayCafeResponse.java
+++ b/src/main/java/com/birca/bircabackend/query/dto/BirthdayCafeResponse.java
@@ -1,0 +1,20 @@
+package com.birca.bircabackend.query.dto;
+
+import java.time.LocalDateTime;
+
+public record BirthdayCafeResponse(
+        Long birthdayCafeId,
+        String mainImageUrl,
+        LocalDateTime startDate,
+        LocalDateTime endDate,
+        String birthdayCafeName,
+        Boolean isLiked,
+        ArtistResponse artist
+) {
+
+    public record ArtistResponse(
+            String groupName,
+            String name
+    ) {
+    }
+}

--- a/src/main/java/com/birca/bircabackend/query/dto/BirthdayCafeResponse.java
+++ b/src/main/java/com/birca/bircabackend/query/dto/BirthdayCafeResponse.java
@@ -1,5 +1,12 @@
 package com.birca.bircabackend.query.dto;
 
+import com.birca.bircabackend.command.artist.domain.Artist;
+import com.birca.bircabackend.command.artist.domain.ArtistGroup;
+import com.birca.bircabackend.command.birca.domain.BirthdayCafe;
+import com.birca.bircabackend.command.birca.domain.BirthdayCafeImage;
+import com.birca.bircabackend.command.like.domain.Like;
+import com.birca.bircabackend.query.repository.model.BirthdayCafeView;
+
 import java.time.LocalDateTime;
 
 public record BirthdayCafeResponse(
@@ -11,6 +18,28 @@ public record BirthdayCafeResponse(
         Boolean isLiked,
         ArtistResponse artist
 ) {
+
+
+    public static BirthdayCafeResponse from(BirthdayCafeView birthdayCafeView) {
+        BirthdayCafe birthdayCafe = birthdayCafeView.birthdayCafe();
+        BirthdayCafeImage mainImage = birthdayCafeView.mainImage();
+        ArtistGroup artistGroup = birthdayCafeView.artistGroup();
+        Artist artist = birthdayCafeView.artist();
+        Like like = birthdayCafeView.like();
+        return new BirthdayCafeResponse(
+                birthdayCafe.getId(),
+                mainImage == null ? null : mainImage.getImageUrl(),
+                birthdayCafe.getSchedule().getStartDate(),
+                birthdayCafe.getSchedule().getEndDate(),
+                birthdayCafe.getName(),
+                like != null,
+                new ArtistResponse(
+                        artistGroup == null ? null : artistGroup.getName(),
+                        artist.getName()
+                )
+
+        );
+    }
 
     public record ArtistResponse(
             String groupName,

--- a/src/main/java/com/birca/bircabackend/query/repository/BirthdayCafeDynamicRepository.java
+++ b/src/main/java/com/birca/bircabackend/query/repository/BirthdayCafeDynamicRepository.java
@@ -8,5 +8,7 @@ import java.util.List;
 
 public interface BirthdayCafeDynamicRepository {
 
-    List<BirthdayCafeView> findByParams(BirthdayCafeParams birthdayCafeParams, PagingParams pagingParams);
+    List<BirthdayCafeView> findByBirthdayCafes(Long visitantId,
+                                               BirthdayCafeParams birthdayCafeParams,
+                                               PagingParams pagingParams);
 }

--- a/src/main/java/com/birca/bircabackend/query/repository/BirthdayCafeDynamicRepository.java
+++ b/src/main/java/com/birca/bircabackend/query/repository/BirthdayCafeDynamicRepository.java
@@ -1,0 +1,12 @@
+package com.birca.bircabackend.query.repository;
+
+import com.birca.bircabackend.query.dto.BirthdayCafeParams;
+import com.birca.bircabackend.query.dto.PagingParams;
+import com.birca.bircabackend.query.repository.model.BirthdayCafeView;
+
+import java.util.List;
+
+public interface BirthdayCafeDynamicRepository {
+
+    List<BirthdayCafeView> findByParams(BirthdayCafeParams birthdayCafeParams, PagingParams pagingParams);
+}

--- a/src/main/java/com/birca/bircabackend/query/repository/BirthdayCafeDynamicRepositoryImpl.java
+++ b/src/main/java/com/birca/bircabackend/query/repository/BirthdayCafeDynamicRepositoryImpl.java
@@ -51,6 +51,7 @@ public class BirthdayCafeDynamicRepositoryImpl implements BirthdayCafeDynamicRep
                 .where(birthdayCafe.visibility.eq(Visibility.PUBLIC))
                 .where(DynamicBooleanBuilder.builder()
                         .and(() -> birthdayCafe.progressState.eq(ProgressState.valueOf(birthdayCafeParams.getProgressState())))
+                        .and(() -> birthdayCafe.artistId.eq(birthdayCafeParams.getArtistId()))
                         .build()
                 )
                 .fetch();

--- a/src/main/java/com/birca/bircabackend/query/repository/BirthdayCafeDynamicRepositoryImpl.java
+++ b/src/main/java/com/birca/bircabackend/query/repository/BirthdayCafeDynamicRepositoryImpl.java
@@ -1,23 +1,53 @@
 package com.birca.bircabackend.query.repository;
 
+import com.birca.bircabackend.command.birca.domain.value.Visibility;
+import com.birca.bircabackend.command.like.domain.LikeTargetType;
 import com.birca.bircabackend.query.dto.BirthdayCafeParams;
 import com.birca.bircabackend.query.dto.PagingParams;
 import com.birca.bircabackend.query.repository.model.BirthdayCafeView;
+import com.querydsl.core.types.Projections;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
 
+import static com.birca.bircabackend.command.artist.domain.QArtist.artist;
+import static com.birca.bircabackend.command.artist.domain.QArtistGroup.artistGroup;
+import static com.birca.bircabackend.command.birca.domain.QBirthdayCafe.birthdayCafe;
+import static com.birca.bircabackend.command.birca.domain.QBirthdayCafeImage.birthdayCafeImage;
+import static com.birca.bircabackend.command.like.domain.QLike.like;
+
 @Repository
 @RequiredArgsConstructor
 public class BirthdayCafeDynamicRepositoryImpl implements BirthdayCafeDynamicRepository {
 
+
     private final JPAQueryFactory queryFactory;
 
     @Override
-    public List<BirthdayCafeView> findByParams(BirthdayCafeParams birthdayCafeParams,
-                                               PagingParams pagingParams) {
-        return null;
+    public List<BirthdayCafeView> findByBirthdayCafes(Long visitantId,
+                                                      BirthdayCafeParams birthdayCafeParams,
+                                                      PagingParams pagingParams) {
+        return queryFactory.select(Projections.constructor(BirthdayCafeView.class,
+                        birthdayCafe, birthdayCafeImage, artist, artistGroup, like))
+                .from(birthdayCafe)
+                .join(artist).on(
+                        birthdayCafe.artistId.eq(artist.id)
+                )
+                .leftJoin(artistGroup).on(
+                        artistGroup.id.eq(artist.groupId)
+                )
+                .leftJoin(birthdayCafeImage).on(
+                        birthdayCafe.id.eq(birthdayCafeImage.birthdayCafeId)
+                                .and(birthdayCafeImage.isMain.isTrue())
+                )
+                .leftJoin(like).on(
+                        birthdayCafe.id.eq(like.target.targetId)
+                                .and(like.target.targetType.eq(LikeTargetType.BIRTHDAY_CAFE))
+                                .and(like.visitantId.eq(visitantId))
+                )
+                .where(birthdayCafe.visibility.eq(Visibility.PUBLIC))
+                .fetch();
     }
 }

--- a/src/main/java/com/birca/bircabackend/query/repository/BirthdayCafeDynamicRepositoryImpl.java
+++ b/src/main/java/com/birca/bircabackend/query/repository/BirthdayCafeDynamicRepositoryImpl.java
@@ -6,6 +6,7 @@ import com.birca.bircabackend.command.like.domain.LikeTargetType;
 import com.birca.bircabackend.query.dto.BirthdayCafeParams;
 import com.birca.bircabackend.query.dto.PagingParams;
 import com.birca.bircabackend.query.repository.model.BirthdayCafeView;
+import com.querydsl.core.BooleanBuilder;
 import com.querydsl.core.types.Projections;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import lombok.RequiredArgsConstructor;
@@ -31,17 +32,11 @@ public class BirthdayCafeDynamicRepositoryImpl implements BirthdayCafeDynamicRep
     public List<BirthdayCafeView> findByBirthdayCafes(Long visitantId,
                                                       BirthdayCafeParams birthdayCafeParams,
                                                       PagingParams pagingParams) {
-        Long cursor = pagingParams.getCursor();
-        LocalDateTime cursorStartDate = findCursorStartDate(cursor);
         return queryFactory.select(Projections.constructor(BirthdayCafeView.class,
                         birthdayCafe, birthdayCafeImage, artist, artistGroup, like))
                 .from(birthdayCafe)
-                .join(artist).on(
-                        birthdayCafe.artistId.eq(artist.id)
-                )
-                .leftJoin(artistGroup).on(
-                        artistGroup.id.eq(artist.groupId)
-                )
+                .join(artist).on(birthdayCafe.artistId.eq(artist.id))
+                .leftJoin(artistGroup).on(artistGroup.id.eq(artist.groupId))
                 .leftJoin(birthdayCafeImage).on(
                         birthdayCafe.id.eq(birthdayCafeImage.birthdayCafeId)
                                 .and(birthdayCafeImage.isMain.isTrue())
@@ -52,17 +47,23 @@ public class BirthdayCafeDynamicRepositoryImpl implements BirthdayCafeDynamicRep
                                 .and(like.visitantId.eq(visitantId))
                 )
                 .where(birthdayCafe.visibility.eq(Visibility.PUBLIC))
-                .where(DynamicBooleanBuilder.builder()
-                        .and(() -> birthdayCafe.progressState.eq(ProgressState.valueOf(birthdayCafeParams.getProgressState())))
-                        .and(() -> birthdayCafe.artistId.eq(birthdayCafeParams.getArtistId()))
-                        .and(() -> birthdayCafe.cafeId.eq(birthdayCafeParams.getCafeId()))
-                        .and(() -> birthdayCafe.schedule.startDate.eq(cursorStartDate).and(birthdayCafe.id.gt(cursor))
-                                .or(birthdayCafe.schedule.startDate.gt(cursorStartDate)))
-                        .build()
-                )
+                .where(generateDynamicCondition(birthdayCafeParams, pagingParams))
                 .orderBy(birthdayCafe.schedule.startDate.asc(), birthdayCafe.id.asc())
                 .limit(pagingParams.getSize())
                 .fetch();
+    }
+
+    private BooleanBuilder generateDynamicCondition(BirthdayCafeParams birthdayCafeParams,
+                                                    PagingParams pagingParams) {
+        Long cursor = pagingParams.getCursor();
+        LocalDateTime cursorStartDate = findCursorStartDate(cursor);
+        return DynamicBooleanBuilder.builder()
+                .and(() -> birthdayCafe.progressState.eq(ProgressState.valueOf(birthdayCafeParams.getProgressState())))
+                .and(() -> birthdayCafe.artistId.eq(birthdayCafeParams.getArtistId()))
+                .and(() -> birthdayCafe.cafeId.eq(birthdayCafeParams.getCafeId()))
+                .and(() -> birthdayCafe.schedule.startDate.eq(cursorStartDate).and(birthdayCafe.id.gt(cursor))
+                        .or(birthdayCafe.schedule.startDate.gt(cursorStartDate)))
+                .build();
     }
 
     private LocalDateTime findCursorStartDate(Long cursor) {

--- a/src/main/java/com/birca/bircabackend/query/repository/BirthdayCafeDynamicRepositoryImpl.java
+++ b/src/main/java/com/birca/bircabackend/query/repository/BirthdayCafeDynamicRepositoryImpl.java
@@ -52,6 +52,7 @@ public class BirthdayCafeDynamicRepositoryImpl implements BirthdayCafeDynamicRep
                 .where(DynamicBooleanBuilder.builder()
                         .and(() -> birthdayCafe.progressState.eq(ProgressState.valueOf(birthdayCafeParams.getProgressState())))
                         .and(() -> birthdayCafe.artistId.eq(birthdayCafeParams.getArtistId()))
+                        .and(() -> birthdayCafe.cafeId.eq(birthdayCafeParams.getCafeId()))
                         .build()
                 )
                 .fetch();

--- a/src/main/java/com/birca/bircabackend/query/repository/BirthdayCafeDynamicRepositoryImpl.java
+++ b/src/main/java/com/birca/bircabackend/query/repository/BirthdayCafeDynamicRepositoryImpl.java
@@ -1,5 +1,6 @@
 package com.birca.bircabackend.query.repository;
 
+import com.birca.bircabackend.command.birca.domain.value.ProgressState;
 import com.birca.bircabackend.command.birca.domain.value.Visibility;
 import com.birca.bircabackend.command.like.domain.LikeTargetType;
 import com.birca.bircabackend.query.dto.BirthdayCafeParams;
@@ -48,6 +49,10 @@ public class BirthdayCafeDynamicRepositoryImpl implements BirthdayCafeDynamicRep
                                 .and(like.visitantId.eq(visitantId))
                 )
                 .where(birthdayCafe.visibility.eq(Visibility.PUBLIC))
+                .where(DynamicBooleanBuilder.builder()
+                        .and(() -> birthdayCafe.progressState.eq(ProgressState.valueOf(birthdayCafeParams.getProgressState())))
+                        .build()
+                )
                 .fetch();
     }
 }

--- a/src/main/java/com/birca/bircabackend/query/repository/BirthdayCafeDynamicRepositoryImpl.java
+++ b/src/main/java/com/birca/bircabackend/query/repository/BirthdayCafeDynamicRepositoryImpl.java
@@ -1,0 +1,23 @@
+package com.birca.bircabackend.query.repository;
+
+import com.birca.bircabackend.query.dto.BirthdayCafeParams;
+import com.birca.bircabackend.query.dto.PagingParams;
+import com.birca.bircabackend.query.repository.model.BirthdayCafeView;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+@Repository
+@RequiredArgsConstructor
+public class BirthdayCafeDynamicRepositoryImpl implements BirthdayCafeDynamicRepository {
+
+    private final JPAQueryFactory queryFactory;
+
+    @Override
+    public List<BirthdayCafeView> findByParams(BirthdayCafeParams birthdayCafeParams,
+                                               PagingParams pagingParams) {
+        return null;
+    }
+}

--- a/src/main/java/com/birca/bircabackend/query/repository/BirthdayCafeQueryRepository.java
+++ b/src/main/java/com/birca/bircabackend/query/repository/BirthdayCafeQueryRepository.java
@@ -11,7 +11,7 @@ import org.springframework.data.repository.query.Param;
 
 import java.util.List;
 
-public interface BirthdayCafeQueryRepository extends Repository<BirthdayCafe, Long> {
+public interface BirthdayCafeQueryRepository extends Repository<BirthdayCafe, Long>, BirthdayCafeDynamicRepository {
 
     @Query("select bc.specialGoods from BirthdayCafe bc where bc.id = :id")
     List<SpecialGoods> findSpecialGoodsById(Long id);

--- a/src/main/java/com/birca/bircabackend/query/repository/model/BirthdayCafeView.java
+++ b/src/main/java/com/birca/bircabackend/query/repository/model/BirthdayCafeView.java
@@ -4,11 +4,17 @@ import com.birca.bircabackend.command.artist.domain.Artist;
 import com.birca.bircabackend.command.artist.domain.ArtistGroup;
 import com.birca.bircabackend.command.birca.domain.BirthdayCafe;
 import com.birca.bircabackend.command.birca.domain.BirthdayCafeImage;
+import com.birca.bircabackend.command.like.domain.Like;
 
 public record BirthdayCafeView(
         BirthdayCafe birthdayCafe,
         BirthdayCafeImage mainImage,
         Artist artist,
-        ArtistGroup artistGroup
+        ArtistGroup artistGroup,
+        Like like
 ) {
+
+    public BirthdayCafeView(BirthdayCafe birthdayCafe, BirthdayCafeImage mainImage, Artist artist, ArtistGroup artistGroup) {
+        this(birthdayCafe, mainImage, artist, artistGroup, null);
+    }
 }

--- a/src/main/java/com/birca/bircabackend/query/service/BirthdayCafeQueryService.java
+++ b/src/main/java/com/birca/bircabackend/query/service/BirthdayCafeQueryService.java
@@ -46,6 +46,9 @@ public class BirthdayCafeQueryService {
 
     public List<BirthdayCafeResponse> findBirthdayCafes(BirthdayCafeParams birthdayCafeParams,
                                                         PagingParams pagingParams) {
-        return null;
+        return birthdayCafeQueryRepository.findByParams(birthdayCafeParams, pagingParams)
+                .stream()
+                .map(BirthdayCafeResponse::from)
+                .toList();
     }
 }

--- a/src/main/java/com/birca/bircabackend/query/service/BirthdayCafeQueryService.java
+++ b/src/main/java/com/birca/bircabackend/query/service/BirthdayCafeQueryService.java
@@ -1,10 +1,7 @@
 package com.birca.bircabackend.query.service;
 
 import com.birca.bircabackend.command.auth.authorization.LoginMember;
-import com.birca.bircabackend.query.dto.LuckyDrawResponse;
-import com.birca.bircabackend.query.dto.MenuResponse;
-import com.birca.bircabackend.query.dto.MyBirthdayCafeResponse;
-import com.birca.bircabackend.query.dto.SpecialGoodsResponse;
+import com.birca.bircabackend.query.dto.*;
 import com.birca.bircabackend.query.repository.BirthdayCafeQueryRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -45,5 +42,10 @@ public class BirthdayCafeQueryService {
                 .stream()
                 .map(MyBirthdayCafeResponse::from)
                 .toList();
+    }
+
+    public List<BirthdayCafeResponse> findBirthdayCafes(BirthdayCafeParams birthdayCafeParams,
+                                                        PagingParams pagingParams) {
+        return null;
     }
 }

--- a/src/main/java/com/birca/bircabackend/query/service/BirthdayCafeQueryService.java
+++ b/src/main/java/com/birca/bircabackend/query/service/BirthdayCafeQueryService.java
@@ -45,8 +45,9 @@ public class BirthdayCafeQueryService {
     }
 
     public List<BirthdayCafeResponse> findBirthdayCafes(BirthdayCafeParams birthdayCafeParams,
-                                                        PagingParams pagingParams) {
-        return birthdayCafeQueryRepository.findByParams(birthdayCafeParams, pagingParams)
+                                                        PagingParams pagingParams,
+                                                        LoginMember loginMember) {
+        return birthdayCafeQueryRepository.findByBirthdayCafes(loginMember.id(), birthdayCafeParams, pagingParams)
                 .stream()
                 .map(BirthdayCafeResponse::from)
                 .toList();

--- a/src/main/resources/db/migration/V1__init.sql
+++ b/src/main/resources/db/migration/V1__init.sql
@@ -139,6 +139,8 @@ ALTER TABLE birthday_cafe
 ALTER TABLE birthday_cafe
     ADD CONSTRAINT FK_BIRTHDAYCAFE_ON_HOST FOREIGN KEY (host_id) REFERENCES member (id);
 
+CREATE INDEX idx_start_date ON birthday_cafe (start_date);
+
 CREATE TABLE special_goods
 (
     birthday_cafe_id BIGINT       NOT NULL,

--- a/src/main/resources/static/docs/api.html
+++ b/src/main/resources/static/docs/api.html
@@ -499,6 +499,7 @@ body.book #toc,body.book #preamble,body.book h1.sect0,body.book .sect1>h2{page-b
 <li><a href="#_생일_카페_이미지_삭제">생일 카페 이미지 삭제</a></li>
 <li><a href="#_주최자의_나의_생일_카페_목록_조회">주최자의 나의 생일 카페 목록 조회</a></li>
 <li><a href="#_찜한_생일_카페_목록_조회">찜한 생일 카페 목록 조회</a></li>
+<li><a href="#_방문자의_생일_카페_목록_조회">방문자의 생일 카페 목록 조회</a></li>
 <li><a href="#_에러_코드_5">에러 코드</a></li>
 </ul>
 </li>
@@ -648,7 +649,7 @@ Content-Length: 97
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">POST /api/v1/members/role-change HTTP/1.1
 Content-Type: application/json;charset=UTF-8
-Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwiaWF0IjoxNzExMDMwNzQ4LCJleHAiOjE3MTEwMzI1NDh9.MhFQ2J4zlmyqsByxH5qW3yhpQLXIqEvmMJ6z7LlpYOg
+Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwiaWF0IjoxNzExMjgyOTAxLCJleHAiOjE3MTEyODQ3MDF9.yN549hV6gGHArayINc_ARpDbk5gyeo-SkF0bAoc7n7U
 Content-Length: 21
 Host: www.api.birca.com
 
@@ -678,7 +679,7 @@ Vary: Access-Control-Request-Headers</code></pre>
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">GET /api/v1/join/check-nickname?nickname=does HTTP/1.1
 Content-Type: application/json;charset=UTF-8
-Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwiaWF0IjoxNzExMDMwNzUwLCJleHAiOjE3MTEwMzI1NTB9.1nR0MQFnL96y3LKes3-Tytsp5Psqg2mqFKgIGEdvdfo
+Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwiaWF0IjoxNzExMjgyOTA0LCJleHAiOjE3MTEyODQ3MDR9.jXgMDgIIrrziWYhf82B-6LS-RD3Of00_YSS1KPn14TU
 Host: www.api.birca.com</code></pre>
 </div>
 </div>
@@ -752,7 +753,7 @@ Content-Length: 16
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">POST /api/v1/join/register-nickname HTTP/1.1
 Content-Type: application/json;charset=UTF-8
-Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwiaWF0IjoxNzExMDMwNzQ4LCJleHAiOjE3MTEwMzI1NDh9.MhFQ2J4zlmyqsByxH5qW3yhpQLXIqEvmMJ6z7LlpYOg
+Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwiaWF0IjoxNzExMjgyOTAxLCJleHAiOjE3MTEyODQ3MDF9.yN549hV6gGHArayINc_ARpDbk5gyeo-SkF0bAoc7n7U
 Content-Length: 30
 Host: www.api.birca.com
 
@@ -840,7 +841,7 @@ Vary: Access-Control-Request-Headers</code></pre>
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">GET /api/v1/artist-groups?cursor=10&amp;size=3 HTTP/1.1
 Content-Type: application/json;charset=UTF-8
-Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwiaWF0IjoxNzExMDMwNzUwLCJleHAiOjE3MTEwMzI1NTB9.1nR0MQFnL96y3LKes3-Tytsp5Psqg2mqFKgIGEdvdfo
+Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwiaWF0IjoxNzExMjgyOTA0LCJleHAiOjE3MTEyODQ3MDR9.jXgMDgIIrrziWYhf82B-6LS-RD3Of00_YSS1KPn14TU
 Host: www.api.birca.com</code></pre>
 </div>
 </div>
@@ -940,7 +941,7 @@ Content-Length: 250
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">GET /api/v1/artist-groups/1/artists HTTP/1.1
 Content-Type: application/json;charset=UTF-8
-Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwiaWF0IjoxNzExMDMwNzUwLCJleHAiOjE3MTEwMzI1NTB9.1nR0MQFnL96y3LKes3-Tytsp5Psqg2mqFKgIGEdvdfo
+Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwiaWF0IjoxNzExMjgyOTA0LCJleHAiOjE3MTEyODQ3MDR9.jXgMDgIIrrziWYhf82B-6LS-RD3Of00_YSS1KPn14TU
 Host: www.api.birca.com</code></pre>
 </div>
 </div>
@@ -1053,7 +1054,7 @@ Content-Length: 565
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">GET /api/v1/artists/solo?cursor=12&amp;size=6 HTTP/1.1
 Content-Type: application/json;charset=UTF-8
-Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwiaWF0IjoxNzExMDMwNzUwLCJleHAiOjE3MTEwMzI1NTB9.1nR0MQFnL96y3LKes3-Tytsp5Psqg2mqFKgIGEdvdfo
+Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwiaWF0IjoxNzExMjgyOTA0LCJleHAiOjE3MTEyODQ3MDR9.jXgMDgIIrrziWYhf82B-6LS-RD3Of00_YSS1KPn14TU
 Host: www.api.birca.com</code></pre>
 </div>
 </div>
@@ -1165,7 +1166,7 @@ Content-Length: 518
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">POST /api/v1/artists/favorite HTTP/1.1
 Content-Type: application/json;charset=UTF-8
-Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwiaWF0IjoxNzExMDMwNzQ0LCJleHAiOjE3MTEwMzI1NDR9.yt6vt5PwvZY9c22xIc_65RWnn4uMhsw6QE-nGIQybgk
+Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwiaWF0IjoxNzExMjgyODk4LCJleHAiOjE3MTEyODQ2OTh9.vdz0s_0CfewpHFJTU64ih5y0-GnUZbkRS_mt4yDuJeQ
 Content-Length: 20
 Host: www.api.birca.com
 
@@ -1219,7 +1220,7 @@ Vary: Access-Control-Request-Headers</code></pre>
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">POST /api/v1/artists/interest HTTP/1.1
 Content-Type: application/json;charset=UTF-8
-Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwiaWF0IjoxNzExMDMwNzQ0LCJleHAiOjE3MTEwMzI1NDR9.yt6vt5PwvZY9c22xIc_65RWnn4uMhsw6QE-nGIQybgk
+Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwiaWF0IjoxNzExMjgyODk4LCJleHAiOjE3MTEyODQ2OTh9.vdz0s_0CfewpHFJTU64ih5y0-GnUZbkRS_mt4yDuJeQ
 Content-Length: 68
 Host: www.api.birca.com
 
@@ -1277,7 +1278,7 @@ Vary: Access-Control-Request-Headers</code></pre>
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">GET /api/v1/artists/favorite HTTP/1.1
 Content-Type: application/json;charset=UTF-8
-Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwiaWF0IjoxNzExMDMwNzUwLCJleHAiOjE3MTEwMzI1NTB9.1nR0MQFnL96y3LKes3-Tytsp5Psqg2mqFKgIGEdvdfo
+Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwiaWF0IjoxNzExMjgyOTA0LCJleHAiOjE3MTEyODQ3MDR9.jXgMDgIIrrziWYhf82B-6LS-RD3Of00_YSS1KPn14TU
 Host: www.api.birca.com</code></pre>
 </div>
 </div>
@@ -1344,7 +1345,7 @@ Content-Length: 81
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">GET /api/v1/artists/interest HTTP/1.1
 Content-Type: application/json;charset=UTF-8
-Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwiaWF0IjoxNzExMDMwNzUwLCJleHAiOjE3MTEwMzI1NTB9.1nR0MQFnL96y3LKes3-Tytsp5Psqg2mqFKgIGEdvdfo
+Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwiaWF0IjoxNzExMjgyOTA0LCJleHAiOjE3MTEyODQ3MDR9.jXgMDgIIrrziWYhf82B-6LS-RD3Of00_YSS1KPn14TU
 Host: www.api.birca.com</code></pre>
 </div>
 </div>
@@ -1427,7 +1428,7 @@ Content-Length: 416
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">GET /api/v1/artists/search?name=%EB%A7%88%ED%81%AC HTTP/1.1
 Content-Type: application/json;charset=UTF-8
-Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwiaWF0IjoxNzExMDMwNzUwLCJleHAiOjE3MTEwMzI1NTB9.1nR0MQFnL96y3LKes3-Tytsp5Psqg2mqFKgIGEdvdfo
+Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwiaWF0IjoxNzExMjgyOTA0LCJleHAiOjE3MTEyODQ3MDR9.jXgMDgIIrrziWYhf82B-6LS-RD3Of00_YSS1KPn14TU
 Host: www.api.birca.com</code></pre>
 </div>
 </div>
@@ -1492,7 +1493,7 @@ Content-Length: 225
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">POST /api/v1/cafes/license-read HTTP/1.1
 Content-Type: multipart/form-data;charset=UTF-8; boundary=6o2knFse3p53ty9dmcQvWAIx1zInP11uCfbm
-Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwiaWF0IjoxNzExMDMwNzQ3LCJleHAiOjE3MTEwMzI1NDd9.qYrfj71uQZ9CYg0EajoHHLWWWXeSkq9S3s-opowJilY
+Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwiaWF0IjoxNzExMjgyOTAwLCJleHAiOjE3MTEyODQ3MDB9.NwWNn0PgRBWqB53moIw9DvDKPNpS8GZUiUYjvyG6Zbc
 Host: www.api.birca.com
 
 --6o2knFse3p53ty9dmcQvWAIx1zInP11uCfbm
@@ -1578,7 +1579,7 @@ Content-Length: 141
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">POST /api/v1/cafes/apply HTTP/1.1
 Content-Type: multipart/form-data;charset=UTF-8; boundary=6o2knFse3p53ty9dmcQvWAIx1zInP11uCfbm
-Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwiaWF0IjoxNzExMDMwNzQ3LCJleHAiOjE3MTEwMzI1NDd9.qYrfj71uQZ9CYg0EajoHHLWWWXeSkq9S3s-opowJilY
+Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwiaWF0IjoxNzExMjgyOTAwLCJleHAiOjE3MTEyODQ3MDB9.NwWNn0PgRBWqB53moIw9DvDKPNpS8GZUiUYjvyG6Zbc
 Host: www.api.birca.com
 
 --6o2knFse3p53ty9dmcQvWAIx1zInP11uCfbm
@@ -1652,7 +1653,7 @@ Vary: Access-Control-Request-Headers</code></pre>
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">POST /api/v1/birthday-cafes HTTP/1.1
 Content-Type: application/json;charset=UTF-8
-Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwiaWF0IjoxNzExMDMwNzQ2LCJleHAiOjE3MTEwMzI1NDZ9.hzI1-u8c4UI6RKAjs9Rhf5iR5lFH2XGTIhtLUQF0Lnw
+Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwiaWF0IjoxNzExMjgyODk5LCJleHAiOjE3MTEyODQ2OTl9.0Ljcnc25a4HCttJAkjLBowT3UAOxvPtjg21FNg-S_cU
 Content-Length: 234
 Host: www.api.birca.com
 
@@ -1748,7 +1749,7 @@ Vary: Access-Control-Request-Headers</code></pre>
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">POST /api/v1/birthday-cafes/1/cancel HTTP/1.1
 Content-Type: application/json;charset=UTF-8
-Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwiaWF0IjoxNzExMDMwNzQ2LCJleHAiOjE3MTEwMzI1NDZ9.hzI1-u8c4UI6RKAjs9Rhf5iR5lFH2XGTIhtLUQF0Lnw
+Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwiaWF0IjoxNzExMjgyODk5LCJleHAiOjE3MTEyODQ2OTl9.0Ljcnc25a4HCttJAkjLBowT3UAOxvPtjg21FNg-S_cU
 Host: www.api.birca.com</code></pre>
 </div>
 </div>
@@ -1795,7 +1796,7 @@ Vary: Access-Control-Request-Headers</code></pre>
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">PATCH /api/v1/birthday-cafes/1/congestion HTTP/1.1
 Content-Type: application/json;charset=UTF-8
-Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwiaWF0IjoxNzExMDMwNzQ2LCJleHAiOjE3MTEwMzI1NDZ9.hzI1-u8c4UI6RKAjs9Rhf5iR5lFH2XGTIhtLUQF0Lnw
+Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwiaWF0IjoxNzExMjgyODk5LCJleHAiOjE3MTEyODQ2OTl9.0Ljcnc25a4HCttJAkjLBowT3UAOxvPtjg21FNg-S_cU
 Content-Length: 26
 Host: www.api.birca.com
 
@@ -1875,7 +1876,7 @@ Vary: Access-Control-Request-Headers</code></pre>
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">POST /api/v1/birthday-cafes/1/special-goods HTTP/1.1
 Content-Type: application/json;charset=UTF-8
-Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwiaWF0IjoxNzExMDMwNzQ2LCJleHAiOjE3MTEwMzI1NDZ9.hzI1-u8c4UI6RKAjs9Rhf5iR5lFH2XGTIhtLUQF0Lnw
+Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwiaWF0IjoxNzExMjgyODk5LCJleHAiOjE3MTEyODQ2OTl9.0Ljcnc25a4HCttJAkjLBowT3UAOxvPtjg21FNg-S_cU
 Content-Length: 147
 Host: www.api.birca.com
 
@@ -1960,7 +1961,7 @@ Vary: Access-Control-Request-Headers</code></pre>
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">POST /api/v1/birthday-cafes/1/menus HTTP/1.1
 Content-Type: application/json;charset=UTF-8
-Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwiaWF0IjoxNzExMDMwNzQ2LCJleHAiOjE3MTEwMzI1NDZ9.hzI1-u8c4UI6RKAjs9Rhf5iR5lFH2XGTIhtLUQF0Lnw
+Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwiaWF0IjoxNzExMjgyODk5LCJleHAiOjE3MTEyODQ2OTl9.0Ljcnc25a4HCttJAkjLBowT3UAOxvPtjg21FNg-S_cU
 Content-Length: 197
 Host: www.api.birca.com
 
@@ -2052,7 +2053,7 @@ Vary: Access-Control-Request-Headers</code></pre>
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">POST /api/v1/birthday-cafes/1/lucky-draws HTTP/1.1
 Content-Type: application/json;charset=UTF-8
-Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwiaWF0IjoxNzExMDMwNzQ2LCJleHAiOjE3MTEwMzI1NDZ9.hzI1-u8c4UI6RKAjs9Rhf5iR5lFH2XGTIhtLUQF0Lnw
+Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwiaWF0IjoxNzExMjgyODk5LCJleHAiOjE3MTEyODQ2OTl9.0Ljcnc25a4HCttJAkjLBowT3UAOxvPtjg21FNg-S_cU
 Content-Length: 92
 Host: www.api.birca.com
 
@@ -2137,7 +2138,7 @@ Vary: Access-Control-Request-Headers</code></pre>
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">GET /api/v1/birthday-cafes/1/special-goods HTTP/1.1
 Content-Type: application/json;charset=UTF-8
-Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwiaWF0IjoxNzExMDMwNzUwLCJleHAiOjE3MTEwMzI1NTB9.1nR0MQFnL96y3LKes3-Tytsp5Psqg2mqFKgIGEdvdfo
+Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwiaWF0IjoxNzExMjgyOTA0LCJleHAiOjE3MTEyODQ3MDR9.jXgMDgIIrrziWYhf82B-6LS-RD3Of00_YSS1KPn14TU
 Host: www.api.birca.com</code></pre>
 </div>
 </div>
@@ -2194,7 +2195,7 @@ Content-Length: 126
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">GET /api/v1/birthday-cafes/1/menus HTTP/1.1
 Content-Type: application/json;charset=UTF-8
-Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwiaWF0IjoxNzExMDMwNzUwLCJleHAiOjE3MTEwMzI1NTB9.1nR0MQFnL96y3LKes3-Tytsp5Psqg2mqFKgIGEdvdfo
+Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwiaWF0IjoxNzExMjgyOTA0LCJleHAiOjE3MTEyODQ3MDR9.jXgMDgIIrrziWYhf82B-6LS-RD3Of00_YSS1KPn14TU
 Host: www.api.birca.com</code></pre>
 </div>
 </div>
@@ -2253,7 +2254,7 @@ Content-Length: 196
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">GET /api/v1/birthday-cafes/1/lucky-draws HTTP/1.1
 Content-Type: application/json;charset=UTF-8
-Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwiaWF0IjoxNzExMDMwNzUwLCJleHAiOjE3MTEwMzI1NTB9.1nR0MQFnL96y3LKes3-Tytsp5Psqg2mqFKgIGEdvdfo
+Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwiaWF0IjoxNzExMjgyOTA0LCJleHAiOjE3MTEyODQ3MDR9.jXgMDgIIrrziWYhf82B-6LS-RD3Of00_YSS1KPn14TU
 Host: www.api.birca.com</code></pre>
 </div>
 </div>
@@ -2310,7 +2311,7 @@ Content-Length: 88
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">PATCH /api/v1/birthday-cafes/1 HTTP/1.1
 Content-Type: application/json;charset=UTF-8
-Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwiaWF0IjoxNzExMDMwNzQ2LCJleHAiOjE3MTEwMzI1NDZ9.hzI1-u8c4UI6RKAjs9Rhf5iR5lFH2XGTIhtLUQF0Lnw
+Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwiaWF0IjoxNzExMjgyODk5LCJleHAiOjE3MTEyODQ2OTl9.0Ljcnc25a4HCttJAkjLBowT3UAOxvPtjg21FNg-S_cU
 Content-Length: 86
 Host: www.api.birca.com
 
@@ -2392,7 +2393,7 @@ Vary: Access-Control-Request-Headers</code></pre>
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">POST /api/v1/birthday-cafes/1/images HTTP/1.1
 Content-Type: multipart/form-data;charset=UTF-8; boundary=6o2knFse3p53ty9dmcQvWAIx1zInP11uCfbm
-Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwiaWF0IjoxNzExMDMwNzQ2LCJleHAiOjE3MTEwMzI1NDZ9.hzI1-u8c4UI6RKAjs9Rhf5iR5lFH2XGTIhtLUQF0Lnw
+Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwiaWF0IjoxNzExMjgyODk5LCJleHAiOjE3MTEyODQ2OTl9.0Ljcnc25a4HCttJAkjLBowT3UAOxvPtjg21FNg-S_cU
 Host: www.api.birca.com
 
 --6o2knFse3p53ty9dmcQvWAIx1zInP11uCfbm
@@ -2423,7 +2424,7 @@ Vary: Access-Control-Request-Headers</code></pre>
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">POST /api/v1/birthday-cafes/1/images/main HTTP/1.1
 Content-Type: multipart/form-data;charset=UTF-8; boundary=6o2knFse3p53ty9dmcQvWAIx1zInP11uCfbm
-Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwiaWF0IjoxNzExMDMwNzQ2LCJleHAiOjE3MTEwMzI1NDZ9.hzI1-u8c4UI6RKAjs9Rhf5iR5lFH2XGTIhtLUQF0Lnw
+Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwiaWF0IjoxNzExMjgyODk5LCJleHAiOjE3MTEyODQ2OTl9.0Ljcnc25a4HCttJAkjLBowT3UAOxvPtjg21FNg-S_cU
 Host: www.api.birca.com
 
 --6o2knFse3p53ty9dmcQvWAIx1zInP11uCfbm
@@ -2454,7 +2455,7 @@ Vary: Access-Control-Request-Headers</code></pre>
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">POST /api/v1/birthday-cafes/1/images HTTP/1.1
 Content-Type: multipart/form-data;charset=UTF-8; boundary=6o2knFse3p53ty9dmcQvWAIx1zInP11uCfbm
-Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwiaWF0IjoxNzExMDMwNzQ2LCJleHAiOjE3MTEwMzI1NDZ9.hzI1-u8c4UI6RKAjs9Rhf5iR5lFH2XGTIhtLUQF0Lnw
+Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwiaWF0IjoxNzExMjgyODk5LCJleHAiOjE3MTEyODQ2OTl9.0Ljcnc25a4HCttJAkjLBowT3UAOxvPtjg21FNg-S_cU
 Host: www.api.birca.com
 
 --6o2knFse3p53ty9dmcQvWAIx1zInP11uCfbm
@@ -2485,7 +2486,7 @@ Vary: Access-Control-Request-Headers</code></pre>
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">DELETE /api/v1/birthday-cafes/1/images HTTP/1.1
 Content-Type: application/json;charset=UTF-8
-Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwiaWF0IjoxNzExMDMwNzQ2LCJleHAiOjE3MTEwMzI1NDZ9.hzI1-u8c4UI6RKAjs9Rhf5iR5lFH2XGTIhtLUQF0Lnw
+Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwiaWF0IjoxNzExMjgyODk5LCJleHAiOjE3MTEyODQ2OTl9.0Ljcnc25a4HCttJAkjLBowT3UAOxvPtjg21FNg-S_cU
 Content-Length: 26
 Host: www.api.birca.com
 
@@ -2539,7 +2540,7 @@ Vary: Access-Control-Request-Headers</code></pre>
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">GET /api/v1/birthday-cafes/me HTTP/1.1
 Content-Type: application/json;charset=UTF-8
-Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwiaWF0IjoxNzExMDMwNzUwLCJleHAiOjE3MTEwMzI1NTB9.1nR0MQFnL96y3LKes3-Tytsp5Psqg2mqFKgIGEdvdfo
+Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwiaWF0IjoxNzExMjgyOTA0LCJleHAiOjE3MTEyODQ3MDR9.jXgMDgIIrrziWYhf82B-6LS-RD3Of00_YSS1KPn14TU
 Host: www.api.birca.com</code></pre>
 </div>
 </div>
@@ -2649,7 +2650,7 @@ Content-Length: 586
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">GET /api/v1/birthday-cafes/like HTTP/1.1
 Content-Type: application/json;charset=UTF-8
-Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwiaWF0IjoxNzExMDMwNzUwLCJleHAiOjE3MTEwMzI1NTB9.1nR0MQFnL96y3LKes3-Tytsp5Psqg2mqFKgIGEdvdfo
+Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwiaWF0IjoxNzExMjgyOTA0LCJleHAiOjE3MTEyODQ3MDR9.jXgMDgIIrrziWYhf82B-6LS-RD3Of00_YSS1KPn14TU
 Host: www.api.birca.com</code></pre>
 </div>
 </div>
@@ -2752,6 +2753,153 @@ Content-Length: 583
 </div>
 </div>
 <div class="sect2">
+<h3 id="_방문자의_생일_카페_목록_조회"><a class="link" href="#_방문자의_생일_카페_목록_조회">방문자의 생일 카페 목록 조회</a></h3>
+<div class="sect3">
+<h4 id="_방문자의_생일_카페_목록_조회_http_request"><a class="link" href="#_방문자의_생일_카페_목록_조회_http_request">HTTP request</a></h4>
+<div class="listingblock">
+<div class="content">
+<pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">GET /api/v1/birthday-cafes?cursor=1&amp;size=10&amp;artistId=1&amp;cafeId=1&amp;progressState=IN_PROGRESS HTTP/1.1
+Content-Type: application/json;charset=UTF-8
+Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwiaWF0IjoxNzExMjgyOTA0LCJleHAiOjE3MTEyODQ3MDR9.jXgMDgIIrrziWYhf82B-6LS-RD3Of00_YSS1KPn14TU
+Host: www.api.birca.com</code></pre>
+</div>
+</div>
+</div>
+<div class="sect3">
+<h4 id="_방문자의_생일_카페_목록_조회_query_parameters"><a class="link" href="#_방문자의_생일_카페_목록_조회_query_parameters">Query parameters</a></h4>
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 50%;">
+<col style="width: 50%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">Parameter</th>
+<th class="tableblock halign-left valign-top">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>cursor</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">이전에 쿼리된 마지막 birthdayCafeId</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>size</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">검색할 개수</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>artistId</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">생일 카페의 아티스트</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>cafeId</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">생일 카페의 카페</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>progressState</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">생일 카페 진행 상태</p></td>
+</tr>
+</tbody>
+</table>
+</div>
+<div class="sect3">
+<h4 id="_방문자의_생일_카페_목록_조회_http_response"><a class="link" href="#_방문자의_생일_카페_목록_조회_http_response">HTTP response</a></h4>
+<div class="listingblock">
+<div class="content">
+<pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">HTTP/1.1 200 OK
+Vary: Origin
+Vary: Access-Control-Request-Method
+Vary: Access-Control-Request-Headers
+Content-Type: application/json
+Content-Length: 560
+
+[ {
+  "birthdayCafeId" : 1,
+  "mainImageUrl" : "image.com",
+  "startDate" : "2024-03-18T00:00:00",
+  "endDate" : "2024-03-19T00:00:00",
+  "birthdayCafeName" : "민호의 생일 카페",
+  "isLiked" : true,
+  "artist" : {
+    "groupName" : "샤이니",
+    "name" : "민호"
+  }
+}, {
+  "birthdayCafeId" : 2,
+  "mainImageUrl" : "image.com",
+  "startDate" : "2024-03-20T00:00:00",
+  "endDate" : "2024-03-23T00:00:00",
+  "birthdayCafeName" : "아이유의 생일 카페",
+  "isLiked" : false,
+  "artist" : {
+    "groupName" : null,
+    "name" : "아이유"
+  }
+} ]</code></pre>
+</div>
+</div>
+</div>
+<div class="sect3">
+<h4 id="_방문자의_생일_카페_목록_조회_response_fields"><a class="link" href="#_방문자의_생일_카페_목록_조회_response_fields">Response fields</a></h4>
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 33.3333%;">
+<col style="width: 33.3333%;">
+<col style="width: 33.3334%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">Path</th>
+<th class="tableblock halign-left valign-top">Type</th>
+<th class="tableblock halign-left valign-top">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>[].birthdayCafeId</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Number</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">생일 카페 ID</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>[].mainImageUrl</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">생일 카페 메인 이미지 url</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>[].startDate</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">생일 카페 시작일</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>[].endDate</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">생일 카페 종료일</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>[].birthdayCafeName</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">생일 카페 이름</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>[].isLiked</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Boolean</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">찜 했는지 여부</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>[].artist.groupName</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">아티스트 그룹 이름</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>[].artist.name</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">아티스트 이름</p></td>
+</tr>
+</tbody>
+</table>
+</div>
+</div>
+<div class="sect2">
 <h3 id="_에러_코드_5"><a class="link" href="#_에러_코드_5">에러 코드</a></h3>
 <div class="listingblock">
 <div class="content">
@@ -2813,7 +2961,7 @@ Content-Length: 583
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">GET /api/v1/cafes/search?name=%EC%BB%A4%ED%94%BC HTTP/1.1
 Content-Type: application/json;charset=UTF-8
-Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwiaWF0IjoxNzExMDMwNzUwLCJleHAiOjE3MTEwMzI1NTB9.1nR0MQFnL96y3LKes3-Tytsp5Psqg2mqFKgIGEdvdfo
+Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwiaWF0IjoxNzExMjgyOTA0LCJleHAiOjE3MTEyODQ3MDR9.jXgMDgIIrrziWYhf82B-6LS-RD3Of00_YSS1KPn14TU
 Host: www.api.birca.com</code></pre>
 </div>
 </div>
@@ -2853,7 +3001,7 @@ Content-Length: 106
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">POST /api/v1/birthday-cafes/1/like HTTP/1.1
 Content-Type: application/json;charset=UTF-8
-Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwiaWF0IjoxNzExMDMwNzQ3LCJleHAiOjE3MTEwMzI1NDd9.qYrfj71uQZ9CYg0EajoHHLWWWXeSkq9S3s-opowJilY
+Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwiaWF0IjoxNzExMjgyOTAxLCJleHAiOjE3MTEyODQ3MDF9.yN549hV6gGHArayINc_ARpDbk5gyeo-SkF0bAoc7n7U
 Host: www.api.birca.com</code></pre>
 </div>
 </div>
@@ -2900,7 +3048,7 @@ Vary: Access-Control-Request-Headers</code></pre>
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">DELETE /api/v1/birthday-cafes/1/like HTTP/1.1
 Content-Type: application/json;charset=UTF-8
-Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwiaWF0IjoxNzExMDMwNzQ3LCJleHAiOjE3MTEwMzI1NDd9.qYrfj71uQZ9CYg0EajoHHLWWWXeSkq9S3s-opowJilY
+Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwiaWF0IjoxNzExMjgyOTAxLCJleHAiOjE3MTEyODQ3MDF9.yN549hV6gGHArayINc_ARpDbk5gyeo-SkF0bAoc7n7U
 Host: www.api.birca.com</code></pre>
 </div>
 </div>
@@ -2962,7 +3110,7 @@ Vary: Access-Control-Request-Headers</code></pre>
 <div id="footer">
 <div id="footer-text">
 Version 0.0.1-SNAPSHOT<br>
-Last updated 2024-03-21 23:18:46 +0900
+Last updated 2024-03-24 21:21:14 +0900
 </div>
 </div>
 <script src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/9.18.3/highlight.min.js"></script>

--- a/src/test/java/com/birca/bircabackend/command/birca/acceptance/BirthdayCafeAcceptanceTest.java
+++ b/src/test/java/com/birca/bircabackend/command/birca/acceptance/BirthdayCafeAcceptanceTest.java
@@ -22,7 +22,7 @@ public class BirthdayCafeAcceptanceTest extends AcceptanceTest {
     private static final Long HOST_1_ID = 1L;
     private static final Long HOST_2_ID = 2L;
     private static final Long RENTAL_PENDING_CAFE = 1L;
-    private static final Long IN_PROGRESS_CAFE = 2L;
+    private static final Long IN_PROGRESS_CAFE = 4L;
     private static final ApplyRentalRequest APPLY_RENTAL_REQUEST = new ApplyRentalRequest(
             1L,
             1L,

--- a/src/test/java/com/birca/bircabackend/command/birca/application/BirthdayCafeServiceTest.java
+++ b/src/test/java/com/birca/bircabackend/command/birca/application/BirthdayCafeServiceTest.java
@@ -34,7 +34,7 @@ class BirthdayCafeServiceTest extends ServiceTest {
     private static final long CAFE2_ID = 2L;
 
     private static final Long PENDING_BIRTHDAY_CAFE_ID = 1L;
-    private static final Long IN_PROGRESS_BIRTHDAY_CAFE_ID = 2L;
+    private static final Long IN_PROGRESS_BIRTHDAY_CAFE_ID = 4L;
 
     private static final ApplyRentalRequest VALID_REQUEST = new ApplyRentalRequest(
             ARTIST_ID,
@@ -230,7 +230,7 @@ class BirthdayCafeServiceTest extends ServiceTest {
     @Nested
     @DisplayName("생일 카페 상태에서")
     class ChangeStateTest {
-        private final Long inProgressCafeId = 2L;
+        private final Long inProgressCafeId = 4L;
 
         @Test
         void 특전_재고_상태를_변경한다() {

--- a/src/test/java/com/birca/bircabackend/query/acceptance/BirthdayCafeQueryAcceptanceTest.java
+++ b/src/test/java/com/birca/bircabackend/query/acceptance/BirthdayCafeQueryAcceptanceTest.java
@@ -17,7 +17,7 @@ import static org.junit.jupiter.api.Assertions.assertAll;
 public class BirthdayCafeQueryAcceptanceTest extends AcceptanceTest {
 
     private static final Long HOST_ID = 1L;
-    private static final Long BIRTHDAY_CAFE_ID = 2L;
+    private static final Long BIRTHDAY_CAFE_ID = 4L;
 
     @Test
     void 생일_카페_특전_목록을_조회한다() {
@@ -88,7 +88,7 @@ public class BirthdayCafeQueryAcceptanceTest extends AcceptanceTest {
         // then
         assertAll(
                 () -> assertThat(response.statusCode()).isEqualTo(HttpStatus.OK.value()),
-                () -> assertThat(response.jsonPath().getList(".")).hasSize(2)
+                () -> assertThat(response.jsonPath().getList(".")).hasSize(3)
         );
     }
 
@@ -106,7 +106,7 @@ public class BirthdayCafeQueryAcceptanceTest extends AcceptanceTest {
         // then
         assertAll(
                 () -> assertThat(response.statusCode()).isEqualTo(HttpStatus.OK.value()),
-                () -> assertThat(response.jsonPath().getList(".")).hasSize(2)
+                () -> assertThat(response.jsonPath().getList(".")).hasSize(5)
         );
     }
 }

--- a/src/test/java/com/birca/bircabackend/query/acceptance/BirthdayCafeQueryAcceptanceTest.java
+++ b/src/test/java/com/birca/bircabackend/query/acceptance/BirthdayCafeQueryAcceptanceTest.java
@@ -91,4 +91,22 @@ public class BirthdayCafeQueryAcceptanceTest extends AcceptanceTest {
                 () -> assertThat(response.jsonPath().getList(".")).hasSize(2)
         );
     }
+
+    @Test
+    void 방문자가_생일_카페_목록을_조회한다() {
+        // when
+        ExtractableResponse<Response> response = RestAssured.given().log().all()
+                .when()
+                .contentType(MediaType.APPLICATION_JSON_VALUE)
+                .header(HttpHeaders.AUTHORIZATION, bearerTokenProvider.getToken(HOST_ID))
+                .get("/api/v1/birthday-cafes")
+                .then().log().all()
+                .extract();
+
+        // then
+        assertAll(
+                () -> assertThat(response.statusCode()).isEqualTo(HttpStatus.OK.value()),
+                () -> assertThat(response.jsonPath().getList(".")).hasSize(2)
+        );
+    }
 }

--- a/src/test/java/com/birca/bircabackend/query/controller/BirthdayCafeQueryControllerTest.java
+++ b/src/test/java/com/birca/bircabackend/query/controller/BirthdayCafeQueryControllerTest.java
@@ -176,7 +176,7 @@ class BirthdayCafeQueryControllerTest extends DocumentationTest {
         birthdayCafeParams.setCafeId(cafeId);
         birthdayCafeParams.setArtistId(artistId);
         birthdayCafeParams.setProgressState(progressState);
-        given(birthdayCafeQueryService.findBirthdayCafes(birthdayCafeParams, pagingParams))
+        given(birthdayCafeQueryService.findBirthdayCafes(birthdayCafeParams, pagingParams, new LoginMember(1L)))
                 .willReturn(List.of(
                         new BirthdayCafeResponse(
                                 1L,

--- a/src/test/java/com/birca/bircabackend/query/controller/BirthdayCafeQueryControllerTest.java
+++ b/src/test/java/com/birca/bircabackend/query/controller/BirthdayCafeQueryControllerTest.java
@@ -163,4 +163,30 @@ class BirthdayCafeQueryControllerTest extends DocumentationTest {
                         )
                 ));
     }
+
+    @Test
+    void 방문자가_생일_카페_목록을_조회한다() throws Exception {
+        // given
+
+        // when
+        ResultActions result = mockMvc.perform(
+                get("/api/v1/birthday-cafes")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .header(HttpHeaders.AUTHORIZATION, bearerTokenProvider.getToken(MEMBER_ID)));
+
+        // then
+        result.andExpect((status().isOk()))
+                .andDo(document("get-birthday-cafe-list", HOST_INFO, DOCUMENT_RESPONSE,
+                        responseFields(
+                                fieldWithPath("[].birthdayCafeId").type(JsonFieldType.NUMBER).description("생일 카페 ID"),
+                                fieldWithPath("[].mainImageUrl").type(JsonFieldType.STRING).description("생일 카페 메인 이미지 url"),
+                                fieldWithPath("[].startDate").type(JsonFieldType.STRING).description("생일 카페 시작일"),
+                                fieldWithPath("[].endDate").type(JsonFieldType.STRING).description("생일 카페 종료일"),
+                                fieldWithPath("[].birthdayCafeName").type(JsonFieldType.STRING).description("생일 카페 이름"),
+                                fieldWithPath("[].isLiked").type(JsonFieldType.BOOLEAN).description("찜 했는지 여부"),
+                                fieldWithPath("[].artist.groupName").type(JsonFieldType.STRING).description("아티스트 그룹 이름").optional(),
+                                fieldWithPath("[].artist.name").type(JsonFieldType.STRING).description("아티스트 이름")
+                        )
+                ));
+    }
 }

--- a/src/test/java/com/birca/bircabackend/query/service/BirthdayCafeQueryServiceTest.java
+++ b/src/test/java/com/birca/bircabackend/query/service/BirthdayCafeQueryServiceTest.java
@@ -114,5 +114,22 @@ class BirthdayCafeQueryServiceTest extends ServiceTest {
                     .map(BirthdayCafeResponse::birthdayCafeId)
                     .containsExactly(3L);
         }
+
+        @Test
+        void 실시간_생일_카페만_조회한다() {
+            // given
+            birthdayCafeParams.setProgressState("IN_PROGRESS");
+
+            // when
+            List<BirthdayCafeResponse> actual = birthdayCafeQueryService.findBirthdayCafes(
+                    birthdayCafeParams, pagingParams, new LoginMember(VISITANT_ID));
+
+            // then
+            assertAll(
+                    () -> assertThat(actual)
+                            .map(BirthdayCafeResponse::birthdayCafeId)
+                            .containsExactly(4L, 6L)
+            );
+        }
     }
 }

--- a/src/test/java/com/birca/bircabackend/query/service/BirthdayCafeQueryServiceTest.java
+++ b/src/test/java/com/birca/bircabackend/query/service/BirthdayCafeQueryServiceTest.java
@@ -148,5 +148,22 @@ class BirthdayCafeQueryServiceTest extends ServiceTest {
                             .containsExactly(4L, 5L)
             );
         }
+
+        @Test
+        void 특정_카페에서_진행_되는_생일_카페만_조회한다() {
+            // given
+            birthdayCafeParams.setCafeId(1L);
+
+            // when
+            List<BirthdayCafeResponse> actual = birthdayCafeQueryService.findBirthdayCafes(
+                    birthdayCafeParams, pagingParams, new LoginMember(VISITANT_ID));
+
+            // then
+            assertAll(
+                    () -> assertThat(actual)
+                            .map(BirthdayCafeResponse::birthdayCafeId)
+                            .containsExactly(2L, 3L, 5L)
+            );
+        }
     }
 }

--- a/src/test/java/com/birca/bircabackend/query/service/BirthdayCafeQueryServiceTest.java
+++ b/src/test/java/com/birca/bircabackend/query/service/BirthdayCafeQueryServiceTest.java
@@ -118,7 +118,8 @@ class BirthdayCafeQueryServiceTest extends ServiceTest {
         @Test
         void 실시간_생일_카페만_조회한다() {
             // given
-            birthdayCafeParams.setProgressState("IN_PROGRESS");
+            String progressState = "IN_PROGRESS";
+            birthdayCafeParams.setProgressState(progressState);
 
             // when
             List<BirthdayCafeResponse> actual = birthdayCafeQueryService.findBirthdayCafes(
@@ -135,7 +136,8 @@ class BirthdayCafeQueryServiceTest extends ServiceTest {
         @Test
         void 특정_아티스트의_카페만_조회한다() {
             // given
-            birthdayCafeParams.setArtistId(3L);
+            long artistId = 3L;
+            birthdayCafeParams.setArtistId(artistId);
 
             // when
             List<BirthdayCafeResponse> actual = birthdayCafeQueryService.findBirthdayCafes(
@@ -152,7 +154,8 @@ class BirthdayCafeQueryServiceTest extends ServiceTest {
         @Test
         void 특정_카페에서_진행_되는_생일_카페만_조회한다() {
             // given
-            birthdayCafeParams.setCafeId(1L);
+            long cafeId = 1L;
+            birthdayCafeParams.setCafeId(cafeId);
 
             // when
             List<BirthdayCafeResponse> actual = birthdayCafeQueryService.findBirthdayCafes(
@@ -163,6 +166,42 @@ class BirthdayCafeQueryServiceTest extends ServiceTest {
                     () -> assertThat(actual)
                             .map(BirthdayCafeResponse::birthdayCafeId)
                             .containsExactly(2L, 3L, 5L)
+            );
+        }
+
+        @Test
+        void 지정한_개수만큼_조회한다() {
+            // given
+            int size = 3;
+            pagingParams.setSize(size);
+
+            // when
+            List<BirthdayCafeResponse> actual = birthdayCafeQueryService.findBirthdayCafes(
+                    birthdayCafeParams, pagingParams, new LoginMember(VISITANT_ID));
+
+            // then
+            assertAll(
+                    () -> assertThat(actual)
+                            .map(BirthdayCafeResponse::birthdayCafeId)
+                            .containsExactly(2L, 3L, 4L)
+            );
+        }
+
+        @Test
+        void 커서_이후로_조회한다() {
+            // given
+            long cursor = 3L;
+            pagingParams.setCursor(cursor);
+
+            // when
+            List<BirthdayCafeResponse> actual = birthdayCafeQueryService.findBirthdayCafes(
+                    birthdayCafeParams, pagingParams, new LoginMember(VISITANT_ID));
+
+            // then
+            assertAll(
+                    () -> assertThat(actual)
+                            .map(BirthdayCafeResponse::birthdayCafeId)
+                            .containsExactly(4L, 5L, 6L)
             );
         }
     }

--- a/src/test/java/com/birca/bircabackend/query/service/BirthdayCafeQueryServiceTest.java
+++ b/src/test/java/com/birca/bircabackend/query/service/BirthdayCafeQueryServiceTest.java
@@ -9,7 +9,6 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.test.context.jdbc.Sql;
 
-import java.time.LocalDateTime;
 import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -18,7 +17,7 @@ import static org.junit.jupiter.api.Assertions.assertAll;
 @Sql("/fixture/birthday-cafe-fixture.sql")
 class BirthdayCafeQueryServiceTest extends ServiceTest {
 
-    private static final Long BIRTHDAY_CAFE_ID = 2L;
+    private static final Long BIRTHDAY_CAFE_ID = 4L;
     private static final Long HOST_ID = 1L;
     private static final Long VISITANT_ID = 4L;
 
@@ -77,26 +76,8 @@ class BirthdayCafeQueryServiceTest extends ServiceTest {
             List<MyBirthdayCafeResponse> actual = birthdayCafeQueryService.findMyBirthdayCafes(loginMember);
 
             // then
-            assertThat(actual).containsExactly(
-                    new MyBirthdayCafeResponse(
-                            2L,
-                            "winter-cafe-main-image.com",
-                            LocalDateTime.of(2024, 2, 8, 0, 0, 0),
-                            LocalDateTime.of(2024, 2, 10, 0, 0, 0),
-                            "윈터의 생일 카페",
-                            "IN_PROGRESS",
-                            new MyBirthdayCafeResponse.ArtistResponse("에스파", "윈터")
-                    ),
-                    new MyBirthdayCafeResponse(
-                            1L,
-                            null,
-                            LocalDateTime.of(2024, 2, 8, 0, 0, 0),
-                            LocalDateTime.of(2024, 2, 10, 0, 0, 0),
-                            null,
-                            "RENTAL_PENDING",
-                            new MyBirthdayCafeResponse.ArtistResponse(null, "아이유")
-                    )
-            );
+            assertThat(actual).map(MyBirthdayCafeResponse::birthdayCafeId)
+                    .containsExactly(4L, 3L, 1L);
         }
     }
 
@@ -117,17 +98,7 @@ class BirthdayCafeQueryServiceTest extends ServiceTest {
             assertAll(
                     () -> assertThat(actual)
                             .map(BirthdayCafeResponse::birthdayCafeId)
-                            .containsExactly(2L, 3L),
-                    () -> assertThat(actual.get(0))
-                            .isEqualTo(new BirthdayCafeResponse(
-                                    2L,
-                                    "winter-cafe-main-image.com",
-                                    LocalDateTime.of(2024, 2, 8, 0, 0, 0),
-                                    LocalDateTime.of(2024, 2, 10, 0, 0, 0),
-                                    "윈터의 생일 카페",
-                                    false,
-                                    new BirthdayCafeResponse.ArtistResponse("에스파", "윈터")
-                            ))
+                            .containsExactly(2L, 3L, 4L, 5L, 6L)
             );
         }
 

--- a/src/test/java/com/birca/bircabackend/query/service/BirthdayCafeQueryServiceTest.java
+++ b/src/test/java/com/birca/bircabackend/query/service/BirthdayCafeQueryServiceTest.java
@@ -112,7 +112,7 @@ class BirthdayCafeQueryServiceTest extends ServiceTest {
             assertThat(actual)
                     .filteredOn(BirthdayCafeResponse::isLiked)
                     .map(BirthdayCafeResponse::birthdayCafeId)
-                    .containsExactly(3L);
+                    .containsExactly(3L, 6L);
         }
 
         @Test

--- a/src/test/java/com/birca/bircabackend/query/service/BirthdayCafeQueryServiceTest.java
+++ b/src/test/java/com/birca/bircabackend/query/service/BirthdayCafeQueryServiceTest.java
@@ -103,7 +103,7 @@ class BirthdayCafeQueryServiceTest extends ServiceTest {
         }
 
         @Test
-        void 찜한_생일_카페는_true로_표시한다() {
+        void 조회_시_찜한_생일_카페는_true로_표시한다() {
             // when
             List<BirthdayCafeResponse> actual = birthdayCafeQueryService.findBirthdayCafes(
                     birthdayCafeParams, pagingParams, new LoginMember(VISITANT_ID));
@@ -129,6 +129,23 @@ class BirthdayCafeQueryServiceTest extends ServiceTest {
                     () -> assertThat(actual)
                             .map(BirthdayCafeResponse::birthdayCafeId)
                             .containsExactly(4L, 6L)
+            );
+        }
+
+        @Test
+        void 특정_아티스트의_카페만_조회한다() {
+            // given
+            birthdayCafeParams.setArtistId(3L);
+
+            // when
+            List<BirthdayCafeResponse> actual = birthdayCafeQueryService.findBirthdayCafes(
+                    birthdayCafeParams, pagingParams, new LoginMember(VISITANT_ID));
+
+            // then
+            assertAll(
+                    () -> assertThat(actual)
+                            .map(BirthdayCafeResponse::birthdayCafeId)
+                            .containsExactly(4L, 5L)
             );
         }
     }

--- a/src/test/java/com/birca/bircabackend/query/service/BirthdayCafeQueryServiceTest.java
+++ b/src/test/java/com/birca/bircabackend/query/service/BirthdayCafeQueryServiceTest.java
@@ -1,10 +1,7 @@
 package com.birca.bircabackend.query.service;
 
 import com.birca.bircabackend.command.auth.authorization.LoginMember;
-import com.birca.bircabackend.query.dto.LuckyDrawResponse;
-import com.birca.bircabackend.query.dto.MenuResponse;
-import com.birca.bircabackend.query.dto.MyBirthdayCafeResponse;
-import com.birca.bircabackend.query.dto.SpecialGoodsResponse;
+import com.birca.bircabackend.query.dto.*;
 import com.birca.bircabackend.support.enviroment.ServiceTest;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
@@ -16,12 +13,14 @@ import java.time.LocalDateTime;
 import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertAll;
 
 @Sql("/fixture/birthday-cafe-fixture.sql")
 class BirthdayCafeQueryServiceTest extends ServiceTest {
 
     private static final Long BIRTHDAY_CAFE_ID = 2L;
     private static final Long HOST_ID = 1L;
+    private static final Long VISITANT_ID = 4L;
 
     @Autowired
     private BirthdayCafeQueryService birthdayCafeQueryService;
@@ -97,6 +96,38 @@ class BirthdayCafeQueryServiceTest extends ServiceTest {
                             "RENTAL_PENDING",
                             new MyBirthdayCafeResponse.ArtistResponse(null, "아이유")
                     )
+            );
+        }
+    }
+
+    @Nested
+    @DisplayName("방문자가 생일 카페 목록을")
+    class GetBirthdayCafesTest {
+
+        private final BirthdayCafeParams birthdayCafeParams = new BirthdayCafeParams();
+        private final PagingParams pagingParams = new PagingParams();
+
+        @Test
+        void 공개된_것만_전부_조회한다() {
+            // when
+            List<BirthdayCafeResponse> actual = birthdayCafeQueryService.findBirthdayCafes(
+                    birthdayCafeParams, pagingParams, new LoginMember(VISITANT_ID));
+
+            // then
+            assertAll(
+                    () -> assertThat(actual)
+                            .map(BirthdayCafeResponse::birthdayCafeId)
+                            .containsExactly(2L, 3L),
+                    () -> assertThat(actual.get(0))
+                            .isEqualTo(new BirthdayCafeResponse(
+                                    2L,
+                                    "winter-cafe-main-image.com",
+                                    LocalDateTime.of(2024, 2, 8, 0, 0, 0),
+                                    LocalDateTime.of(2024, 2, 10, 0, 0, 0),
+                                    "윈터의 생일 카페",
+                                    false,
+                                    new BirthdayCafeResponse.ArtistResponse("에스파", "윈터")
+                            ))
             );
         }
     }

--- a/src/test/java/com/birca/bircabackend/query/service/BirthdayCafeQueryServiceTest.java
+++ b/src/test/java/com/birca/bircabackend/query/service/BirthdayCafeQueryServiceTest.java
@@ -108,7 +108,7 @@ class BirthdayCafeQueryServiceTest extends ServiceTest {
         private final PagingParams pagingParams = new PagingParams();
 
         @Test
-        void 공개된_것만_전부_조회한다() {
+        void 공개된_것만_시작일_순으로_조회한다() {
             // when
             List<BirthdayCafeResponse> actual = birthdayCafeQueryService.findBirthdayCafes(
                     birthdayCafeParams, pagingParams, new LoginMember(VISITANT_ID));
@@ -129,6 +129,19 @@ class BirthdayCafeQueryServiceTest extends ServiceTest {
                                     new BirthdayCafeResponse.ArtistResponse("에스파", "윈터")
                             ))
             );
+        }
+
+        @Test
+        void 찜한_생일_카페는_true로_표시한다() {
+            // when
+            List<BirthdayCafeResponse> actual = birthdayCafeQueryService.findBirthdayCafes(
+                    birthdayCafeParams, pagingParams, new LoginMember(VISITANT_ID));
+
+            // then
+            assertThat(actual)
+                    .filteredOn(BirthdayCafeResponse::isLiked)
+                    .map(BirthdayCafeResponse::birthdayCafeId)
+                    .containsExactly(3L);
         }
     }
 }

--- a/src/test/resources/fixture/birthday-cafe-fixture.sql
+++ b/src/test/resources/fixture/birthday-cafe-fixture.sql
@@ -4,7 +4,9 @@ SET foreign_key_checks = 0;
 INSERT INTO member (id, nickname, email, social_id, social_provider, member_role)
 VALUES (1, '더즈', 'ldk@gmail.com', '231323', 'kakao', 'HOST'), -- 주최자1
        (2, '민혁', 'cm@gmail.com', '341234', 'kakao', 'HOST'), -- 주최자2
-       (3, '카페1 사장', 'owner@gmail.com', '23412', 'kakao', 'OWNER'); -- 사장님
+       (3, '카페1 사장', 'owner@gmail.com', '23412', 'kakao', 'OWNER'), -- 사장님
+
+       (4, '방문자', 'visitant@gmail.com', '232', 'kakao', 'VISITANT'); -- 방문자
 
 -- 사장님의 사업자 등록증
 INSERT INTO business_license(id, owner_id, owner_name, cafe_name, tax_office_code, business_type_code, serial_code,
@@ -29,11 +31,11 @@ VALUES (1, null, '아이유', 'image1.com'),
 INSERT INTO birthday_cafe
 (id, name, host_id, artist_id, cafe_id, cafe_owner_id, start_date, end_date, minimum_visitant, maximum_visitant,
  twitter_account, host_phone_number, progress_state, visibility, congestion_state, special_goods_stock_state)
-VALUES (1, null, 1, 1, 1, 3, '2024-02-08T00:00:00', '2024-02-10T00:00:00', 5, 10, '@ChaseM', '010-0000-0000',
-        'RENTAL_PENDING', 'PRIVATE', 'SMOOTH', 'ABUNDANT'), -- 주최자1의 대관 대기 카페
+VALUES (1, null, 1, 1, 1, 3, '2024-02-08T00:00:00', '2024-02-10T00:00:00', 5, 10, '@ChaseM', '010-0000-0000','RENTAL_PENDING',
+        'PRIVATE', 'SMOOTH', 'ABUNDANT'), -- 주최자1의 대관 대기 카페
        (2, '윈터의 생일 카페', 1, 3, 1, 3, '2024-02-08T00:00:00', '2024-02-10T00:00:00', 5, 10, '@ChaseM', '010-0000-0000', 'IN_PROGRESS',
         'PUBLIC', 'SMOOTH', 'ABUNDANT'), -- 주최자1의 진행 중 카페
-       (3, null, 2, 1, 1, 3, '2024-02-08T00:00:00', '2024-02-10T00:00:00', 5, 10, '@ChaseM', '010-0000-0000', 'IN_PROGRESS',
+       (3, null, 2, 1, 1, 3, '2024-02-09T00:00:00', '2024-02-10T00:00:00', 5, 10, '@ChaseM', '010-0000-0000', 'IN_PROGRESS',
         'PUBLIC', 'SMOOTH', 'ABUNDANT'); -- 주최자 2의 진행 중 카페
 
 

--- a/src/test/resources/fixture/birthday-cafe-fixture.sql
+++ b/src/test/resources/fixture/birthday-cafe-fixture.sql
@@ -32,9 +32,9 @@ INSERT INTO birthday_cafe
 VALUES (1, null, 1, 1, 1, 3, '2024-02-08T00:00:00', '2024-02-10T00:00:00', 5, 10, '@ChaseM', '010-0000-0000',
         'RENTAL_PENDING', 'PRIVATE', 'SMOOTH', 'ABUNDANT'), -- 주최자1의 대관 대기 카페
        (2, '윈터의 생일 카페', 1, 3, 1, 3, '2024-02-08T00:00:00', '2024-02-10T00:00:00', 5, 10, '@ChaseM', '010-0000-0000', 'IN_PROGRESS',
-        'PRIVATE', 'SMOOTH', 'ABUNDANT'), -- 주최자1의 진행 중 카페
+        'PUBLIC', 'SMOOTH', 'ABUNDANT'), -- 주최자1의 진행 중 카페
        (3, null, 2, 1, 1, 3, '2024-02-08T00:00:00', '2024-02-10T00:00:00', 5, 10, '@ChaseM', '010-0000-0000', 'IN_PROGRESS',
-        'PRIVATE', 'SMOOTH', 'ABUNDANT'); -- 주최자 2의 진행 중 카페
+        'PUBLIC', 'SMOOTH', 'ABUNDANT'); -- 주최자 2의 진행 중 카페
 
 
 -- 주최자1의 진행 중 생일 카페 특전, 메뉴, 럭키 드로우

--- a/src/test/resources/fixture/birthday-cafe-fixture.sql
+++ b/src/test/resources/fixture/birthday-cafe-fixture.sql
@@ -70,7 +70,8 @@ VALUES (1, 4, 'winter-cafe-default-image', false),
 
 -- 방문자(id=4)가 누른 찜
 INSERT INTO likes (visitant_id, target_id, target_type)
-VALUES (4, 3, 'BIRTHDAY_CAFE');
+VALUES (4, 3, 'BIRTHDAY_CAFE'),
+       (4, 6, 'BIRTHDAY_CAFE');
 
 SET
 foreign_key_checks = 1;

--- a/src/test/resources/fixture/birthday-cafe-fixture.sql
+++ b/src/test/resources/fixture/birthday-cafe-fixture.sql
@@ -31,35 +31,42 @@ VALUES (1, null, '아이유', 'image1.com'),
 INSERT INTO birthday_cafe
 (id, name, host_id, artist_id, cafe_id, cafe_owner_id, start_date, end_date, minimum_visitant, maximum_visitant,
  twitter_account, host_phone_number, progress_state, visibility, congestion_state, special_goods_stock_state)
-VALUES (1, null, 1, 1, 1, 3, '2024-02-08T00:00:00', '2024-02-10T00:00:00', 5, 10, '@ChaseM', '010-0000-0000','RENTAL_PENDING',
-        'PRIVATE', 'SMOOTH', 'ABUNDANT'), -- 주최자1의 대관 대기 카페
-       (2, '윈터의 생일 카페', 1, 3, 1, 3, '2024-02-08T00:00:00', '2024-02-10T00:00:00', 5, 10, '@ChaseM', '010-0000-0000', 'IN_PROGRESS',
-        'PUBLIC', 'SMOOTH', 'ABUNDANT'), -- 주최자1의 진행 중 카페
-       (3, null, 2, 1, 1, 3, '2024-02-09T00:00:00', '2024-02-10T00:00:00', 5, 10, '@ChaseM', '010-0000-0000', 'IN_PROGRESS',
-        'PUBLIC', 'SMOOTH', 'ABUNDANT'); -- 주최자 2의 진행 중 카페
+VALUES (1, null, 1, 1, 1, 3, '2024-02-08T00:00:00', '2024-02-10T00:00:00', 5, 10, '@ChaseM', '010-0000-0000',
+        'RENTAL_PENDING','PRIVATE', 'SMOOTH', 'ABUNDANT'), -- 주최자1의 대관 대기 카페, 비공개
+
+       (2, '윤종신의 생일 카페', 2, 2, 1, 3, '2024-02-08T00:00:00', '2024-02-10T00:00:00', 5, 10, '@ChaseM', '010-0000-0000',
+        'FINISHED','PUBLIC', 'SMOOTH', 'ABUNDANT'), -- 주최자1의 종료된 카페
+       (3, '아이유의 생일 카페', 1, 1, 1, 3, '2024-02-09T00:00:00', '2024-02-10T00:00:00', 5, 10, '@ChaseM', '010-0000-0000',
+        'FINISHED','PUBLIC', 'SMOOTH', 'ABUNDANT'), -- 주최자1의 종료된 카페
+       (4, '윈터의 생일 카페', 1, 3, 2, 3, '2024-02-10T00:00:00', '2024-02-11T00:00:00', 5, 10, '@ChaseM', '010-0000-0000',
+        'IN_PROGRESS','PUBLIC', 'SMOOTH', 'ABUNDANT'), -- 주최자1의 진행 중 카페
+       (5, '윈터의 생일 카페', 2, 3, 1, 3, '2024-02-11T00:00:00', '2024-02-12T00:00:00', 5, 10, '@ChaseM', '010-0000-0000',
+        'RENTAL_APPROVED','PUBLIC', 'SMOOTH', 'ABUNDANT'), -- 주최자1의 대관 승인 카페
+       (6, null, 2, 1, 2, 3, '2024-02-11T00:00:00', '2024-02-14T00:00:00', 5, 10, '@ChaseM', '010-0000-0000',
+        'IN_PROGRESS','PUBLIC', 'SMOOTH', 'ABUNDANT'); -- 주최자 2의 진행 중인 카페
 
 
 -- 주최자1의 진행 중 생일 카페 특전, 메뉴, 럭키 드로우
 INSERT INTO special_goods
     (birthday_cafe_id, name, details)
-VALUES (2, '특전', '포토카드'),
-       (2, '디저트', '포토카드, ID 카드');
+VALUES (4, '특전', '포토카드'),
+       (4, '디저트', '포토카드, ID 카드');
 
 INSERT INTO menu
     (birthday_cafe_id, name, details, price)
-VALUES (2, '기본', '아메리카노+포토카드+ID카드', 6000),
-       (2, '디저트', '케이크+포토카드+ID카드', 10000);
+VALUES (4, '기본', '아메리카노+포토카드+ID카드', 6000),
+       (4, '디저트', '케이크+포토카드+ID카드', 10000);
 
 INSERT INTO lucky_draw
     (birthday_cafe_id, ranks, prize)
-VALUES (2, 1, '티셔츠'),
-       (2, 2, '머그컵');
+VALUES (4, 1, '티셔츠'),
+       (4, 2, '머그컵');
 
 -- 주최자1의 진행 중 생일 카페 이미지
 INSERT INTO birthday_cafe_image (id, birthday_cafe_id, image_url, is_main)
-VALUES (1, 2, 'winter-cafe-default-image', false),
-       (2, 2, 'winter-cafe-main-image.com', true),
-       (3, 2, 'winter-cafe-default-image', false);
+VALUES (1, 4, 'winter-cafe-default-image', false),
+       (2, 4, 'winter-cafe-main-image.com', true),
+       (3, 4, 'winter-cafe-default-image', false);
 
 -- 방문자(id=4)가 누른 찜
 INSERT INTO likes (visitant_id, target_id, target_type)

--- a/src/test/resources/fixture/birthday-cafe-fixture.sql
+++ b/src/test/resources/fixture/birthday-cafe-fixture.sql
@@ -61,5 +61,9 @@ VALUES (1, 2, 'winter-cafe-default-image', false),
        (2, 2, 'winter-cafe-main-image.com', true),
        (3, 2, 'winter-cafe-default-image', false);
 
+-- 방문자(id=4)가 누른 찜
+INSERT INTO likes (visitant_id, target_id, target_type)
+VALUES (4, 3, 'BIRTHDAY_CAFE');
+
 SET
 foreign_key_checks = 1;


### PR DESCRIPTION
## 🌍 이슈 번호
- closed #77 

## 📝 구현 내용
- 방문자의 생일 카페 목록 조회 구현

## 🍀 확인해야 할 부분

- 문제
    - 현재 로직대로라면 옛날에 이미 종료된 생일 카페를 제일 처음 방문자가 확인하게 된다.
    - 무한 스크롤을 한다고는 하나 앞으로 열릴 카페와 진행 중인 카페부터 확인하는게 좋을 거라 생각이 듦
- 2가지 해결 방안
    1. 기본적으로 ‘공개 상태’인 생일 카페만 조회하 듯이 ‘종료’된 생일 카페는 기본적으로 조회하지 않도록 하기
    2. 생일 카페가 `FINISHED` 상태가 되는 시점에 공개 상태를 비공개로 전환하는 로직 짜기

근데 1번 해결 방안으로 가면 쿼리 스트링으로 progressState=FINISHED로 주는 것과 대치되는 상황이 발생하기에 2번이 나을 것 같기도 하네요. 어떻게 생각하시나요?