### PR TITLE
[FEAT] 생일 카페 스케줄링 - 생일 카페 종료 시 비공개로 상태 변경

### DIFF
--- a/src/main/java/com/birca/bircabackend/command/birca/domain/BirthdayCafe.java
+++ b/src/main/java/com/birca/bircabackend/command/birca/domain/BirthdayCafe.java
@@ -164,6 +164,7 @@ public class BirthdayCafe extends BaseEntity {
         }
         if (now.isEqual(endDate)) {
             this.progressState = ProgressState.FINISHED;
+            this.visibility = Visibility.PRIVATE;
         }
     }
 

--- a/src/test/java/com/birca/bircabackend/command/birca/domain/BirthdayCafeTest.java
+++ b/src/test/java/com/birca/bircabackend/command/birca/domain/BirthdayCafeTest.java
@@ -623,8 +623,8 @@ class BirthdayCafeTest {
                             LocalDateTime.parse(end);
             Schedule schedule = Schedule.of(startDate, endDate);
             BirthdayCafe birthdayCafe = fixtureMonkey.giveMeBuilder(BirthdayCafe.class)
-                    .set("Schedule", schedule)
-                    .set("Visibility", Visibility.PUBLIC)
+                    .set("schedule", schedule)
+                    .set("visibility", Visibility.PUBLIC)
                     .sample();
 
             // when

--- a/src/test/java/com/birca/bircabackend/command/birca/domain/BirthdayCafeTest.java
+++ b/src/test/java/com/birca/bircabackend/command/birca/domain/BirthdayCafeTest.java
@@ -17,6 +17,7 @@ import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.assertAll;
 import static org.junit.jupiter.params.provider.EnumSource.Mode.EXCLUDE;
 import static org.junit.jupiter.params.provider.EnumSource.Mode.INCLUDE;
 
@@ -609,10 +610,10 @@ class BirthdayCafeTest {
 
         @ParameterizedTest
         @CsvSource({
-                "NOW, MAX, IN_PROGRESS",
-                "MIN, NOW, FINISHED"
+                "NOW, MAX, IN_PROGRESS, PUBLIC",
+                "MIN, NOW, FINISHED, PRIVATE"
         })
-        void 진행이나_종료로_변경한다(String start, String end, String expectedState) {
+        void 진행이나_종료로_변경한다(String start, String end, String progressState, String visibility) {
             // given
             LocalDateTime startDate = start.equals("NOW") ? LocalDateTime.now() :
                     start.equals("MIN") ? LocalDateTime.MIN :
@@ -623,15 +624,21 @@ class BirthdayCafeTest {
             Schedule schedule = Schedule.of(startDate, endDate);
             BirthdayCafe birthdayCafe = fixtureMonkey.giveMeBuilder(BirthdayCafe.class)
                     .set("Schedule", schedule)
+                    .set("Visibility", Visibility.PUBLIC)
                     .sample();
 
             // when
             birthdayCafe.changeState(schedule);
+            ProgressState actualState = birthdayCafe.getProgressState();
+            Visibility actualVisibility = birthdayCafe.getVisibility();
+            ProgressState expectedProgressState = ProgressState.valueOf(progressState);
+            Visibility expectedVisibility = Visibility.valueOf(visibility);
 
             // then
-            ProgressState actualState = birthdayCafe.getProgressState();
-            ProgressState expectedProgressState = ProgressState.valueOf(expectedState);
-            assertThat(actualState).isEqualTo(expectedProgressState);
+            assertAll(
+                    () -> assertThat(actualState).isEqualTo(expectedProgressState),
+                    () -> assertThat(actualVisibility).isEqualTo(expectedVisibility)
+            );
         }
 
         @Test


### PR DESCRIPTION
## 🌍 이슈 번호
* closed #159 

## 📝 구현 내용
* 생일 카페 종료 시 비공개로 상태 변경

## 🍀 확인해야 할 부분
