### PR TITLE
[FEAT] 생일 카페 상세 조회

### DIFF
--- a/src/docs/asciidoc/api.adoc
+++ b/src/docs/asciidoc/api.adoc
@@ -88,6 +88,8 @@ operation::get-my-birthday-cafe-list[snippets='http-request,http-response,respon
 operation::get-birthday-cafe-likes[snippets='http-request,http-response,response-fields']
 === 방문자의 생일 카페 목록 조회
 operation::get-birthday-cafe-list[snippets='http-request,query-parameters,http-response,response-fields']
+=== 생일 카페 상세 조회
+operation::get-birthday-cafe-detail[snippets='http-request,http-response,response-fields']
 === 에러 코드
 include::{snippets}/birthday-cafe-error-Code/response-body.adoc[]
 

--- a/src/docs/asciidoc/api.adoc
+++ b/src/docs/asciidoc/api.adoc
@@ -89,7 +89,7 @@ operation::get-birthday-cafe-likes[snippets='http-request,http-response,response
 === 방문자의 생일 카페 목록 조회
 operation::get-birthday-cafe-list[snippets='http-request,query-parameters,http-response,response-fields']
 === 생일 카페 상세 조회
-operation::get-birthday-cafe-detail[snippets='http-request,http-response,response-fields']
+operation::get-birthday-cafe-detail[snippets='http-request,path-parameters,http-response']
 === 에러 코드
 include::{snippets}/birthday-cafe-error-Code/response-body.adoc[]
 

--- a/src/main/java/com/birca/bircabackend/query/controller/BirthdayCafeQueryController.java
+++ b/src/main/java/com/birca/bircabackend/query/controller/BirthdayCafeQueryController.java
@@ -48,4 +48,10 @@ public class BirthdayCafeQueryController {
                                                                         LoginMember loginMember) {
         return ResponseEntity.ok(birthdayCafeQueryService.findBirthdayCafes(birthdayCafeParams, pagingParams, loginMember));
     }
+
+    @GetMapping("/v1/birthday-cafes/{birthdayCafeId}")
+    @RequiredLogin
+    public ResponseEntity<BirthdayCafeDetailResponse> findBirthdayCafeDetail(LoginMember loginMember, @PathVariable Long birthdayCafeId) {
+        return ResponseEntity.ok(birthdayCafeQueryService.findBirthdayCafeDetail(loginMember, birthdayCafeId));
+    }
 }

--- a/src/main/java/com/birca/bircabackend/query/dto/BirthdayCafeDetailResponse.java
+++ b/src/main/java/com/birca/bircabackend/query/dto/BirthdayCafeDetailResponse.java
@@ -15,7 +15,7 @@ import java.time.LocalDateTime;
 import java.util.List;
 
 public record BirthdayCafeDetailResponse(
-        ArtistResponse artistResponse,
+        ArtistResponse artist,
         LocalDateTime startDate,
         LocalDateTime endDate,
         String birthdayCafeName,

--- a/src/main/java/com/birca/bircabackend/query/dto/BirthdayCafeDetailResponse.java
+++ b/src/main/java/com/birca/bircabackend/query/dto/BirthdayCafeDetailResponse.java
@@ -1,0 +1,68 @@
+package com.birca.bircabackend.query.dto;
+
+import com.birca.bircabackend.command.artist.domain.Artist;
+import com.birca.bircabackend.command.artist.domain.ArtistGroup;
+import com.birca.bircabackend.command.birca.domain.BirthdayCafe;
+import com.birca.bircabackend.command.birca.domain.BirthdayCafeImage;
+import com.birca.bircabackend.command.birca.domain.value.CongestionState;
+import com.birca.bircabackend.command.birca.domain.value.ProgressState;
+import com.birca.bircabackend.command.birca.domain.value.SpecialGoodsStockState;
+import com.birca.bircabackend.command.birca.domain.value.Visibility;
+import com.birca.bircabackend.command.like.domain.Like;
+import com.birca.bircabackend.query.repository.model.BirthdayCafeView;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+public record BirthdayCafeDetailResponse(
+        ArtistResponse artistResponse,
+        LocalDateTime startDate,
+        LocalDateTime endDate,
+        String birthdayCafeName,
+        Integer likeCount,
+        Boolean isLiked,
+        String twitterAccount,
+        Integer minimumVisitant,
+        Integer maximumVisitant,
+        CongestionState congestionState,
+        Visibility visibility,
+        ProgressState progressState,
+        SpecialGoodsStockState specialGoodsStockState,
+        String mainImage,
+        List<String> defaultImages
+) {
+
+    public static BirthdayCafeDetailResponse of(BirthdayCafeView birthdayCafeView, Integer likeCount, List<String> images) {
+        BirthdayCafe birthdayCafe = birthdayCafeView.birthdayCafe();
+        Artist artist = birthdayCafeView.artist();
+        ArtistGroup artistGroup = birthdayCafeView.artistGroup();
+        BirthdayCafeImage mainImage = birthdayCafeView.mainImage();
+        Like like = birthdayCafeView.like();
+        return new BirthdayCafeDetailResponse(
+                new ArtistResponse(
+                        artistGroup == null ? null : artistGroup.getName(),
+                        artist.getName()
+                ),
+                birthdayCafe.getSchedule().getStartDate(),
+                birthdayCafe.getSchedule().getEndDate(),
+                birthdayCafe.getName(),
+                likeCount,
+                like != null,
+                birthdayCafe.getTwitterAccount(),
+                birthdayCafe.getVisitants().getMinimumVisitant(),
+                birthdayCafe.getVisitants().getMaximumVisitant(),
+                birthdayCafe.getCongestionState(),
+                birthdayCafe.getVisibility(),
+                birthdayCafe.getProgressState(),
+                birthdayCafe.getSpecialGoodsStockState(),
+                mainImage == null ? null : mainImage.getImageUrl(),
+                images
+        );
+    }
+
+    public record ArtistResponse(
+            String groupName,
+            String name
+    ) {
+    }
+}

--- a/src/main/java/com/birca/bircabackend/query/repository/BirthdayCafeImageQueryRepository.java
+++ b/src/main/java/com/birca/bircabackend/query/repository/BirthdayCafeImageQueryRepository.java
@@ -1,0 +1,13 @@
+package com.birca.bircabackend.query.repository;
+
+import com.birca.bircabackend.command.birca.domain.BirthdayCafeImage;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.Repository;
+
+import java.util.List;
+
+public interface BirthdayCafeImageQueryRepository extends Repository<BirthdayCafeImage, Long> {
+
+    @Query("select bci.imageUrl from BirthdayCafeImage bci where bci.birthdayCafeId = :birthdayCafeId and bci.isMain = false")
+    List<String> findBirthdayCafeDefaultImages(Long birthdayCafeId);
+}

--- a/src/main/java/com/birca/bircabackend/query/repository/BirthdayCafeQueryRepository.java
+++ b/src/main/java/com/birca/bircabackend/query/repository/BirthdayCafeQueryRepository.java
@@ -10,6 +10,7 @@ import org.springframework.data.repository.Repository;
 import org.springframework.data.repository.query.Param;
 
 import java.util.List;
+import java.util.Optional;
 
 public interface BirthdayCafeQueryRepository extends Repository<BirthdayCafe, Long>, BirthdayCafeDynamicRepository {
 
@@ -30,4 +31,13 @@ public interface BirthdayCafeQueryRepository extends Repository<BirthdayCafe, Lo
             "where bc.hostId = :hostId " +
             "order by bc.id desc")
     List<BirthdayCafeView> findMyBirthdayCafes(@Param("hostId") Long hostId);
+
+    @Query("select new com.birca.bircabackend.query.repository.model.BirthdayCafeView(bc, bci, a, ag, lk) " +
+            "from BirthdayCafe bc " +
+            "join Artist a on a.id = bc.artistId " +
+            "left join BirthdayCafeImage bci on bc.id = bci.birthdayCafeId and bci.isMain = true " +
+            "left join ArtistGroup ag on a.groupId = ag.id " +
+            "left join Like lk on lk.target.targetId = bc.id and lk.target.targetType = 'BIRTHDAY_CAFE' and lk.visitantId = :visitantId " +
+            "where bc.id = :birthdayCafeId")
+    Optional<BirthdayCafeView> findBirthdayCafeDetail(Long visitantId, Long birthdayCafeId);
 }

--- a/src/main/java/com/birca/bircabackend/query/repository/LikedBirthdayCafeQueryRepository.java
+++ b/src/main/java/com/birca/bircabackend/query/repository/LikedBirthdayCafeQueryRepository.java
@@ -18,4 +18,9 @@ public interface LikedBirthdayCafeQueryRepository extends Repository<Like, Long>
             "left join ArtistGroup ag on a.groupId = ag.id " +
             "where lk.visitantId = :visitantId")
     List<BirthdayCafeView> findLikedBirthdayCafes(@Param("visitantId") Long visitantId);
+
+    @Query("select count(lk.id) " +
+            "from Like lk " +
+            "where lk.target.targetId = :birthdayCafeId and lk.target.targetType = 'BIRTHDAY_CAFE'")
+    Integer findLikedCount(Long birthdayCafeId);
 }

--- a/src/main/java/com/birca/bircabackend/query/service/BirthdayCafeQueryService.java
+++ b/src/main/java/com/birca/bircabackend/query/service/BirthdayCafeQueryService.java
@@ -1,8 +1,13 @@
 package com.birca.bircabackend.query.service;
 
 import com.birca.bircabackend.command.auth.authorization.LoginMember;
+import com.birca.bircabackend.command.birca.exception.BirthdayCafeErrorCode;
+import com.birca.bircabackend.common.exception.BusinessException;
 import com.birca.bircabackend.query.dto.*;
+import com.birca.bircabackend.query.repository.BirthdayCafeImageQueryRepository;
 import com.birca.bircabackend.query.repository.BirthdayCafeQueryRepository;
+import com.birca.bircabackend.query.repository.LikedBirthdayCafeQueryRepository;
+import com.birca.bircabackend.query.repository.model.BirthdayCafeView;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -15,6 +20,8 @@ import java.util.List;
 public class BirthdayCafeQueryService {
 
     private final BirthdayCafeQueryRepository birthdayCafeQueryRepository;
+    private final BirthdayCafeImageQueryRepository birthdayCafeImageQueryRepository;
+    private final LikedBirthdayCafeQueryRepository likedBirthdayCafeQueryRepository;
 
     public List<SpecialGoodsResponse> findSpecialGoods(Long birthdayCafeId) {
         return birthdayCafeQueryRepository.findSpecialGoodsById(birthdayCafeId)
@@ -51,5 +58,13 @@ public class BirthdayCafeQueryService {
                 .stream()
                 .map(BirthdayCafeResponse::from)
                 .toList();
+    }
+
+    public BirthdayCafeDetailResponse findBirthdayCafeDetail(LoginMember loginMember, Long birthdayCafeId) {
+        BirthdayCafeView birthdayCafeView = birthdayCafeQueryRepository.findBirthdayCafeDetail(loginMember.id(), birthdayCafeId)
+                .orElseThrow(() -> BusinessException.from(BirthdayCafeErrorCode.NOT_FOUND));
+        List<String> defaultImages = birthdayCafeImageQueryRepository.findBirthdayCafeDefaultImages(birthdayCafeId);
+        Integer likeCount = likedBirthdayCafeQueryRepository.findLikedCount(birthdayCafeId);
+        return BirthdayCafeDetailResponse.of(birthdayCafeView, likeCount, defaultImages);
     }
 }

--- a/src/main/resources/static/docs/api.html
+++ b/src/main/resources/static/docs/api.html
@@ -500,6 +500,7 @@ body.book #toc,body.book #preamble,body.book h1.sect0,body.book .sect1>h2{page-b
 <li><a href="#_주최자의_나의_생일_카페_목록_조회">주최자의 나의 생일 카페 목록 조회</a></li>
 <li><a href="#_찜한_생일_카페_목록_조회">찜한 생일 카페 목록 조회</a></li>
 <li><a href="#_방문자의_생일_카페_목록_조회">방문자의 생일 카페 목록 조회</a></li>
+<li><a href="#_생일_카페_상세_조회">생일 카페 상세 조회</a></li>
 <li><a href="#_에러_코드_5">에러 코드</a></li>
 </ul>
 </li>
@@ -649,7 +650,7 @@ Content-Length: 97
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">POST /api/v1/members/role-change HTTP/1.1
 Content-Type: application/json;charset=UTF-8
-Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwiaWF0IjoxNzExMjgyOTAxLCJleHAiOjE3MTEyODQ3MDF9.yN549hV6gGHArayINc_ARpDbk5gyeo-SkF0bAoc7n7U
+Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwiaWF0IjoxNzExNDYzOTk2LCJleHAiOjE3MTE0NjU3OTZ9.XNdou7YarLlzmUxgpzevlUxUZoMu6_RiAsGBUKIBNXg
 Content-Length: 21
 Host: www.api.birca.com
 
@@ -679,7 +680,7 @@ Vary: Access-Control-Request-Headers</code></pre>
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">GET /api/v1/join/check-nickname?nickname=does HTTP/1.1
 Content-Type: application/json;charset=UTF-8
-Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwiaWF0IjoxNzExMjgyOTA0LCJleHAiOjE3MTEyODQ3MDR9.jXgMDgIIrrziWYhf82B-6LS-RD3Of00_YSS1KPn14TU
+Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwiaWF0IjoxNzExNDYzOTk5LCJleHAiOjE3MTE0NjU3OTl9.VXxHUeoxjHzsroI8flntnr4nCfOw39wmbNioR38lP9E
 Host: www.api.birca.com</code></pre>
 </div>
 </div>
@@ -753,7 +754,7 @@ Content-Length: 16
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">POST /api/v1/join/register-nickname HTTP/1.1
 Content-Type: application/json;charset=UTF-8
-Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwiaWF0IjoxNzExMjgyOTAxLCJleHAiOjE3MTEyODQ3MDF9.yN549hV6gGHArayINc_ARpDbk5gyeo-SkF0bAoc7n7U
+Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwiaWF0IjoxNzExNDYzOTk2LCJleHAiOjE3MTE0NjU3OTZ9.XNdou7YarLlzmUxgpzevlUxUZoMu6_RiAsGBUKIBNXg
 Content-Length: 30
 Host: www.api.birca.com
 
@@ -841,7 +842,7 @@ Vary: Access-Control-Request-Headers</code></pre>
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">GET /api/v1/artist-groups?cursor=10&amp;size=3 HTTP/1.1
 Content-Type: application/json;charset=UTF-8
-Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwiaWF0IjoxNzExMjgyOTA0LCJleHAiOjE3MTEyODQ3MDR9.jXgMDgIIrrziWYhf82B-6LS-RD3Of00_YSS1KPn14TU
+Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwiaWF0IjoxNzExNDYzOTk4LCJleHAiOjE3MTE0NjU3OTh9.-REcv7LD-DrxvmGrxaPYuVeX0DXB4lYaVeDZkRQu14g
 Host: www.api.birca.com</code></pre>
 </div>
 </div>
@@ -941,7 +942,7 @@ Content-Length: 250
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">GET /api/v1/artist-groups/1/artists HTTP/1.1
 Content-Type: application/json;charset=UTF-8
-Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwiaWF0IjoxNzExMjgyOTA0LCJleHAiOjE3MTEyODQ3MDR9.jXgMDgIIrrziWYhf82B-6LS-RD3Of00_YSS1KPn14TU
+Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwiaWF0IjoxNzExNDYzOTk4LCJleHAiOjE3MTE0NjU3OTh9.-REcv7LD-DrxvmGrxaPYuVeX0DXB4lYaVeDZkRQu14g
 Host: www.api.birca.com</code></pre>
 </div>
 </div>
@@ -1054,7 +1055,7 @@ Content-Length: 565
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">GET /api/v1/artists/solo?cursor=12&amp;size=6 HTTP/1.1
 Content-Type: application/json;charset=UTF-8
-Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwiaWF0IjoxNzExMjgyOTA0LCJleHAiOjE3MTEyODQ3MDR9.jXgMDgIIrrziWYhf82B-6LS-RD3Of00_YSS1KPn14TU
+Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwiaWF0IjoxNzExNDYzOTk4LCJleHAiOjE3MTE0NjU3OTh9.-REcv7LD-DrxvmGrxaPYuVeX0DXB4lYaVeDZkRQu14g
 Host: www.api.birca.com</code></pre>
 </div>
 </div>
@@ -1166,7 +1167,7 @@ Content-Length: 518
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">POST /api/v1/artists/favorite HTTP/1.1
 Content-Type: application/json;charset=UTF-8
-Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwiaWF0IjoxNzExMjgyODk4LCJleHAiOjE3MTEyODQ2OTh9.vdz0s_0CfewpHFJTU64ih5y0-GnUZbkRS_mt4yDuJeQ
+Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwiaWF0IjoxNzExNDYzOTkwLCJleHAiOjE3MTE0NjU3OTB9.vA7lWgGUD5TLMzyWE2HzlNYbYdWMg4o9oW0UtNB4yMY
 Content-Length: 20
 Host: www.api.birca.com
 
@@ -1220,7 +1221,7 @@ Vary: Access-Control-Request-Headers</code></pre>
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">POST /api/v1/artists/interest HTTP/1.1
 Content-Type: application/json;charset=UTF-8
-Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwiaWF0IjoxNzExMjgyODk4LCJleHAiOjE3MTEyODQ2OTh9.vdz0s_0CfewpHFJTU64ih5y0-GnUZbkRS_mt4yDuJeQ
+Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwiaWF0IjoxNzExNDYzOTkwLCJleHAiOjE3MTE0NjU3OTB9.vA7lWgGUD5TLMzyWE2HzlNYbYdWMg4o9oW0UtNB4yMY
 Content-Length: 68
 Host: www.api.birca.com
 
@@ -1278,7 +1279,7 @@ Vary: Access-Control-Request-Headers</code></pre>
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">GET /api/v1/artists/favorite HTTP/1.1
 Content-Type: application/json;charset=UTF-8
-Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwiaWF0IjoxNzExMjgyOTA0LCJleHAiOjE3MTEyODQ3MDR9.jXgMDgIIrrziWYhf82B-6LS-RD3Of00_YSS1KPn14TU
+Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwiaWF0IjoxNzExNDYzOTk5LCJleHAiOjE3MTE0NjU3OTl9.VXxHUeoxjHzsroI8flntnr4nCfOw39wmbNioR38lP9E
 Host: www.api.birca.com</code></pre>
 </div>
 </div>
@@ -1345,7 +1346,7 @@ Content-Length: 81
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">GET /api/v1/artists/interest HTTP/1.1
 Content-Type: application/json;charset=UTF-8
-Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwiaWF0IjoxNzExMjgyOTA0LCJleHAiOjE3MTEyODQ3MDR9.jXgMDgIIrrziWYhf82B-6LS-RD3Of00_YSS1KPn14TU
+Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwiaWF0IjoxNzExNDYzOTk5LCJleHAiOjE3MTE0NjU3OTl9.VXxHUeoxjHzsroI8flntnr4nCfOw39wmbNioR38lP9E
 Host: www.api.birca.com</code></pre>
 </div>
 </div>
@@ -1428,7 +1429,7 @@ Content-Length: 416
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">GET /api/v1/artists/search?name=%EB%A7%88%ED%81%AC HTTP/1.1
 Content-Type: application/json;charset=UTF-8
-Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwiaWF0IjoxNzExMjgyOTA0LCJleHAiOjE3MTEyODQ3MDR9.jXgMDgIIrrziWYhf82B-6LS-RD3Of00_YSS1KPn14TU
+Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwiaWF0IjoxNzExNDYzOTk4LCJleHAiOjE3MTE0NjU3OTh9.-REcv7LD-DrxvmGrxaPYuVeX0DXB4lYaVeDZkRQu14g
 Host: www.api.birca.com</code></pre>
 </div>
 </div>
@@ -1493,7 +1494,7 @@ Content-Length: 225
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">POST /api/v1/cafes/license-read HTTP/1.1
 Content-Type: multipart/form-data;charset=UTF-8; boundary=6o2knFse3p53ty9dmcQvWAIx1zInP11uCfbm
-Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwiaWF0IjoxNzExMjgyOTAwLCJleHAiOjE3MTEyODQ3MDB9.NwWNn0PgRBWqB53moIw9DvDKPNpS8GZUiUYjvyG6Zbc
+Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwiaWF0IjoxNzExNDYzOTk2LCJleHAiOjE3MTE0NjU3OTZ9.XNdou7YarLlzmUxgpzevlUxUZoMu6_RiAsGBUKIBNXg
 Host: www.api.birca.com
 
 --6o2knFse3p53ty9dmcQvWAIx1zInP11uCfbm
@@ -1579,7 +1580,7 @@ Content-Length: 141
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">POST /api/v1/cafes/apply HTTP/1.1
 Content-Type: multipart/form-data;charset=UTF-8; boundary=6o2knFse3p53ty9dmcQvWAIx1zInP11uCfbm
-Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwiaWF0IjoxNzExMjgyOTAwLCJleHAiOjE3MTEyODQ3MDB9.NwWNn0PgRBWqB53moIw9DvDKPNpS8GZUiUYjvyG6Zbc
+Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwiaWF0IjoxNzExNDYzOTk2LCJleHAiOjE3MTE0NjU3OTZ9.XNdou7YarLlzmUxgpzevlUxUZoMu6_RiAsGBUKIBNXg
 Host: www.api.birca.com
 
 --6o2knFse3p53ty9dmcQvWAIx1zInP11uCfbm
@@ -1653,7 +1654,7 @@ Vary: Access-Control-Request-Headers</code></pre>
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">POST /api/v1/birthday-cafes HTTP/1.1
 Content-Type: application/json;charset=UTF-8
-Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwiaWF0IjoxNzExMjgyODk5LCJleHAiOjE3MTEyODQ2OTl9.0Ljcnc25a4HCttJAkjLBowT3UAOxvPtjg21FNg-S_cU
+Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwiaWF0IjoxNzExNDYzOTkzLCJleHAiOjE3MTE0NjU3OTN9.H6gyujFBaJ3F9SOlKIWOByoO8ALWiLBtPnERWLNeZxM
 Content-Length: 234
 Host: www.api.birca.com
 
@@ -1749,7 +1750,7 @@ Vary: Access-Control-Request-Headers</code></pre>
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">POST /api/v1/birthday-cafes/1/cancel HTTP/1.1
 Content-Type: application/json;charset=UTF-8
-Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwiaWF0IjoxNzExMjgyODk5LCJleHAiOjE3MTEyODQ2OTl9.0Ljcnc25a4HCttJAkjLBowT3UAOxvPtjg21FNg-S_cU
+Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwiaWF0IjoxNzExNDYzOTkzLCJleHAiOjE3MTE0NjU3OTN9.H6gyujFBaJ3F9SOlKIWOByoO8ALWiLBtPnERWLNeZxM
 Host: www.api.birca.com</code></pre>
 </div>
 </div>
@@ -1796,7 +1797,7 @@ Vary: Access-Control-Request-Headers</code></pre>
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">PATCH /api/v1/birthday-cafes/1/congestion HTTP/1.1
 Content-Type: application/json;charset=UTF-8
-Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwiaWF0IjoxNzExMjgyODk5LCJleHAiOjE3MTEyODQ2OTl9.0Ljcnc25a4HCttJAkjLBowT3UAOxvPtjg21FNg-S_cU
+Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwiaWF0IjoxNzExNDYzOTkzLCJleHAiOjE3MTE0NjU3OTN9.H6gyujFBaJ3F9SOlKIWOByoO8ALWiLBtPnERWLNeZxM
 Content-Length: 26
 Host: www.api.birca.com
 
@@ -1876,7 +1877,7 @@ Vary: Access-Control-Request-Headers</code></pre>
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">POST /api/v1/birthday-cafes/1/special-goods HTTP/1.1
 Content-Type: application/json;charset=UTF-8
-Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwiaWF0IjoxNzExMjgyODk5LCJleHAiOjE3MTEyODQ2OTl9.0Ljcnc25a4HCttJAkjLBowT3UAOxvPtjg21FNg-S_cU
+Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwiaWF0IjoxNzExNDYzOTkzLCJleHAiOjE3MTE0NjU3OTN9.H6gyujFBaJ3F9SOlKIWOByoO8ALWiLBtPnERWLNeZxM
 Content-Length: 147
 Host: www.api.birca.com
 
@@ -1961,7 +1962,7 @@ Vary: Access-Control-Request-Headers</code></pre>
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">POST /api/v1/birthday-cafes/1/menus HTTP/1.1
 Content-Type: application/json;charset=UTF-8
-Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwiaWF0IjoxNzExMjgyODk5LCJleHAiOjE3MTEyODQ2OTl9.0Ljcnc25a4HCttJAkjLBowT3UAOxvPtjg21FNg-S_cU
+Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwiaWF0IjoxNzExNDYzOTkzLCJleHAiOjE3MTE0NjU3OTN9.H6gyujFBaJ3F9SOlKIWOByoO8ALWiLBtPnERWLNeZxM
 Content-Length: 197
 Host: www.api.birca.com
 
@@ -2053,7 +2054,7 @@ Vary: Access-Control-Request-Headers</code></pre>
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">POST /api/v1/birthday-cafes/1/lucky-draws HTTP/1.1
 Content-Type: application/json;charset=UTF-8
-Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwiaWF0IjoxNzExMjgyODk5LCJleHAiOjE3MTEyODQ2OTl9.0Ljcnc25a4HCttJAkjLBowT3UAOxvPtjg21FNg-S_cU
+Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwiaWF0IjoxNzExNDYzOTkzLCJleHAiOjE3MTE0NjU3OTN9.H6gyujFBaJ3F9SOlKIWOByoO8ALWiLBtPnERWLNeZxM
 Content-Length: 92
 Host: www.api.birca.com
 
@@ -2138,7 +2139,7 @@ Vary: Access-Control-Request-Headers</code></pre>
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">GET /api/v1/birthday-cafes/1/special-goods HTTP/1.1
 Content-Type: application/json;charset=UTF-8
-Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwiaWF0IjoxNzExMjgyOTA0LCJleHAiOjE3MTEyODQ3MDR9.jXgMDgIIrrziWYhf82B-6LS-RD3Of00_YSS1KPn14TU
+Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwiaWF0IjoxNzExNDYzOTk4LCJleHAiOjE3MTE0NjU3OTh9.-REcv7LD-DrxvmGrxaPYuVeX0DXB4lYaVeDZkRQu14g
 Host: www.api.birca.com</code></pre>
 </div>
 </div>
@@ -2195,7 +2196,7 @@ Content-Length: 126
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">GET /api/v1/birthday-cafes/1/menus HTTP/1.1
 Content-Type: application/json;charset=UTF-8
-Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwiaWF0IjoxNzExMjgyOTA0LCJleHAiOjE3MTEyODQ3MDR9.jXgMDgIIrrziWYhf82B-6LS-RD3Of00_YSS1KPn14TU
+Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwiaWF0IjoxNzExNDYzOTk5LCJleHAiOjE3MTE0NjU3OTl9.VXxHUeoxjHzsroI8flntnr4nCfOw39wmbNioR38lP9E
 Host: www.api.birca.com</code></pre>
 </div>
 </div>
@@ -2254,7 +2255,7 @@ Content-Length: 196
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">GET /api/v1/birthday-cafes/1/lucky-draws HTTP/1.1
 Content-Type: application/json;charset=UTF-8
-Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwiaWF0IjoxNzExMjgyOTA0LCJleHAiOjE3MTEyODQ3MDR9.jXgMDgIIrrziWYhf82B-6LS-RD3Of00_YSS1KPn14TU
+Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwiaWF0IjoxNzExNDYzOTk4LCJleHAiOjE3MTE0NjU3OTh9.-REcv7LD-DrxvmGrxaPYuVeX0DXB4lYaVeDZkRQu14g
 Host: www.api.birca.com</code></pre>
 </div>
 </div>
@@ -2311,7 +2312,7 @@ Content-Length: 88
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">PATCH /api/v1/birthday-cafes/1 HTTP/1.1
 Content-Type: application/json;charset=UTF-8
-Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwiaWF0IjoxNzExMjgyODk5LCJleHAiOjE3MTEyODQ2OTl9.0Ljcnc25a4HCttJAkjLBowT3UAOxvPtjg21FNg-S_cU
+Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwiaWF0IjoxNzExNDYzOTkzLCJleHAiOjE3MTE0NjU3OTN9.H6gyujFBaJ3F9SOlKIWOByoO8ALWiLBtPnERWLNeZxM
 Content-Length: 86
 Host: www.api.birca.com
 
@@ -2393,7 +2394,7 @@ Vary: Access-Control-Request-Headers</code></pre>
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">POST /api/v1/birthday-cafes/1/images HTTP/1.1
 Content-Type: multipart/form-data;charset=UTF-8; boundary=6o2knFse3p53ty9dmcQvWAIx1zInP11uCfbm
-Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwiaWF0IjoxNzExMjgyODk5LCJleHAiOjE3MTEyODQ2OTl9.0Ljcnc25a4HCttJAkjLBowT3UAOxvPtjg21FNg-S_cU
+Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwiaWF0IjoxNzExNDYzOTkzLCJleHAiOjE3MTE0NjU3OTN9.H6gyujFBaJ3F9SOlKIWOByoO8ALWiLBtPnERWLNeZxM
 Host: www.api.birca.com
 
 --6o2knFse3p53ty9dmcQvWAIx1zInP11uCfbm
@@ -2424,7 +2425,7 @@ Vary: Access-Control-Request-Headers</code></pre>
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">POST /api/v1/birthday-cafes/1/images/main HTTP/1.1
 Content-Type: multipart/form-data;charset=UTF-8; boundary=6o2knFse3p53ty9dmcQvWAIx1zInP11uCfbm
-Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwiaWF0IjoxNzExMjgyODk5LCJleHAiOjE3MTEyODQ2OTl9.0Ljcnc25a4HCttJAkjLBowT3UAOxvPtjg21FNg-S_cU
+Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwiaWF0IjoxNzExNDYzOTkzLCJleHAiOjE3MTE0NjU3OTN9.H6gyujFBaJ3F9SOlKIWOByoO8ALWiLBtPnERWLNeZxM
 Host: www.api.birca.com
 
 --6o2knFse3p53ty9dmcQvWAIx1zInP11uCfbm
@@ -2455,7 +2456,7 @@ Vary: Access-Control-Request-Headers</code></pre>
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">POST /api/v1/birthday-cafes/1/images HTTP/1.1
 Content-Type: multipart/form-data;charset=UTF-8; boundary=6o2knFse3p53ty9dmcQvWAIx1zInP11uCfbm
-Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwiaWF0IjoxNzExMjgyODk5LCJleHAiOjE3MTEyODQ2OTl9.0Ljcnc25a4HCttJAkjLBowT3UAOxvPtjg21FNg-S_cU
+Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwiaWF0IjoxNzExNDYzOTkzLCJleHAiOjE3MTE0NjU3OTN9.H6gyujFBaJ3F9SOlKIWOByoO8ALWiLBtPnERWLNeZxM
 Host: www.api.birca.com
 
 --6o2knFse3p53ty9dmcQvWAIx1zInP11uCfbm
@@ -2486,7 +2487,7 @@ Vary: Access-Control-Request-Headers</code></pre>
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">DELETE /api/v1/birthday-cafes/1/images HTTP/1.1
 Content-Type: application/json;charset=UTF-8
-Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwiaWF0IjoxNzExMjgyODk5LCJleHAiOjE3MTEyODQ2OTl9.0Ljcnc25a4HCttJAkjLBowT3UAOxvPtjg21FNg-S_cU
+Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwiaWF0IjoxNzExNDYzOTkzLCJleHAiOjE3MTE0NjU3OTN9.H6gyujFBaJ3F9SOlKIWOByoO8ALWiLBtPnERWLNeZxM
 Content-Length: 26
 Host: www.api.birca.com
 
@@ -2540,7 +2541,7 @@ Vary: Access-Control-Request-Headers</code></pre>
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">GET /api/v1/birthday-cafes/me HTTP/1.1
 Content-Type: application/json;charset=UTF-8
-Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwiaWF0IjoxNzExMjgyOTA0LCJleHAiOjE3MTEyODQ3MDR9.jXgMDgIIrrziWYhf82B-6LS-RD3Of00_YSS1KPn14TU
+Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwiaWF0IjoxNzExNDYzOTk4LCJleHAiOjE3MTE0NjU3OTh9.-REcv7LD-DrxvmGrxaPYuVeX0DXB4lYaVeDZkRQu14g
 Host: www.api.birca.com</code></pre>
 </div>
 </div>
@@ -2650,7 +2651,7 @@ Content-Length: 586
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">GET /api/v1/birthday-cafes/like HTTP/1.1
 Content-Type: application/json;charset=UTF-8
-Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwiaWF0IjoxNzExMjgyOTA0LCJleHAiOjE3MTEyODQ3MDR9.jXgMDgIIrrziWYhf82B-6LS-RD3Of00_YSS1KPn14TU
+Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwiaWF0IjoxNzExNDYzOTk4LCJleHAiOjE3MTE0NjU3OTh9.-REcv7LD-DrxvmGrxaPYuVeX0DXB4lYaVeDZkRQu14g
 Host: www.api.birca.com</code></pre>
 </div>
 </div>
@@ -2760,7 +2761,7 @@ Content-Length: 583
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">GET /api/v1/birthday-cafes?cursor=1&amp;size=10&amp;artistId=1&amp;cafeId=1&amp;progressState=IN_PROGRESS HTTP/1.1
 Content-Type: application/json;charset=UTF-8
-Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwiaWF0IjoxNzExMjgyOTA0LCJleHAiOjE3MTEyODQ3MDR9.jXgMDgIIrrziWYhf82B-6LS-RD3Of00_YSS1KPn14TU
+Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwiaWF0IjoxNzExNDYzOTk5LCJleHAiOjE3MTE0NjU3OTl9.VXxHUeoxjHzsroI8flntnr4nCfOw39wmbNioR38lP9E
 Host: www.api.birca.com</code></pre>
 </div>
 </div>
@@ -2900,6 +2901,153 @@ Content-Length: 560
 </div>
 </div>
 <div class="sect2">
+<h3 id="_생일_카페_상세_조회"><a class="link" href="#_생일_카페_상세_조회">생일 카페 상세 조회</a></h3>
+<div class="sect3">
+<h4 id="_생일_카페_상세_조회_http_request"><a class="link" href="#_생일_카페_상세_조회_http_request">HTTP request</a></h4>
+<div class="listingblock">
+<div class="content">
+<pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">GET /api/v1/birthday-cafes/1 HTTP/1.1
+Content-Type: application/json;charset=UTF-8
+Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwiaWF0IjoxNzExNDYzOTk4LCJleHAiOjE3MTE0NjU3OTh9.-REcv7LD-DrxvmGrxaPYuVeX0DXB4lYaVeDZkRQu14g
+Host: www.api.birca.com</code></pre>
+</div>
+</div>
+</div>
+<div class="sect3">
+<h4 id="_생일_카페_상세_조회_http_response"><a class="link" href="#_생일_카페_상세_조회_http_response">HTTP response</a></h4>
+<div class="listingblock">
+<div class="content">
+<pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">HTTP/1.1 200 OK
+Vary: Origin
+Vary: Access-Control-Request-Method
+Vary: Access-Control-Request-Headers
+Content-Type: application/json
+Content-Length: 551
+
+{
+  "artistResponse" : {
+    "groupName" : "샤이니",
+    "name" : "민호"
+  },
+  "startDate" : "2024-03-20T00:00:00",
+  "endDate" : "2024-03-23T00:00:00",
+  "birthdayCafeName" : "아이유의 생일 카페",
+  "likeCount" : 10,
+  "isLiked" : true,
+  "twitterAccount" : "@ChaseM",
+  "minimumVisitant" : 5,
+  "maximumVisitant" : 10,
+  "congestionState" : "SMOOTH",
+  "visibility" : "PUBLIC",
+  "progressState" : "IN_PROGRESS",
+  "specialGoodsStockState" : "ABUNDANT",
+  "mainImage" : "image.com",
+  "defaultImages" : [ "image1.com", "image2.com" ]
+}</code></pre>
+</div>
+</div>
+</div>
+<div class="sect3">
+<h4 id="_생일_카페_상세_조회_response_fields"><a class="link" href="#_생일_카페_상세_조회_response_fields">Response fields</a></h4>
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 33.3333%;">
+<col style="width: 33.3333%;">
+<col style="width: 33.3334%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">Path</th>
+<th class="tableblock halign-left valign-top">Type</th>
+<th class="tableblock halign-left valign-top">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>artistResponse.groupName</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">아티스트 그룹 이름</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>artistResponse.name</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">아티스트 이름</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>startDate</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">생일 카페 시작일</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>endDate</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">생일 카페 종료일</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>birthdayCafeName</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">생일 카페 이름</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>likeCount</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Number</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">생일 카페 찜된 수</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>isLiked</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Boolean</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">찜 했는지 여부</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>twitterAccount</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">트위터 계정</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>minimumVisitant</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Number</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">생일 카페 최소 방문자 수</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>maximumVisitant</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Number</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">생일 카페 최대 방문자 수</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>congestionState</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">생일 카페 혼잡도</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>visibility</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">생일 카페 공개 여부</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>progressState</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">생일 카페 진행 상태</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>specialGoodsStockState</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">생일 카페 굿즈 양</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>mainImage</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">생일 카페 메인 이미지 url</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>defaultImages.[]</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Array</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">생일 카페 기본 이미지 url</p></td>
+</tr>
+</tbody>
+</table>
+</div>
+</div>
+<div class="sect2">
 <h3 id="_에러_코드_5"><a class="link" href="#_에러_코드_5">에러 코드</a></h3>
 <div class="listingblock">
 <div class="content">
@@ -2961,7 +3109,7 @@ Content-Length: 560
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">GET /api/v1/cafes/search?name=%EC%BB%A4%ED%94%BC HTTP/1.1
 Content-Type: application/json;charset=UTF-8
-Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwiaWF0IjoxNzExMjgyOTA0LCJleHAiOjE3MTEyODQ3MDR9.jXgMDgIIrrziWYhf82B-6LS-RD3Of00_YSS1KPn14TU
+Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwiaWF0IjoxNzExNDYzOTk5LCJleHAiOjE3MTE0NjU3OTl9.VXxHUeoxjHzsroI8flntnr4nCfOw39wmbNioR38lP9E
 Host: www.api.birca.com</code></pre>
 </div>
 </div>
@@ -3001,7 +3149,7 @@ Content-Length: 106
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">POST /api/v1/birthday-cafes/1/like HTTP/1.1
 Content-Type: application/json;charset=UTF-8
-Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwiaWF0IjoxNzExMjgyOTAxLCJleHAiOjE3MTEyODQ3MDF9.yN549hV6gGHArayINc_ARpDbk5gyeo-SkF0bAoc7n7U
+Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwiaWF0IjoxNzExNDYzOTk2LCJleHAiOjE3MTE0NjU3OTZ9.XNdou7YarLlzmUxgpzevlUxUZoMu6_RiAsGBUKIBNXg
 Host: www.api.birca.com</code></pre>
 </div>
 </div>
@@ -3048,7 +3196,7 @@ Vary: Access-Control-Request-Headers</code></pre>
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">DELETE /api/v1/birthday-cafes/1/like HTTP/1.1
 Content-Type: application/json;charset=UTF-8
-Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwiaWF0IjoxNzExMjgyOTAxLCJleHAiOjE3MTEyODQ3MDF9.yN549hV6gGHArayINc_ARpDbk5gyeo-SkF0bAoc7n7U
+Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwiaWF0IjoxNzExNDYzOTk2LCJleHAiOjE3MTE0NjU3OTZ9.XNdou7YarLlzmUxgpzevlUxUZoMu6_RiAsGBUKIBNXg
 Host: www.api.birca.com</code></pre>
 </div>
 </div>
@@ -3110,7 +3258,7 @@ Vary: Access-Control-Request-Headers</code></pre>
 <div id="footer">
 <div id="footer-text">
 Version 0.0.1-SNAPSHOT<br>
-Last updated 2024-03-24 21:21:14 +0900
+Last updated 2024-03-26 18:25:42 +0900
 </div>
 </div>
 <script src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/9.18.3/highlight.min.js"></script>

--- a/src/main/resources/static/docs/api.html
+++ b/src/main/resources/static/docs/api.html
@@ -650,7 +650,7 @@ Content-Length: 97
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">POST /api/v1/members/role-change HTTP/1.1
 Content-Type: application/json;charset=UTF-8
-Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwiaWF0IjoxNzExNDYzOTk2LCJleHAiOjE3MTE0NjU3OTZ9.XNdou7YarLlzmUxgpzevlUxUZoMu6_RiAsGBUKIBNXg
+Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwiaWF0IjoxNzExNTI1MDg0LCJleHAiOjE3MTE1MjY4ODR9.62Cq76-J3aDQ5zYteG_aWatg4mOrD3YJoxvfki0H_o0
 Content-Length: 21
 Host: www.api.birca.com
 
@@ -680,7 +680,7 @@ Vary: Access-Control-Request-Headers</code></pre>
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">GET /api/v1/join/check-nickname?nickname=does HTTP/1.1
 Content-Type: application/json;charset=UTF-8
-Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwiaWF0IjoxNzExNDYzOTk5LCJleHAiOjE3MTE0NjU3OTl9.VXxHUeoxjHzsroI8flntnr4nCfOw39wmbNioR38lP9E
+Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwiaWF0IjoxNzExNTI1MDg3LCJleHAiOjE3MTE1MjY4ODd9.Tr30fu8F7VRo_IUkR744y3gxXmqyQsye6kihRu02cHM
 Host: www.api.birca.com</code></pre>
 </div>
 </div>
@@ -754,7 +754,7 @@ Content-Length: 16
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">POST /api/v1/join/register-nickname HTTP/1.1
 Content-Type: application/json;charset=UTF-8
-Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwiaWF0IjoxNzExNDYzOTk2LCJleHAiOjE3MTE0NjU3OTZ9.XNdou7YarLlzmUxgpzevlUxUZoMu6_RiAsGBUKIBNXg
+Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwiaWF0IjoxNzExNTI1MDg0LCJleHAiOjE3MTE1MjY4ODR9.62Cq76-J3aDQ5zYteG_aWatg4mOrD3YJoxvfki0H_o0
 Content-Length: 30
 Host: www.api.birca.com
 
@@ -842,7 +842,7 @@ Vary: Access-Control-Request-Headers</code></pre>
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">GET /api/v1/artist-groups?cursor=10&amp;size=3 HTTP/1.1
 Content-Type: application/json;charset=UTF-8
-Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwiaWF0IjoxNzExNDYzOTk4LCJleHAiOjE3MTE0NjU3OTh9.-REcv7LD-DrxvmGrxaPYuVeX0DXB4lYaVeDZkRQu14g
+Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwiaWF0IjoxNzExNTI1MDg3LCJleHAiOjE3MTE1MjY4ODd9.Tr30fu8F7VRo_IUkR744y3gxXmqyQsye6kihRu02cHM
 Host: www.api.birca.com</code></pre>
 </div>
 </div>
@@ -942,7 +942,7 @@ Content-Length: 250
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">GET /api/v1/artist-groups/1/artists HTTP/1.1
 Content-Type: application/json;charset=UTF-8
-Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwiaWF0IjoxNzExNDYzOTk4LCJleHAiOjE3MTE0NjU3OTh9.-REcv7LD-DrxvmGrxaPYuVeX0DXB4lYaVeDZkRQu14g
+Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwiaWF0IjoxNzExNTI1MDg3LCJleHAiOjE3MTE1MjY4ODd9.Tr30fu8F7VRo_IUkR744y3gxXmqyQsye6kihRu02cHM
 Host: www.api.birca.com</code></pre>
 </div>
 </div>
@@ -1055,7 +1055,7 @@ Content-Length: 565
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">GET /api/v1/artists/solo?cursor=12&amp;size=6 HTTP/1.1
 Content-Type: application/json;charset=UTF-8
-Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwiaWF0IjoxNzExNDYzOTk4LCJleHAiOjE3MTE0NjU3OTh9.-REcv7LD-DrxvmGrxaPYuVeX0DXB4lYaVeDZkRQu14g
+Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwiaWF0IjoxNzExNTI1MDg3LCJleHAiOjE3MTE1MjY4ODd9.Tr30fu8F7VRo_IUkR744y3gxXmqyQsye6kihRu02cHM
 Host: www.api.birca.com</code></pre>
 </div>
 </div>
@@ -1167,7 +1167,7 @@ Content-Length: 518
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">POST /api/v1/artists/favorite HTTP/1.1
 Content-Type: application/json;charset=UTF-8
-Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwiaWF0IjoxNzExNDYzOTkwLCJleHAiOjE3MTE0NjU3OTB9.vA7lWgGUD5TLMzyWE2HzlNYbYdWMg4o9oW0UtNB4yMY
+Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwiaWF0IjoxNzExNTI1MDc4LCJleHAiOjE3MTE1MjY4Nzh9.OG8cQKXLdBJcfI3HDrRXQoLE2S-zENHdiphUkpXBxkA
 Content-Length: 20
 Host: www.api.birca.com
 
@@ -1221,7 +1221,7 @@ Vary: Access-Control-Request-Headers</code></pre>
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">POST /api/v1/artists/interest HTTP/1.1
 Content-Type: application/json;charset=UTF-8
-Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwiaWF0IjoxNzExNDYzOTkwLCJleHAiOjE3MTE0NjU3OTB9.vA7lWgGUD5TLMzyWE2HzlNYbYdWMg4o9oW0UtNB4yMY
+Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwiaWF0IjoxNzExNTI1MDc5LCJleHAiOjE3MTE1MjY4Nzl9.LaOrSbRQzVivT6mMs6Wg3HwIK_OiA0l3nwcCGKIAA1A
 Content-Length: 68
 Host: www.api.birca.com
 
@@ -1279,7 +1279,7 @@ Vary: Access-Control-Request-Headers</code></pre>
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">GET /api/v1/artists/favorite HTTP/1.1
 Content-Type: application/json;charset=UTF-8
-Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwiaWF0IjoxNzExNDYzOTk5LCJleHAiOjE3MTE0NjU3OTl9.VXxHUeoxjHzsroI8flntnr4nCfOw39wmbNioR38lP9E
+Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwiaWF0IjoxNzExNTI1MDg3LCJleHAiOjE3MTE1MjY4ODd9.Tr30fu8F7VRo_IUkR744y3gxXmqyQsye6kihRu02cHM
 Host: www.api.birca.com</code></pre>
 </div>
 </div>
@@ -1346,7 +1346,7 @@ Content-Length: 81
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">GET /api/v1/artists/interest HTTP/1.1
 Content-Type: application/json;charset=UTF-8
-Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwiaWF0IjoxNzExNDYzOTk5LCJleHAiOjE3MTE0NjU3OTl9.VXxHUeoxjHzsroI8flntnr4nCfOw39wmbNioR38lP9E
+Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwiaWF0IjoxNzExNTI1MDg3LCJleHAiOjE3MTE1MjY4ODd9.Tr30fu8F7VRo_IUkR744y3gxXmqyQsye6kihRu02cHM
 Host: www.api.birca.com</code></pre>
 </div>
 </div>
@@ -1429,7 +1429,7 @@ Content-Length: 416
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">GET /api/v1/artists/search?name=%EB%A7%88%ED%81%AC HTTP/1.1
 Content-Type: application/json;charset=UTF-8
-Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwiaWF0IjoxNzExNDYzOTk4LCJleHAiOjE3MTE0NjU3OTh9.-REcv7LD-DrxvmGrxaPYuVeX0DXB4lYaVeDZkRQu14g
+Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwiaWF0IjoxNzExNTI1MDg3LCJleHAiOjE3MTE1MjY4ODd9.Tr30fu8F7VRo_IUkR744y3gxXmqyQsye6kihRu02cHM
 Host: www.api.birca.com</code></pre>
 </div>
 </div>
@@ -1494,7 +1494,7 @@ Content-Length: 225
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">POST /api/v1/cafes/license-read HTTP/1.1
 Content-Type: multipart/form-data;charset=UTF-8; boundary=6o2knFse3p53ty9dmcQvWAIx1zInP11uCfbm
-Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwiaWF0IjoxNzExNDYzOTk2LCJleHAiOjE3MTE0NjU3OTZ9.XNdou7YarLlzmUxgpzevlUxUZoMu6_RiAsGBUKIBNXg
+Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwiaWF0IjoxNzExNTI1MDg0LCJleHAiOjE3MTE1MjY4ODR9.62Cq76-J3aDQ5zYteG_aWatg4mOrD3YJoxvfki0H_o0
 Host: www.api.birca.com
 
 --6o2knFse3p53ty9dmcQvWAIx1zInP11uCfbm
@@ -1580,7 +1580,7 @@ Content-Length: 141
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">POST /api/v1/cafes/apply HTTP/1.1
 Content-Type: multipart/form-data;charset=UTF-8; boundary=6o2knFse3p53ty9dmcQvWAIx1zInP11uCfbm
-Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwiaWF0IjoxNzExNDYzOTk2LCJleHAiOjE3MTE0NjU3OTZ9.XNdou7YarLlzmUxgpzevlUxUZoMu6_RiAsGBUKIBNXg
+Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwiaWF0IjoxNzExNTI1MDg0LCJleHAiOjE3MTE1MjY4ODR9.62Cq76-J3aDQ5zYteG_aWatg4mOrD3YJoxvfki0H_o0
 Host: www.api.birca.com
 
 --6o2knFse3p53ty9dmcQvWAIx1zInP11uCfbm
@@ -1654,7 +1654,7 @@ Vary: Access-Control-Request-Headers</code></pre>
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">POST /api/v1/birthday-cafes HTTP/1.1
 Content-Type: application/json;charset=UTF-8
-Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwiaWF0IjoxNzExNDYzOTkzLCJleHAiOjE3MTE0NjU3OTN9.H6gyujFBaJ3F9SOlKIWOByoO8ALWiLBtPnERWLNeZxM
+Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwiaWF0IjoxNzExNTI1MDgxLCJleHAiOjE3MTE1MjY4ODF9.DRQX3FkZYNq21hMjs55JRCaSaT9QYNln_gThNQsH-hw
 Content-Length: 234
 Host: www.api.birca.com
 
@@ -1750,7 +1750,7 @@ Vary: Access-Control-Request-Headers</code></pre>
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">POST /api/v1/birthday-cafes/1/cancel HTTP/1.1
 Content-Type: application/json;charset=UTF-8
-Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwiaWF0IjoxNzExNDYzOTkzLCJleHAiOjE3MTE0NjU3OTN9.H6gyujFBaJ3F9SOlKIWOByoO8ALWiLBtPnERWLNeZxM
+Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwiaWF0IjoxNzExNTI1MDgxLCJleHAiOjE3MTE1MjY4ODF9.DRQX3FkZYNq21hMjs55JRCaSaT9QYNln_gThNQsH-hw
 Host: www.api.birca.com</code></pre>
 </div>
 </div>
@@ -1797,7 +1797,7 @@ Vary: Access-Control-Request-Headers</code></pre>
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">PATCH /api/v1/birthday-cafes/1/congestion HTTP/1.1
 Content-Type: application/json;charset=UTF-8
-Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwiaWF0IjoxNzExNDYzOTkzLCJleHAiOjE3MTE0NjU3OTN9.H6gyujFBaJ3F9SOlKIWOByoO8ALWiLBtPnERWLNeZxM
+Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwiaWF0IjoxNzExNTI1MDgxLCJleHAiOjE3MTE1MjY4ODF9.DRQX3FkZYNq21hMjs55JRCaSaT9QYNln_gThNQsH-hw
 Content-Length: 26
 Host: www.api.birca.com
 
@@ -1877,7 +1877,7 @@ Vary: Access-Control-Request-Headers</code></pre>
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">POST /api/v1/birthday-cafes/1/special-goods HTTP/1.1
 Content-Type: application/json;charset=UTF-8
-Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwiaWF0IjoxNzExNDYzOTkzLCJleHAiOjE3MTE0NjU3OTN9.H6gyujFBaJ3F9SOlKIWOByoO8ALWiLBtPnERWLNeZxM
+Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwiaWF0IjoxNzExNTI1MDgxLCJleHAiOjE3MTE1MjY4ODF9.DRQX3FkZYNq21hMjs55JRCaSaT9QYNln_gThNQsH-hw
 Content-Length: 147
 Host: www.api.birca.com
 
@@ -1962,7 +1962,7 @@ Vary: Access-Control-Request-Headers</code></pre>
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">POST /api/v1/birthday-cafes/1/menus HTTP/1.1
 Content-Type: application/json;charset=UTF-8
-Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwiaWF0IjoxNzExNDYzOTkzLCJleHAiOjE3MTE0NjU3OTN9.H6gyujFBaJ3F9SOlKIWOByoO8ALWiLBtPnERWLNeZxM
+Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwiaWF0IjoxNzExNTI1MDgxLCJleHAiOjE3MTE1MjY4ODF9.DRQX3FkZYNq21hMjs55JRCaSaT9QYNln_gThNQsH-hw
 Content-Length: 197
 Host: www.api.birca.com
 
@@ -2054,7 +2054,7 @@ Vary: Access-Control-Request-Headers</code></pre>
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">POST /api/v1/birthday-cafes/1/lucky-draws HTTP/1.1
 Content-Type: application/json;charset=UTF-8
-Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwiaWF0IjoxNzExNDYzOTkzLCJleHAiOjE3MTE0NjU3OTN9.H6gyujFBaJ3F9SOlKIWOByoO8ALWiLBtPnERWLNeZxM
+Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwiaWF0IjoxNzExNTI1MDgxLCJleHAiOjE3MTE1MjY4ODF9.DRQX3FkZYNq21hMjs55JRCaSaT9QYNln_gThNQsH-hw
 Content-Length: 92
 Host: www.api.birca.com
 
@@ -2139,7 +2139,7 @@ Vary: Access-Control-Request-Headers</code></pre>
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">GET /api/v1/birthday-cafes/1/special-goods HTTP/1.1
 Content-Type: application/json;charset=UTF-8
-Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwiaWF0IjoxNzExNDYzOTk4LCJleHAiOjE3MTE0NjU3OTh9.-REcv7LD-DrxvmGrxaPYuVeX0DXB4lYaVeDZkRQu14g
+Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwiaWF0IjoxNzExNTI1MDg3LCJleHAiOjE3MTE1MjY4ODd9.Tr30fu8F7VRo_IUkR744y3gxXmqyQsye6kihRu02cHM
 Host: www.api.birca.com</code></pre>
 </div>
 </div>
@@ -2196,7 +2196,7 @@ Content-Length: 126
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">GET /api/v1/birthday-cafes/1/menus HTTP/1.1
 Content-Type: application/json;charset=UTF-8
-Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwiaWF0IjoxNzExNDYzOTk5LCJleHAiOjE3MTE0NjU3OTl9.VXxHUeoxjHzsroI8flntnr4nCfOw39wmbNioR38lP9E
+Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwiaWF0IjoxNzExNTI1MDg3LCJleHAiOjE3MTE1MjY4ODd9.Tr30fu8F7VRo_IUkR744y3gxXmqyQsye6kihRu02cHM
 Host: www.api.birca.com</code></pre>
 </div>
 </div>
@@ -2255,7 +2255,7 @@ Content-Length: 196
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">GET /api/v1/birthday-cafes/1/lucky-draws HTTP/1.1
 Content-Type: application/json;charset=UTF-8
-Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwiaWF0IjoxNzExNDYzOTk4LCJleHAiOjE3MTE0NjU3OTh9.-REcv7LD-DrxvmGrxaPYuVeX0DXB4lYaVeDZkRQu14g
+Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwiaWF0IjoxNzExNTI1MDg3LCJleHAiOjE3MTE1MjY4ODd9.Tr30fu8F7VRo_IUkR744y3gxXmqyQsye6kihRu02cHM
 Host: www.api.birca.com</code></pre>
 </div>
 </div>
@@ -2312,7 +2312,7 @@ Content-Length: 88
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">PATCH /api/v1/birthday-cafes/1 HTTP/1.1
 Content-Type: application/json;charset=UTF-8
-Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwiaWF0IjoxNzExNDYzOTkzLCJleHAiOjE3MTE0NjU3OTN9.H6gyujFBaJ3F9SOlKIWOByoO8ALWiLBtPnERWLNeZxM
+Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwiaWF0IjoxNzExNTI1MDgxLCJleHAiOjE3MTE1MjY4ODF9.DRQX3FkZYNq21hMjs55JRCaSaT9QYNln_gThNQsH-hw
 Content-Length: 86
 Host: www.api.birca.com
 
@@ -2394,7 +2394,7 @@ Vary: Access-Control-Request-Headers</code></pre>
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">POST /api/v1/birthday-cafes/1/images HTTP/1.1
 Content-Type: multipart/form-data;charset=UTF-8; boundary=6o2knFse3p53ty9dmcQvWAIx1zInP11uCfbm
-Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwiaWF0IjoxNzExNDYzOTkzLCJleHAiOjE3MTE0NjU3OTN9.H6gyujFBaJ3F9SOlKIWOByoO8ALWiLBtPnERWLNeZxM
+Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwiaWF0IjoxNzExNTI1MDgxLCJleHAiOjE3MTE1MjY4ODF9.DRQX3FkZYNq21hMjs55JRCaSaT9QYNln_gThNQsH-hw
 Host: www.api.birca.com
 
 --6o2knFse3p53ty9dmcQvWAIx1zInP11uCfbm
@@ -2425,7 +2425,7 @@ Vary: Access-Control-Request-Headers</code></pre>
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">POST /api/v1/birthday-cafes/1/images/main HTTP/1.1
 Content-Type: multipart/form-data;charset=UTF-8; boundary=6o2knFse3p53ty9dmcQvWAIx1zInP11uCfbm
-Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwiaWF0IjoxNzExNDYzOTkzLCJleHAiOjE3MTE0NjU3OTN9.H6gyujFBaJ3F9SOlKIWOByoO8ALWiLBtPnERWLNeZxM
+Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwiaWF0IjoxNzExNTI1MDgxLCJleHAiOjE3MTE1MjY4ODF9.DRQX3FkZYNq21hMjs55JRCaSaT9QYNln_gThNQsH-hw
 Host: www.api.birca.com
 
 --6o2knFse3p53ty9dmcQvWAIx1zInP11uCfbm
@@ -2456,7 +2456,7 @@ Vary: Access-Control-Request-Headers</code></pre>
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">POST /api/v1/birthday-cafes/1/images HTTP/1.1
 Content-Type: multipart/form-data;charset=UTF-8; boundary=6o2knFse3p53ty9dmcQvWAIx1zInP11uCfbm
-Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwiaWF0IjoxNzExNDYzOTkzLCJleHAiOjE3MTE0NjU3OTN9.H6gyujFBaJ3F9SOlKIWOByoO8ALWiLBtPnERWLNeZxM
+Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwiaWF0IjoxNzExNTI1MDgxLCJleHAiOjE3MTE1MjY4ODF9.DRQX3FkZYNq21hMjs55JRCaSaT9QYNln_gThNQsH-hw
 Host: www.api.birca.com
 
 --6o2knFse3p53ty9dmcQvWAIx1zInP11uCfbm
@@ -2487,7 +2487,7 @@ Vary: Access-Control-Request-Headers</code></pre>
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">DELETE /api/v1/birthday-cafes/1/images HTTP/1.1
 Content-Type: application/json;charset=UTF-8
-Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwiaWF0IjoxNzExNDYzOTkzLCJleHAiOjE3MTE0NjU3OTN9.H6gyujFBaJ3F9SOlKIWOByoO8ALWiLBtPnERWLNeZxM
+Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwiaWF0IjoxNzExNTI1MDgxLCJleHAiOjE3MTE1MjY4ODF9.DRQX3FkZYNq21hMjs55JRCaSaT9QYNln_gThNQsH-hw
 Content-Length: 26
 Host: www.api.birca.com
 
@@ -2541,7 +2541,7 @@ Vary: Access-Control-Request-Headers</code></pre>
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">GET /api/v1/birthday-cafes/me HTTP/1.1
 Content-Type: application/json;charset=UTF-8
-Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwiaWF0IjoxNzExNDYzOTk4LCJleHAiOjE3MTE0NjU3OTh9.-REcv7LD-DrxvmGrxaPYuVeX0DXB4lYaVeDZkRQu14g
+Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwiaWF0IjoxNzExNTI1MDg3LCJleHAiOjE3MTE1MjY4ODd9.Tr30fu8F7VRo_IUkR744y3gxXmqyQsye6kihRu02cHM
 Host: www.api.birca.com</code></pre>
 </div>
 </div>
@@ -2651,7 +2651,7 @@ Content-Length: 586
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">GET /api/v1/birthday-cafes/like HTTP/1.1
 Content-Type: application/json;charset=UTF-8
-Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwiaWF0IjoxNzExNDYzOTk4LCJleHAiOjE3MTE0NjU3OTh9.-REcv7LD-DrxvmGrxaPYuVeX0DXB4lYaVeDZkRQu14g
+Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwiaWF0IjoxNzExNTI1MDg3LCJleHAiOjE3MTE1MjY4ODd9.Tr30fu8F7VRo_IUkR744y3gxXmqyQsye6kihRu02cHM
 Host: www.api.birca.com</code></pre>
 </div>
 </div>
@@ -2761,7 +2761,7 @@ Content-Length: 583
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">GET /api/v1/birthday-cafes?cursor=1&amp;size=10&amp;artistId=1&amp;cafeId=1&amp;progressState=IN_PROGRESS HTTP/1.1
 Content-Type: application/json;charset=UTF-8
-Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwiaWF0IjoxNzExNDYzOTk5LCJleHAiOjE3MTE0NjU3OTl9.VXxHUeoxjHzsroI8flntnr4nCfOw39wmbNioR38lP9E
+Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwiaWF0IjoxNzExNTI1MDg3LCJleHAiOjE3MTE1MjY4ODd9.Tr30fu8F7VRo_IUkR744y3gxXmqyQsye6kihRu02cHM
 Host: www.api.birca.com</code></pre>
 </div>
 </div>
@@ -2908,10 +2908,32 @@ Content-Length: 560
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">GET /api/v1/birthday-cafes/1 HTTP/1.1
 Content-Type: application/json;charset=UTF-8
-Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwiaWF0IjoxNzExNDYzOTk4LCJleHAiOjE3MTE0NjU3OTh9.-REcv7LD-DrxvmGrxaPYuVeX0DXB4lYaVeDZkRQu14g
+Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwiaWF0IjoxNzExNTI1MDg3LCJleHAiOjE3MTE1MjY4ODd9.Tr30fu8F7VRo_IUkR744y3gxXmqyQsye6kihRu02cHM
 Host: www.api.birca.com</code></pre>
 </div>
 </div>
+</div>
+<div class="sect3">
+<h4 id="_생일_카페_상세_조회_path_parameters"><a class="link" href="#_생일_카페_상세_조회_path_parameters">Path parameters</a></h4>
+<table class="tableblock frame-all grid-all stretch">
+<caption class="title">Table 1. /api/v1/birthday-cafes/{birthdayCafeId}</caption>
+<colgroup>
+<col style="width: 50%;">
+<col style="width: 50%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">Parameter</th>
+<th class="tableblock halign-left valign-top">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>birthdayCafeId</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">생일 카페 ID</p></td>
+</tr>
+</tbody>
+</table>
 </div>
 <div class="sect3">
 <h4 id="_생일_카페_상세_조회_http_response"><a class="link" href="#_생일_카페_상세_조회_http_response">HTTP response</a></h4>
@@ -2922,10 +2944,10 @@ Vary: Origin
 Vary: Access-Control-Request-Method
 Vary: Access-Control-Request-Headers
 Content-Type: application/json
-Content-Length: 551
+Content-Length: 543
 
 {
-  "artistResponse" : {
+  "artist" : {
     "groupName" : "샤이니",
     "name" : "민호"
   },
@@ -2946,105 +2968,6 @@ Content-Length: 551
 }</code></pre>
 </div>
 </div>
-</div>
-<div class="sect3">
-<h4 id="_생일_카페_상세_조회_response_fields"><a class="link" href="#_생일_카페_상세_조회_response_fields">Response fields</a></h4>
-<table class="tableblock frame-all grid-all stretch">
-<colgroup>
-<col style="width: 33.3333%;">
-<col style="width: 33.3333%;">
-<col style="width: 33.3334%;">
-</colgroup>
-<thead>
-<tr>
-<th class="tableblock halign-left valign-top">Path</th>
-<th class="tableblock halign-left valign-top">Type</th>
-<th class="tableblock halign-left valign-top">Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code>artistResponse.groupName</code></p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">아티스트 그룹 이름</p></td>
-</tr>
-<tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code>artistResponse.name</code></p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">아티스트 이름</p></td>
-</tr>
-<tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code>startDate</code></p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">생일 카페 시작일</p></td>
-</tr>
-<tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code>endDate</code></p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">생일 카페 종료일</p></td>
-</tr>
-<tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code>birthdayCafeName</code></p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">생일 카페 이름</p></td>
-</tr>
-<tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code>likeCount</code></p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Number</code></p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">생일 카페 찜된 수</p></td>
-</tr>
-<tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code>isLiked</code></p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Boolean</code></p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">찜 했는지 여부</p></td>
-</tr>
-<tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code>twitterAccount</code></p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">트위터 계정</p></td>
-</tr>
-<tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code>minimumVisitant</code></p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Number</code></p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">생일 카페 최소 방문자 수</p></td>
-</tr>
-<tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code>maximumVisitant</code></p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Number</code></p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">생일 카페 최대 방문자 수</p></td>
-</tr>
-<tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code>congestionState</code></p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">생일 카페 혼잡도</p></td>
-</tr>
-<tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code>visibility</code></p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">생일 카페 공개 여부</p></td>
-</tr>
-<tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code>progressState</code></p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">생일 카페 진행 상태</p></td>
-</tr>
-<tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code>specialGoodsStockState</code></p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">생일 카페 굿즈 양</p></td>
-</tr>
-<tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code>mainImage</code></p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">생일 카페 메인 이미지 url</p></td>
-</tr>
-<tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code>defaultImages.[]</code></p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Array</code></p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">생일 카페 기본 이미지 url</p></td>
-</tr>
-</tbody>
-</table>
 </div>
 </div>
 <div class="sect2">
@@ -3109,7 +3032,7 @@ Content-Length: 551
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">GET /api/v1/cafes/search?name=%EC%BB%A4%ED%94%BC HTTP/1.1
 Content-Type: application/json;charset=UTF-8
-Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwiaWF0IjoxNzExNDYzOTk5LCJleHAiOjE3MTE0NjU3OTl9.VXxHUeoxjHzsroI8flntnr4nCfOw39wmbNioR38lP9E
+Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwiaWF0IjoxNzExNTI1MDg3LCJleHAiOjE3MTE1MjY4ODd9.Tr30fu8F7VRo_IUkR744y3gxXmqyQsye6kihRu02cHM
 Host: www.api.birca.com</code></pre>
 </div>
 </div>
@@ -3149,7 +3072,7 @@ Content-Length: 106
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">POST /api/v1/birthday-cafes/1/like HTTP/1.1
 Content-Type: application/json;charset=UTF-8
-Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwiaWF0IjoxNzExNDYzOTk2LCJleHAiOjE3MTE0NjU3OTZ9.XNdou7YarLlzmUxgpzevlUxUZoMu6_RiAsGBUKIBNXg
+Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwiaWF0IjoxNzExNTI1MDg0LCJleHAiOjE3MTE1MjY4ODR9.62Cq76-J3aDQ5zYteG_aWatg4mOrD3YJoxvfki0H_o0
 Host: www.api.birca.com</code></pre>
 </div>
 </div>
@@ -3196,7 +3119,7 @@ Vary: Access-Control-Request-Headers</code></pre>
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">DELETE /api/v1/birthday-cafes/1/like HTTP/1.1
 Content-Type: application/json;charset=UTF-8
-Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwiaWF0IjoxNzExNDYzOTk2LCJleHAiOjE3MTE0NjU3OTZ9.XNdou7YarLlzmUxgpzevlUxUZoMu6_RiAsGBUKIBNXg
+Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwiaWF0IjoxNzExNTI1MDg0LCJleHAiOjE3MTE1MjY4ODR9.62Cq76-J3aDQ5zYteG_aWatg4mOrD3YJoxvfki0H_o0
 Host: www.api.birca.com</code></pre>
 </div>
 </div>
@@ -3258,7 +3181,7 @@ Vary: Access-Control-Request-Headers</code></pre>
 <div id="footer">
 <div id="footer-text">
 Version 0.0.1-SNAPSHOT<br>
-Last updated 2024-03-26 18:25:42 +0900
+Last updated 2024-03-27 00:11:44 +0900
 </div>
 </div>
 <script src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/9.18.3/highlight.min.js"></script>

--- a/src/test/java/com/birca/bircabackend/query/acceptance/BirthdayCafeQueryAcceptanceTest.java
+++ b/src/test/java/com/birca/bircabackend/query/acceptance/BirthdayCafeQueryAcceptanceTest.java
@@ -109,4 +109,19 @@ public class BirthdayCafeQueryAcceptanceTest extends AcceptanceTest {
                 () -> assertThat(response.jsonPath().getList(".")).hasSize(5)
         );
     }
+
+    @Test
+    void 생일_카페_상세를_조회한다() {
+        // when
+        ExtractableResponse<Response> response = RestAssured.given().log().all()
+                .when()
+                .contentType(MediaType.APPLICATION_JSON_VALUE)
+                .header(HttpHeaders.AUTHORIZATION, bearerTokenProvider.getToken(HOST_ID))
+                .get("/api/v1/birthday-cafes/{birthdayCafeId}", BIRTHDAY_CAFE_ID)
+                .then().log().all()
+                .extract();
+
+        // then
+        assertThat(response.statusCode()).isEqualTo(HttpStatus.OK.value());
+    }
 }

--- a/src/test/java/com/birca/bircabackend/query/controller/BirthdayCafeQueryControllerTest.java
+++ b/src/test/java/com/birca/bircabackend/query/controller/BirthdayCafeQueryControllerTest.java
@@ -272,8 +272,8 @@ class BirthdayCafeQueryControllerTest extends DocumentationTest {
                                 parameterWithName("birthdayCafeId").description("생일 카페 ID")
                         ),
                         responseFields(
-                                fieldWithPath("artistResponse.groupName").type(JsonFieldType.STRING).description("아티스트 그룹 이름").optional(),
-                                fieldWithPath("artistResponse.name").type(JsonFieldType.STRING).description("아티스트 이름"),
+                                fieldWithPath("artist.groupName").type(JsonFieldType.STRING).description("아티스트 그룹 이름").optional(),
+                                fieldWithPath("artist.name").type(JsonFieldType.STRING).description("아티스트 이름"),
                                 fieldWithPath("startDate").type(JsonFieldType.STRING).description("생일 카페 시작일"),
                                 fieldWithPath("endDate").type(JsonFieldType.STRING).description("생일 카페 종료일"),
                                 fieldWithPath("birthdayCafeName").type(JsonFieldType.STRING).description("생일 카페 이름"),

--- a/src/test/java/com/birca/bircabackend/query/controller/BirthdayCafeQueryControllerTest.java
+++ b/src/test/java/com/birca/bircabackend/query/controller/BirthdayCafeQueryControllerTest.java
@@ -1,6 +1,10 @@
 package com.birca.bircabackend.query.controller;
 
 import com.birca.bircabackend.command.auth.authorization.LoginMember;
+import com.birca.bircabackend.command.birca.domain.value.CongestionState;
+import com.birca.bircabackend.command.birca.domain.value.ProgressState;
+import com.birca.bircabackend.command.birca.domain.value.SpecialGoodsStockState;
+import com.birca.bircabackend.command.birca.domain.value.Visibility;
 import com.birca.bircabackend.query.dto.*;
 import com.birca.bircabackend.support.enviroment.DocumentationTest;
 import org.junit.jupiter.api.Test;
@@ -228,6 +232,62 @@ class BirthdayCafeQueryControllerTest extends DocumentationTest {
                                 fieldWithPath("[].isLiked").type(JsonFieldType.BOOLEAN).description("찜 했는지 여부"),
                                 fieldWithPath("[].artist.groupName").type(JsonFieldType.STRING).description("아티스트 그룹 이름").optional(),
                                 fieldWithPath("[].artist.name").type(JsonFieldType.STRING).description("아티스트 이름")
+                        )
+                ));
+    }
+
+    @Test
+    void 생일_카페_상세를_조회한다() throws Exception {
+        // given
+        Long birthdayCafeId = 1L;
+        given(birthdayCafeQueryService.findBirthdayCafeDetail(any(), any()))
+                .willReturn(new BirthdayCafeDetailResponse(
+                        new BirthdayCafeDetailResponse.ArtistResponse("샤이니", "민호"),
+                        LocalDateTime.of(2024, 3, 20, 0, 0, 0),
+                        LocalDateTime.of(2024, 3, 23, 0, 0, 0),
+                        "아이유의 생일 카페",
+                        10,
+                        true,
+                        "@ChaseM",
+                        5,
+                        10,
+                        CongestionState.SMOOTH,
+                        Visibility.PUBLIC,
+                        ProgressState.IN_PROGRESS,
+                        SpecialGoodsStockState.ABUNDANT,
+                        "image.com",
+                        List.of("image1.com", "image2.com")
+                ));
+
+        // when
+        ResultActions result = mockMvc.perform(
+                get("/api/v1/birthday-cafes/{birthdayCafeId}", birthdayCafeId)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .header(HttpHeaders.AUTHORIZATION, bearerTokenProvider.getToken(MEMBER_ID)));
+
+        // then
+        result.andExpect((status().isOk()))
+                .andDo(document("get-birthday-cafe-detail", HOST_INFO, DOCUMENT_RESPONSE,
+                        pathParameters(
+                                parameterWithName("birthdayCafeId").description("생일 카페 ID")
+                        ),
+                        responseFields(
+                                fieldWithPath("artistResponse.groupName").type(JsonFieldType.STRING).description("아티스트 그룹 이름").optional(),
+                                fieldWithPath("artistResponse.name").type(JsonFieldType.STRING).description("아티스트 이름"),
+                                fieldWithPath("startDate").type(JsonFieldType.STRING).description("생일 카페 시작일"),
+                                fieldWithPath("endDate").type(JsonFieldType.STRING).description("생일 카페 종료일"),
+                                fieldWithPath("birthdayCafeName").type(JsonFieldType.STRING).description("생일 카페 이름"),
+                                fieldWithPath("likeCount").type(JsonFieldType.NUMBER).description("생일 카페 찜된 수"),
+                                fieldWithPath("isLiked").type(JsonFieldType.BOOLEAN).description("찜 했는지 여부"),
+                                fieldWithPath("twitterAccount").type(JsonFieldType.STRING).description("트위터 계정"),
+                                fieldWithPath("minimumVisitant").type(JsonFieldType.NUMBER).description("생일 카페 최소 방문자 수"),
+                                fieldWithPath("maximumVisitant").type(JsonFieldType.NUMBER).description("생일 카페 최대 방문자 수"),
+                                fieldWithPath("congestionState").type(JsonFieldType.STRING).description("생일 카페 혼잡도"),
+                                fieldWithPath("visibility").type(JsonFieldType.STRING).description("생일 카페 공개 여부"),
+                                fieldWithPath("progressState").type(JsonFieldType.STRING).description("생일 카페 진행 상태"),
+                                fieldWithPath("specialGoodsStockState").type(JsonFieldType.STRING).description("생일 카페 굿즈 양"),
+                                fieldWithPath("mainImage").type(JsonFieldType.STRING).description("생일 카페 메인 이미지 url"),
+                                fieldWithPath("defaultImages.[]").type(JsonFieldType.ARRAY).description("생일 카페 기본 이미지 url")
                         )
                 ));
     }

--- a/src/test/java/com/birca/bircabackend/query/service/BirthdayCafeQueryServiceTest.java
+++ b/src/test/java/com/birca/bircabackend/query/service/BirthdayCafeQueryServiceTest.java
@@ -5,6 +5,8 @@ import com.birca.bircabackend.command.birca.domain.value.CongestionState;
 import com.birca.bircabackend.command.birca.domain.value.ProgressState;
 import com.birca.bircabackend.command.birca.domain.value.SpecialGoodsStockState;
 import com.birca.bircabackend.command.birca.domain.value.Visibility;
+import com.birca.bircabackend.command.birca.exception.BirthdayCafeErrorCode;
+import com.birca.bircabackend.common.exception.BusinessException;
 import com.birca.bircabackend.query.dto.*;
 import com.birca.bircabackend.support.enviroment.ServiceTest;
 import org.junit.jupiter.api.DisplayName;
@@ -17,6 +19,7 @@ import java.time.LocalDateTime;
 import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.assertAll;
 
 @Sql("/fixture/birthday-cafe-fixture.sql")
@@ -216,10 +219,11 @@ class BirthdayCafeQueryServiceTest extends ServiceTest {
     @DisplayName("생일 카페 상세를 조회할 때")
     class findBirthdayCafeDetailTest {
 
+        private final LoginMember loginMember = new LoginMember(4L);
+
         @Test
         void 정상적으로_조회한다() {
             // given
-            LoginMember loginMember = new LoginMember(4L);
             Long birthdayCafeId = 3L;
 
             // when
@@ -249,7 +253,14 @@ class BirthdayCafeQueryServiceTest extends ServiceTest {
 
         @Test
         void 존재하지_않는_생일_카페는_예외가_발생한다() {
+            // given
+            Long birthdayCafeId = 100L;
 
+            // when then
+            assertThatThrownBy(() -> birthdayCafeQueryService.findBirthdayCafeDetail(loginMember, birthdayCafeId))
+                    .isInstanceOf(BusinessException.class)
+                    .extracting("errorCode")
+                    .isEqualTo(BirthdayCafeErrorCode.NOT_FOUND);
         }
     }
 }

--- a/src/test/java/com/birca/bircabackend/query/service/BirthdayCafeQueryServiceTest.java
+++ b/src/test/java/com/birca/bircabackend/query/service/BirthdayCafeQueryServiceTest.java
@@ -1,6 +1,10 @@
 package com.birca.bircabackend.query.service;
 
 import com.birca.bircabackend.command.auth.authorization.LoginMember;
+import com.birca.bircabackend.command.birca.domain.value.CongestionState;
+import com.birca.bircabackend.command.birca.domain.value.ProgressState;
+import com.birca.bircabackend.command.birca.domain.value.SpecialGoodsStockState;
+import com.birca.bircabackend.command.birca.domain.value.Visibility;
 import com.birca.bircabackend.query.dto.*;
 import com.birca.bircabackend.support.enviroment.ServiceTest;
 import org.junit.jupiter.api.DisplayName;
@@ -9,6 +13,7 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.test.context.jdbc.Sql;
 
+import java.time.LocalDateTime;
 import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -203,6 +208,48 @@ class BirthdayCafeQueryServiceTest extends ServiceTest {
                             .map(BirthdayCafeResponse::birthdayCafeId)
                             .containsExactly(4L, 5L, 6L)
             );
+        }
+    }
+
+
+    @Nested
+    @DisplayName("생일 카페 상세를 조회할 때")
+    class findBirthdayCafeDetailTest {
+
+        @Test
+        void 정상적으로_조회한다() {
+            // given
+            LoginMember loginMember = new LoginMember(4L);
+            Long birthdayCafeId = 3L;
+
+            // when
+            BirthdayCafeDetailResponse actual = birthdayCafeQueryService.findBirthdayCafeDetail(loginMember, birthdayCafeId);
+
+            // then
+            assertThat(actual).isEqualTo(
+                    new BirthdayCafeDetailResponse(
+                            new BirthdayCafeDetailResponse.ArtistResponse(null, "아이유"),
+                            LocalDateTime.parse("2024-02-09T00:00"),
+                            LocalDateTime.parse("2024-02-10T00:00"),
+                            "아이유의 생일 카페",
+                            1,
+                            true,
+                            "@ChaseM",
+                            5,
+                            10,
+                            CongestionState.SMOOTH,
+                            Visibility.PUBLIC,
+                            ProgressState.FINISHED,
+                            SpecialGoodsStockState.ABUNDANT,
+                            "iu-cafe-main-image.com",
+                            List.of("iu-cafe-default-image.com", "iu-cafe-default-image.com")
+                    )
+            );
+        }
+
+        @Test
+        void 존재하지_않는_생일_카페는_예외가_발생한다() {
+
         }
     }
 }

--- a/src/test/resources/fixture/birthday-cafe-fixture.sql
+++ b/src/test/resources/fixture/birthday-cafe-fixture.sql
@@ -66,7 +66,10 @@ VALUES (4, 1, '티셔츠'),
 INSERT INTO birthday_cafe_image (id, birthday_cafe_id, image_url, is_main)
 VALUES (1, 4, 'winter-cafe-default-image', false),
        (2, 4, 'winter-cafe-main-image.com', true),
-       (3, 4, 'winter-cafe-default-image', false);
+       (3, 4, 'winter-cafe-default-image', false),
+       (4, 3, 'iu-cafe-main-image.com', true),
+       (5, 3, 'iu-cafe-default-image.com', false),
+       (6, 3, 'iu-cafe-default-image.com', false);
 
 -- 방문자(id=4)가 누른 찜
 INSERT INTO likes (visitant_id, target_id, target_type)


### PR DESCRIPTION
## 🌍 이슈 번호
* closed #80 

## 📝 구현 내용
* 생일 카페 상세 조회

## 🍀 확인해야 할 부분
일단 카페쪽은 제외하고 구현했습니다.

현재 생일 카페 상세 조회할 때 쿼리 3번이 나갑니다.

- 좋아요 수를 가져오는 쿼리
- 생일 카페 기본 이미지들을 가져오는 쿼리
- 나머지 정보들을 가져오는 쿼리

더 최적화할 방법이 있을까요? 이 이상으로 아이디어가 떠오르지 않네요.

```
"defaultImgaes": [
      { "url": ... },
      { "url": ... }
        ]
    }

"defaultImages" : [ 
	"image1.com", 
	"image2.com" 
	]
```

추가적으로 위가 아닌 아래 형태로 했을 때의 문제 상황이 있을까요? 위 형태로 하면 또 하나의 record를 만들어야 해서, 아래 형태로 하면 더 간단하게 할 수 있지 않을까라는 생각이 들었습니다.